### PR TITLE
allows adding a new dataset requiring less information

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
     '^.+\\.ts$': 'ts-jest'
   },
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.ts$',
-  moduleFileExtensions: ['ts', 'js', 'json', 'node']
+  moduleFileExtensions: ['ts', 'js', 'json', 'node'],
+  coveragePathIgnorePatterns: ['testHelpers']
 }
   

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-dataverse",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "A Dataverse module for JavaScript/TypeScript",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-dataverse",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "A Dataverse module for JavaScript/TypeScript",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-dataverse",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "A Dataverse module for JavaScript/TypeScript",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/@types/FieldTypeClass.ts
+++ b/src/@types/FieldTypeClass.ts
@@ -1,0 +1,5 @@
+export enum FieldTypeClass {
+  PRIMITIVE = 'primitive',
+  COMPOUND = 'compound',
+  CONTROLLED_VOCABULARY = 'controlledVocabulary'
+}

--- a/src/@types/basicDataset.ts
+++ b/src/@types/basicDataset.ts
@@ -1,0 +1,25 @@
+import { DatasetSubjects } from './datasetSubjects'
+
+export interface BasicDatasetAuthor {
+  fullname: string,
+  affiliation?: string
+}
+
+export interface BasicDatasetDescription {
+  text: string,
+  date?: string
+}
+
+export interface BasicDatasetContact {
+  email: string,
+  fullname?: string
+}
+
+export interface BasicDatasetInformation {
+  title: string,
+  subtitle?: string,
+  descriptions: BasicDatasetDescription[],
+  authors: BasicDatasetAuthor[],
+  contact: BasicDatasetContact[],
+  subject: DatasetSubjects[]
+}

--- a/src/@types/datasetSubjects.ts
+++ b/src/@types/datasetSubjects.ts
@@ -1,0 +1,16 @@
+export enum DatasetSubjects {
+  AGRICULTURAL_SCIENCE = 'Agricultural Sciences',
+  ARTS_AND_HUMANITIES = 'Arts and Humanities',
+  ASTRONOMY_AND_ASTROPHYSICS = 'Astronomy and Astrophysics',
+  BUSINESS_AND_MANAGEMENT = 'Business and Management',
+  CHEMISTRY = 'Chemistry',
+  COMPUTER_AND_INFORMATION_SCIENCE = 'Computer and Information Science',
+  EARTH_AND_ENVIRONMENTAL_SCIENCES = 'Earth and Environmental Sciences',
+  ENGINEERING = 'Engineering',
+  LAW = 'Law',
+  MATHEMATICAL_SCIENCE = 'Mathematical Sciences',
+  MEDICINE_HEALTH_AND_LIFE_SCIENCE = 'Medicine, Health and Life Sciences',
+  PHYSICS = 'Physics',
+  SOCIAL_SCIENCES = 'Social Sciences',
+  OTHER = 'Other'
+}

--- a/src/@types/dataverseHeaders.ts
+++ b/src/@types/dataverseHeaders.ts
@@ -1,3 +1,4 @@
 export interface DataverseHeaders {
-  'X-Dataverse-key': string
+  'X-Dataverse-key': string,
+  'Content-Type'?: string
 }

--- a/src/@types/metadataBlockField.ts
+++ b/src/@types/metadataBlockField.ts
@@ -1,0 +1,21 @@
+export interface MetadataBlockField {
+  typeName: string,
+  typeClass: string,
+  multiple: boolean,
+  value: string | MetadataBlockField[]
+}
+
+export interface MetadataBlockFieldAuthor {
+  authorName: MetadataBlockField,
+  authorAffiliation?: MetadataBlockField
+}
+
+export interface MetadataBlockFieldDescription {
+  dsDescriptionValue: MetadataBlockField,
+  dsDescriptionDate?: MetadataBlockField
+}
+
+export interface MetadataBlockFieldContact {
+  datasetContactEmail?: MetadataBlockField,
+  datasetContactName?: MetadataBlockField
+}

--- a/src/dataverseClient.ts
+++ b/src/dataverseClient.ts
@@ -3,6 +3,8 @@ import { DataverseSearchOptions, SearchOptions } from './@types/searchOptions'
 import { DataverseHeaders } from './@types/dataverseHeaders'
 import { DataverseException } from './exceptions/dataverseException'
 import { DataverseMetricType } from './@types/dataverseMetricType'
+import { BasicDatasetInformation } from './@types/basicDataset'
+import { DatasetUtil } from './utils/datasetUtil'
 
 export class DataverseClient {
   private readonly host: string
@@ -26,6 +28,18 @@ export class DataverseClient {
   public async addDataset(dataverseAlias: string, payload: string): Promise<AxiosResponse> {
     const url = `${this.host}/api/dataverses/${dataverseAlias}/datasets`
     return this.postRequest(url, payload)
+  }
+
+  public async addBasicDataset(dataverseAlias: string, datasetInformation: BasicDatasetInformation): Promise<AxiosResponse> {
+    const url = `${this.host}/api/dataverses/${dataverseAlias}/datasets`
+    const payload = DatasetUtil.mapBasicDatasetInformation(datasetInformation)
+
+    return this.postRequest(url, payload, {
+      headers: {
+        ...this.getHeaders(),
+        'Content-Type': 'application/json'
+      }
+    })
   }
 
   public async search(options: SearchOptions): Promise<AxiosResponse> {
@@ -97,7 +111,7 @@ export class DataverseClient {
   }
 
   private async postRequest(url: string, data: string | object, options: { params?: object, headers?: DataverseHeaders } = { headers: this.getHeaders() }) {
-    return await axios.post(url, data, options).catch(error => {
+    return await axios.post(url, JSON.stringify(data), options).catch(error => {
       throw new DataverseException(error.response.status, error.response.data.message)
     })
   }

--- a/src/utils/datasetUtil.ts
+++ b/src/utils/datasetUtil.ts
@@ -1,0 +1,46 @@
+import { MetadataBlocksUtil } from './metadataBlocksUtil'
+import { BasicDatasetInformation } from '../@types/basicDataset'
+import { MetadataBlockField } from '../@types/metadataBlockField'
+
+export const EMPTY_ARRAY_LENGTH = 0
+
+export class DatasetUtil {
+  public static mapBasicDatasetInformation(datasetInformation: BasicDatasetInformation): object {
+    const fields: MetadataBlockField[] = []
+
+    if (datasetInformation.title) {
+      fields.push(MetadataBlocksUtil.createTitleField(datasetInformation.title))
+    }
+
+    if (datasetInformation.subtitle) {
+      fields.push(MetadataBlocksUtil.createSubtitleField(datasetInformation.subtitle))
+    }
+
+    if (datasetInformation.authors && datasetInformation.authors.length > EMPTY_ARRAY_LENGTH) {
+      fields.push(MetadataBlocksUtil.createAuthorField(datasetInformation.authors))
+    }
+
+    if (datasetInformation.descriptions && datasetInformation.descriptions.length > EMPTY_ARRAY_LENGTH) {
+      fields.push(MetadataBlocksUtil.createDescriptionField(datasetInformation.descriptions))
+    }
+
+    if (datasetInformation.subject) {
+      fields.push(MetadataBlocksUtil.createSubjectField(datasetInformation.subject))
+    }
+
+    if (datasetInformation.contact) {
+      fields.push(MetadataBlocksUtil.createContactField(datasetInformation.contact))
+    }
+
+    return {
+      datasetVersion: {
+        metadataBlocks: {
+          citation: {
+            fields: fields,
+            displayName: 'Citation Metadata'
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/utils/metadataBlocksUtil.ts
+++ b/src/utils/metadataBlocksUtil.ts
@@ -1,0 +1,130 @@
+import {
+  MetadataBlockField,
+  MetadataBlockFieldAuthor, MetadataBlockFieldContact,
+  MetadataBlockFieldDescription
+} from '../@types/metadataBlockField'
+import { FieldTypeClass } from '../@types/FieldTypeClass'
+import { BasicDatasetAuthor, BasicDatasetContact, BasicDatasetDescription } from '../@types/basicDataset'
+import { DatasetSubjects } from '../@types/datasetSubjects'
+
+export const METADATA_BLOCK_FIELD_TITLE = 'title'
+export const METADATA_BLOCK_FIELD_SUBTITLE = 'subtitle'
+export const METADATA_BLOCK_FIELD_AUTHOR = 'author'
+export const METADATA_BLOCK_FIELD_DS_DESCRIPTION = 'dsDescription'
+export const METADATA_BLOCK_FIELD_SUBJECT = 'subject'
+export const METADATA_BLOCK_FIELD_CONTACT = 'datasetContact'
+export const METADATA_BLOCK_FIELD_AUTHOR_FULLNAME = 'authorName'
+export const METADATA_BLOCK_FIELD_AUTHOR_AFFILIATION = 'authorAffiliation'
+export const METADATA_BLOCK_FIELD_CONTACT_EMAIL = 'datasetContactEmail'
+export const METADATA_BLOCK_FIELD_CONTACT_NAME = 'datasetContactName'
+
+export class MetadataBlocksUtil {
+
+  public static createTitleField(title: string): MetadataBlockField {
+    return this.createField(METADATA_BLOCK_FIELD_TITLE, FieldTypeClass.PRIMITIVE.toString(), false, title)
+  }
+
+  public static createSubtitleField(subtitle: string): MetadataBlockField {
+    return this.createField(METADATA_BLOCK_FIELD_SUBTITLE, FieldTypeClass.PRIMITIVE.toString(), false, subtitle)
+  }
+
+  public static createAuthorField(basicDatasetAuthors: BasicDatasetAuthor[]): MetadataBlockField {
+    const authors: MetadataBlockFieldAuthor[] = []
+
+    basicDatasetAuthors.forEach((basicAuthor: BasicDatasetAuthor) => {
+      const author: MetadataBlockFieldAuthor = {
+        authorName: {
+          value: basicAuthor.fullname,
+          typeClass: FieldTypeClass.PRIMITIVE,
+          typeName: METADATA_BLOCK_FIELD_AUTHOR_FULLNAME,
+          multiple: false
+        }
+      }
+
+      if (basicAuthor.affiliation) {
+        author.authorAffiliation = {
+          value: basicAuthor.affiliation,
+          typeClass: FieldTypeClass.PRIMITIVE,
+          typeName: METADATA_BLOCK_FIELD_AUTHOR_AFFILIATION,
+          multiple: false
+        }
+      }
+
+      authors.push(author)
+    })
+
+    return this.createField(METADATA_BLOCK_FIELD_AUTHOR, FieldTypeClass.COMPOUND.toString(), true, authors)
+  }
+
+  public static createDescriptionField(basicDescriptions: BasicDatasetDescription[]): MetadataBlockField {
+    const descriptions: MetadataBlockFieldDescription[] = []
+
+    basicDescriptions.forEach((description: BasicDatasetDescription) => {
+      descriptions.push({
+        dsDescriptionValue: {
+          typeName: 'dsDescriptionValue',
+          typeClass: FieldTypeClass.PRIMITIVE.toString(),
+          multiple: false,
+          value: description.text
+        },
+        dsDescriptionDate: {
+          typeName: 'dsDescriptionDate',
+          typeClass: FieldTypeClass.PRIMITIVE.toString(),
+          multiple: false,
+          value: description.date
+        }
+      })
+    })
+
+    return this.createField(METADATA_BLOCK_FIELD_DS_DESCRIPTION, FieldTypeClass.COMPOUND.toString(), true, descriptions)
+  }
+
+  public static createSubjectField(basicSubjects: DatasetSubjects[]): MetadataBlockField {
+    const subjects: string[] = []
+
+    basicSubjects.forEach(subject => {
+      subjects.push(subject.toString())
+    })
+
+    return this.createField(METADATA_BLOCK_FIELD_SUBJECT, FieldTypeClass.CONTROLLED_VOCABULARY.toString(), true, subjects)
+  }
+
+  public static createContactField(basicContacts: BasicDatasetContact[]): MetadataBlockField {
+    const contacts: MetadataBlockFieldContact[] = []
+
+    basicContacts.forEach(contact => {
+      const input: MetadataBlockFieldContact = {}
+
+      if (contact.email) {
+        input.datasetContactEmail = {
+          typeClass: FieldTypeClass.PRIMITIVE,
+          multiple: false,
+          typeName: METADATA_BLOCK_FIELD_CONTACT_EMAIL,
+          value: contact.email
+        }
+      }
+
+      if (contact.fullname) {
+        input.datasetContactName = {
+          typeClass: FieldTypeClass.PRIMITIVE,
+          multiple: false,
+          typeName: METADATA_BLOCK_FIELD_CONTACT_NAME,
+          value: contact.fullname
+        }
+      }
+
+      contacts.push(input)
+    })
+
+    return this.createField(METADATA_BLOCK_FIELD_CONTACT, FieldTypeClass.COMPOUND.toString(), true, contacts)
+  }
+
+  private static createField(typeName: string, typeClass: string, multiple: boolean, value: any): MetadataBlockField {
+    return {
+      typeName: typeName,
+      typeClass: typeClass,
+      multiple: multiple,
+      value: value
+    }
+  }
+}

--- a/test/exceptions/dataverseException.spec.ts
+++ b/test/exceptions/dataverseException.spec.ts
@@ -1,0 +1,29 @@
+import { DataverseException } from '../../src/exceptions/dataverseException'
+import { random } from 'faker'
+import { expect } from 'chai'
+
+describe('DataverseException', () => {
+  let statusCode: number
+  let message: string
+
+  beforeEach(() => {
+    statusCode = random.number()
+    message = random.words()
+  })
+
+  it('should create expected exception', async () => {
+    const result = new DataverseException(statusCode, message)
+
+    expect(result.errorCode).to.be.equal(statusCode)
+    expect(result.message).to.be.equal(message)
+  })
+
+  describe('missing message', () => {
+    it('should create expected exception', async () => {
+      const result = new DataverseException(statusCode)
+
+      expect(result.errorCode).to.be.equal(statusCode)
+      expect(result.message).to.be.equal('')
+    })
+  })
+})

--- a/test/testHelpers/basicDatasetHelper.ts
+++ b/test/testHelpers/basicDatasetHelper.ts
@@ -1,0 +1,23 @@
+import { BasicDatasetInformation } from '../../src/@types/basicDataset'
+import { internet, name, random } from 'faker'
+import { DatasetSubjects } from '../../src/@types/datasetSubjects'
+
+export const createBasicDatasetInformation = (): BasicDatasetInformation => {
+  return {
+    title: random.words(),
+    subtitle: random.words(),
+    descriptions: [{
+      text: random.words(),
+      date: '2019-10-10'
+    }],
+    authors: [{
+      fullname: `${name.firstName()} ${name.lastName()}`,
+      affiliation: name.jobArea()
+    }],
+    contact: [{
+      email: internet.email(),
+      fullname: `${name.firstName()} ${name.lastName()}`
+    }],
+    subject: [DatasetSubjects.OTHER]
+  }
+}

--- a/test/testHelpers/metadataBlockHelper.ts
+++ b/test/testHelpers/metadataBlockHelper.ts
@@ -1,0 +1,12 @@
+import { MetadataBlockField } from '../../src/@types/metadataBlockField'
+import { random } from 'faker'
+import { FieldTypeClass } from '../../src/@types/FieldTypeClass'
+
+export const createMetadataBlockField = (): MetadataBlockField => {
+  return {
+    typeName: random.word(),
+    typeClass: FieldTypeClass.PRIMITIVE,
+    multiple: false,
+    value: random.words()
+  }
+}

--- a/test/utils/datasetUtil.spec.ts
+++ b/test/utils/datasetUtil.spec.ts
@@ -1,0 +1,172 @@
+import { BasicDatasetInformation } from '../../src/@types/basicDataset'
+import { assert, SinonSandbox, SinonStub, createSandbox } from 'sinon'
+import { MetadataBlocksUtil } from '../../src/utils/metadataBlocksUtil'
+import { MetadataBlockField } from '../../src/@types/metadataBlockField'
+import { createMetadataBlockField } from '../testHelpers/metadataBlockHelper'
+import { createBasicDatasetInformation } from '../testHelpers/basicDatasetHelper'
+import { DatasetUtil } from '../../src/utils/datasetUtil'
+import { expect } from 'chai'
+
+describe('DatasetUtil', () => {
+  const sandbox: SinonSandbox = createSandbox()
+
+  let basicDatasetInformation: BasicDatasetInformation
+
+  let mockTitleMetadataBlockField: MetadataBlockField
+  let mockSubtitleMetadataBlockField: MetadataBlockField
+  let mockAuthorMetadataBlockField: MetadataBlockField
+  let mockDescriptionMetadataBlockField: MetadataBlockField
+  let mockSubjectMetadataBlockField: MetadataBlockField
+  let mockContactMetadataBlockField: MetadataBlockField
+
+  let createTitleFieldStub: SinonStub
+  let createSubtitleFieldStub: SinonStub
+  let createAuthorFieldStub: SinonStub
+  let createDescriptionFieldStub: SinonStub
+  let createSubjectFieldStub: SinonStub
+  let createContactFieldStub: SinonStub
+
+  beforeEach(() => {
+    basicDatasetInformation = createBasicDatasetInformation()
+
+    mockTitleMetadataBlockField = createMetadataBlockField()
+    mockSubtitleMetadataBlockField = createMetadataBlockField()
+    mockAuthorMetadataBlockField = createMetadataBlockField()
+    mockDescriptionMetadataBlockField = createMetadataBlockField()
+    mockSubjectMetadataBlockField = createMetadataBlockField()
+    mockContactMetadataBlockField = createMetadataBlockField()
+
+    createTitleFieldStub = sandbox.stub(MetadataBlocksUtil, 'createTitleField').returns(mockTitleMetadataBlockField)
+    createSubtitleFieldStub = sandbox.stub(MetadataBlocksUtil, 'createSubtitleField').returns(mockSubtitleMetadataBlockField)
+    createAuthorFieldStub = sandbox.stub(MetadataBlocksUtil, 'createAuthorField').returns(mockAuthorMetadataBlockField)
+    createDescriptionFieldStub = sandbox.stub(MetadataBlocksUtil, 'createDescriptionField').returns(mockDescriptionMetadataBlockField)
+    createSubjectFieldStub = sandbox.stub(MetadataBlocksUtil, 'createSubjectField').returns(mockSubjectMetadataBlockField)
+    createContactFieldStub = sandbox.stub(MetadataBlocksUtil, 'createContactField').returns(mockContactMetadataBlockField)
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe('mapBasicDatasetInformation', () => {
+    it('should return expected dataset metadata block fields', async () => {
+      const expectedResult = {
+        datasetVersion: {
+          metadataBlocks: {
+            citation: {
+              displayName: 'Citation Metadata',
+              fields: [{
+                multiple: mockTitleMetadataBlockField.multiple,
+                typeClass: mockTitleMetadataBlockField.typeClass,
+                typeName: mockTitleMetadataBlockField.typeName,
+                value: mockTitleMetadataBlockField.value
+              }, {
+                multiple: mockSubtitleMetadataBlockField.multiple,
+                typeClass: mockSubtitleMetadataBlockField.typeClass,
+                typeName: mockSubtitleMetadataBlockField.typeName,
+                value: mockSubtitleMetadataBlockField.value
+              }, {
+                multiple: mockAuthorMetadataBlockField.multiple,
+                typeClass: mockAuthorMetadataBlockField.typeClass,
+                typeName: mockAuthorMetadataBlockField.typeName,
+                value: mockAuthorMetadataBlockField.value
+              }, {
+                multiple: mockDescriptionMetadataBlockField.multiple,
+                typeClass: mockDescriptionMetadataBlockField.typeClass,
+                typeName: mockDescriptionMetadataBlockField.typeName,
+                value: mockDescriptionMetadataBlockField.value
+              }, {
+                multiple: mockSubjectMetadataBlockField.multiple,
+                typeClass: mockSubjectMetadataBlockField.typeClass,
+                typeName: mockSubjectMetadataBlockField.typeName,
+                value: mockSubjectMetadataBlockField.value
+              },
+              {
+                multiple: mockContactMetadataBlockField.multiple,
+                typeClass: mockContactMetadataBlockField.typeClass,
+                typeName: mockContactMetadataBlockField.typeName,
+                value: mockContactMetadataBlockField.value
+              }]
+            }
+          }
+        }
+      }
+
+      const result = DatasetUtil.mapBasicDatasetInformation(basicDatasetInformation)
+
+      expect(result).to.be.deep.equal(expectedResult)
+    })
+
+    describe('null or undefined title', () => {
+      [null, undefined].forEach(title => {
+        it('should not call createTitleField', async () => {
+          basicDatasetInformation.title = title
+
+          DatasetUtil.mapBasicDatasetInformation(basicDatasetInformation)
+
+          assert.notCalled(createTitleFieldStub)
+        })
+      })
+    })
+
+    describe('null or undefined subtitle', () => {
+      [null, undefined].forEach(subtitle => {
+        it('should not call createSubtitleField', async () => {
+          basicDatasetInformation.subtitle = subtitle
+
+          DatasetUtil.mapBasicDatasetInformation(basicDatasetInformation)
+
+          assert.notCalled(createSubtitleFieldStub)
+        })
+      })
+    })
+
+    describe('null or undefined authors', () => {
+      [null, undefined].forEach(authors => {
+        it('should not call createAuthorField', async () => {
+          basicDatasetInformation.authors = authors
+
+          DatasetUtil.mapBasicDatasetInformation(basicDatasetInformation)
+
+          assert.notCalled(createAuthorFieldStub)
+        })
+      })
+    })
+
+    describe('null or undefined descriptions', () => {
+      [null, undefined].forEach(descriptions => {
+        it('should not call createDescriptionField', async () => {
+          basicDatasetInformation.descriptions = descriptions
+
+          DatasetUtil.mapBasicDatasetInformation(basicDatasetInformation)
+
+          assert.notCalled(createDescriptionFieldStub)
+        })
+      })
+    })
+
+    describe('null or undefined subject', () => {
+      [null, undefined].forEach(subject => {
+        it('should not call createSubjectField', async () => {
+          basicDatasetInformation.subject = subject
+
+          DatasetUtil.mapBasicDatasetInformation(basicDatasetInformation)
+
+          assert.notCalled(createSubjectFieldStub)
+        })
+      })
+    })
+
+    describe('null or undefined contact', () => {
+      [null, undefined].forEach(contact => {
+        it('should not call createSubjectField', async () => {
+          basicDatasetInformation.contact = contact
+
+          DatasetUtil.mapBasicDatasetInformation(basicDatasetInformation)
+
+          assert.notCalled(createContactFieldStub)
+        })
+      })
+    })
+  })
+})

--- a/test/utils/metadataBlocksUtil.spec.ts
+++ b/test/utils/metadataBlocksUtil.spec.ts
@@ -1,0 +1,223 @@
+import {
+  METADATA_BLOCK_FIELD_AUTHOR,
+  METADATA_BLOCK_FIELD_AUTHOR_AFFILIATION,
+  METADATA_BLOCK_FIELD_AUTHOR_FULLNAME,
+  MetadataBlocksUtil
+} from '../../src/utils/metadataBlocksUtil'
+import { BasicDatasetAuthor } from '../../src/@types/basicDataset'
+import { name, random, internet } from 'faker'
+import { expect } from 'chai'
+import { FieldTypeClass } from '../../src/@types/FieldTypeClass'
+import { MetadataBlockField } from '../../src/@types/metadataBlockField'
+import { DatasetSubjects } from '../../src/@types/datasetSubjects'
+
+describe('MetadataBlocksUtil', () => {
+  describe('createTitleField', () => {
+    it('should return expected metadata block field', async () => {
+      const title = random.words()
+
+      const expectedResult: MetadataBlockField = {
+        typeName: 'title',
+        multiple: false,
+        typeClass: 'primitive',
+        value: title
+      }
+
+      const result = MetadataBlocksUtil.createTitleField(title)
+
+      expect(result).to.be.deep.equal(expectedResult)
+    })
+  })
+
+  describe('createSubtitleField', () => {
+    it('should return expected metadata block field', async () => {
+      const subtitle = random.words()
+
+      const expectedResult: MetadataBlockField = {
+        typeName: 'subtitle',
+        multiple: false,
+        typeClass: 'primitive',
+        value: subtitle
+      }
+
+      const result = MetadataBlocksUtil.createSubtitleField(subtitle)
+
+      expect(result).to.be.deep.equal(expectedResult)
+    })
+  })
+
+  describe('createDescriptionField', () => {
+    it('should return expected metadata block field', async () => {
+      const description1 = random.words()
+      const date1 = '2019-01-01'
+      const description2 = random.words()
+      const date2 = '2018-09-12'
+
+      const expectedResult = {
+        typeName: 'dsDescription',
+        multiple: true,
+        typeClass: 'compound',
+        value: [
+          {
+            dsDescriptionValue: {
+              typeName: 'dsDescriptionValue',
+              typeClass: 'primitive',
+              multiple: false,
+              value: description1
+            },
+            dsDescriptionDate: {
+              typeName: 'dsDescriptionDate',
+              typeClass: 'primitive',
+              multiple: false,
+              value: date1
+            }
+          },
+          {
+            dsDescriptionValue: {
+              typeName: 'dsDescriptionValue',
+              typeClass: 'primitive',
+              multiple: false,
+              value: description2
+            },
+            dsDescriptionDate: {
+              typeName: 'dsDescriptionDate',
+              typeClass: 'primitive',
+              multiple: false,
+              value: date2
+            }
+          }
+        ]
+      }
+
+      const result = MetadataBlocksUtil.createDescriptionField([
+        {
+          text: description1,
+          date: date1
+        }, {
+          text: description2,
+          date: date2
+        }
+      ])
+
+      expect(result).to.be.deep.equal(expectedResult)
+    })
+  })
+
+  describe('createAuthorField', () => {
+    it('should return expected metadata block field', async () => {
+      const fullname = `${name.firstName()} ${name.lastName()}`
+      const affiliation = random.words()
+
+      const expectedResult = {
+        typeName: METADATA_BLOCK_FIELD_AUTHOR,
+        typeClass: FieldTypeClass.COMPOUND,
+        multiple: true,
+        value: [
+          {
+            'authorName': {
+              value: fullname,
+              typeName: METADATA_BLOCK_FIELD_AUTHOR_FULLNAME,
+              multiple: false,
+              typeClass: FieldTypeClass.PRIMITIVE
+            },
+            'authorAffiliation': {
+              value: affiliation,
+              typeName: METADATA_BLOCK_FIELD_AUTHOR_AFFILIATION,
+              multiple: false,
+              typeClass: FieldTypeClass.PRIMITIVE
+            },
+          }
+        ]
+      }
+
+      const input: BasicDatasetAuthor[] = [
+        {
+          fullname: fullname,
+          affiliation: affiliation
+        }
+      ]
+
+      const result = MetadataBlocksUtil.createAuthorField(input)
+
+      expect(result).to.be.deep.equal(expectedResult)
+    })
+  })
+
+  describe('createSubjectField', () => {
+    it('should return expected subject metadata block field', async () => {
+      const expectedResult = {
+        typeName: 'subject',
+        typeClass: 'controlledVocabulary',
+        multiple: true,
+        value: [
+          'Agricultural Sciences',
+          'Other'
+        ]
+      }
+
+      const result = MetadataBlocksUtil.createSubjectField([
+        DatasetSubjects.AGRICULTURAL_SCIENCE,
+        DatasetSubjects.OTHER
+      ])
+
+      expect(result).to.be.deep.equal(expectedResult)
+    })
+  })
+
+  describe('createContactField', () => {
+    it('should return expected contact metadata block field', async () => {
+      const contactEmail = internet.email()
+      const contactName = `${name.firstName()} ${name.lastName()}`
+      const expectedResult = {
+        typeName: 'datasetContact',
+        typeClass: 'compound',
+        multiple: true,
+        value: [
+          {
+            datasetContactEmail: {
+              typeClass: FieldTypeClass.PRIMITIVE,
+              typeName: 'datasetContactEmail',
+              multiple: false,
+              value: contactEmail
+            },
+            datasetContactName: {
+              typeClass: FieldTypeClass.PRIMITIVE,
+              typeName: 'datasetContactName',
+              multiple: false,
+              value: contactName
+            }
+          }
+        ]
+      }
+
+      const result = MetadataBlocksUtil.createContactField([{ email: contactEmail, fullname: contactName }])
+
+      expect(result).to.be.deep.equal(expectedResult)
+    })
+
+    describe('missing full name', () => {
+      it('should return expected contact metadata block field', async () => {
+        const contactEmail = internet.email()
+        const expectedResult = {
+          typeName: 'datasetContact',
+          typeClass: 'compound',
+          multiple: true,
+          value: [
+            {
+              datasetContactEmail: {
+                typeClass: FieldTypeClass.PRIMITIVE,
+                typeName: 'datasetContactEmail',
+                multiple: false,
+                value: contactEmail
+              }
+            }
+          ]
+        }
+
+        const result = MetadataBlocksUtil.createContactField([{ email: contactEmail }])
+
+        expect(result).to.be.deep.equal(expectedResult)
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Description
Add a new client function to create datasets without having to provide all the metadata block fields

## Changes
- Created new function
- Created Utils
- Improved unit tests
- abstracted classes

## Tests
- Unit tests
- Manual test

## Checklist
[x] The project builds
[x] The project passes lint checks
[x] The project passes format checks
[x] The project passes unit tests
[x] I've manually tested the functionality

## Screenshots

## Additional information

