### PR TITLE
HASI-267 adds new endpoint for publishing datasets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-dataverse",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "description": "A Dataverse module for JavaScript/TypeScript",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/@types/datasetVersionUpgradeType.ts
+++ b/src/@types/datasetVersionUpgradeType.ts
@@ -1,0 +1,5 @@
+export enum DatasetVersionUpgradeType {
+  MAJOR = 'major',
+  MINOR = 'minor',
+  CURRENT = 'updatecurrent' // Only used to just update dataset metadata
+}

--- a/src/dataverseClient.ts
+++ b/src/dataverseClient.ts
@@ -6,6 +6,7 @@ import { DataverseMetricType } from './@types/dataverseMetricType'
 import { BasicDatasetInformation } from './@types/basicDataset'
 import { DatasetUtil } from './utils/datasetUtil'
 import request from 'request-promise'
+import { DatasetVersionUpgradeType } from './@types/datasetVersionUpgradeType'
 
 export class DataverseClient {
   private readonly host: string
@@ -148,6 +149,11 @@ export class DataverseClient {
     return request.post(options).catch(error => {
       throw new DataverseException(error.response.statusCode, error.response.body ? JSON.parse(error.response.body).message : '')
     })
+  }
+
+  public async publishDataset(datasetId: string, versionUpgradeType: DatasetVersionUpgradeType = DatasetVersionUpgradeType.MAJOR): Promise<AxiosResponse> {
+    const url = `${this.host}/api/datasets/${datasetId}/actions/:publish?type=${versionUpgradeType}`
+    return this.postRequest(url, '')
   }
 
   private async getRequest(url: string, options: { params?: object, headers?: DataverseHeaders, responseType?: ResponseType } = { headers: this.getHeaders() }): Promise<AxiosResponse> {

--- a/test/dataverseClient.spec.ts
+++ b/test/dataverseClient.spec.ts
@@ -11,6 +11,7 @@ import { DatasetSubjects } from '../src/@types/datasetSubjects'
 import { BasicDatasetInformation } from '../src/@types/basicDataset'
 import { DatasetUtil } from '../src/utils/datasetUtil'
 import fs from 'fs'
+import { DatasetVersionUpgradeType } from '../src/@types/datasetVersionUpgradeType'
 
 describe('DataverseClient', () => {
   const sandbox: SinonSandbox = createSandbox()
@@ -1149,6 +1150,168 @@ describe('DataverseClient', () => {
       expect(error).to.be.instanceOf(Error)
       expect(error.message).to.be.equal(errorMessage)
       expect(error.errorCode).to.be.equal(errorCode)
+    })
+  })
+
+  describe('publishDataset', () => {
+    let datasetId: string
+
+    beforeEach(() => {
+      datasetId = random.number().toString()
+    })
+
+    describe('minor version upgrade', () => {
+      it('should call axios with expected url', async () => {
+        await client.publishDataset(datasetId, DatasetVersionUpgradeType.MINOR)
+
+        assert.calledOnce(axiosPostStub)
+        assert.calledWithExactly(axiosPostStub,
+          `${host}/api/datasets/${datasetId}/actions/:publish?type=${DatasetVersionUpgradeType.MINOR}`,
+          JSON.stringify(''),
+          { headers: { 'X-Dataverse-key': apiToken } })
+      })
+
+      it('should call axios with expected headers when no apiToken provided', async () => {
+        client = new DataverseClient(host)
+        await client.publishDataset(datasetId, DatasetVersionUpgradeType.MINOR)
+
+        assert.calledOnce(axiosPostStub)
+        assert.calledWithExactly(axiosPostStub, `${host}/api/datasets/${datasetId}/actions/:publish?type=${DatasetVersionUpgradeType.MINOR}`,
+          JSON.stringify(''),
+          { headers: { 'X-Dataverse-key': '' } })
+      })
+
+      it('should return expected response', async () => {
+        const randomValue = random.word()
+        const expectedResponse = {
+          ...mockResponse,
+          'test': randomValue
+        }
+        axiosPostStub
+          .withArgs(`${host}/api/datasets/${datasetId}/actions/:publish?type=${DatasetVersionUpgradeType.MINOR}`, JSON.stringify(''), { headers: { 'X-Dataverse-key': apiToken } })
+          .resolves({ ...mockResponse, 'test': randomValue })
+
+        const response = await client.publishDataset(datasetId, DatasetVersionUpgradeType.MINOR)
+
+        expect(response).to.be.deep.eq(expectedResponse)
+      })
+
+      it('should throw expected error', async () => {
+        const errorMessage = random.words()
+        const errorCode = random.number()
+        axiosPostStub.rejects({ response: { status: errorCode, data: { message: errorMessage } } })
+
+        let error: DataverseException = undefined
+
+        await client.publishDataset(datasetId, DatasetVersionUpgradeType.MINOR).catch(e => error = e)
+
+        expect(error).to.be.instanceOf(Error)
+        expect(error.message).to.be.equal(errorMessage)
+        expect(error.errorCode).to.be.equal(errorCode)
+      })
+    })
+
+    describe('major version upgrade', () => {
+      it('should call axios with expected url', async () => {
+        await client.publishDataset(datasetId, DatasetVersionUpgradeType.MAJOR)
+
+        assert.calledOnce(axiosPostStub)
+        assert.calledWithExactly(axiosPostStub,
+          `${host}/api/datasets/${datasetId}/actions/:publish?type=${DatasetVersionUpgradeType.MAJOR}`,
+          JSON.stringify(''),
+          { headers: { 'X-Dataverse-key': apiToken } })
+      })
+
+      it('should call axios with expected headers when no apiToken provided', async () => {
+        client = new DataverseClient(host)
+        await client.publishDataset(datasetId, DatasetVersionUpgradeType.MAJOR)
+
+        assert.calledOnce(axiosPostStub)
+        assert.calledWithExactly(axiosPostStub, `${host}/api/datasets/${datasetId}/actions/:publish?type=${DatasetVersionUpgradeType.MAJOR}`,
+          JSON.stringify(''),
+          { headers: { 'X-Dataverse-key': '' } })
+      })
+
+      it('should return expected response', async () => {
+        const randomValue = random.word()
+        const expectedResponse = {
+          ...mockResponse,
+          'test': randomValue
+        }
+        axiosPostStub
+          .withArgs(`${host}/api/datasets/${datasetId}/actions/:publish?type=${DatasetVersionUpgradeType.MAJOR}`, JSON.stringify(''), { headers: { 'X-Dataverse-key': apiToken } })
+          .resolves({ ...mockResponse, 'test': randomValue })
+
+        const response = await client.publishDataset(datasetId, DatasetVersionUpgradeType.MAJOR)
+
+        expect(response).to.be.deep.eq(expectedResponse)
+      })
+
+      it('should throw expected error', async () => {
+        const errorMessage = random.words()
+        const errorCode = random.number()
+        axiosPostStub.rejects({ response: { status: errorCode, data: { message: errorMessage } } })
+
+        let error: DataverseException = undefined
+
+        await client.publishDataset(datasetId, DatasetVersionUpgradeType.MAJOR).catch(e => error = e)
+
+        expect(error).to.be.instanceOf(Error)
+        expect(error.message).to.be.equal(errorMessage)
+        expect(error.errorCode).to.be.equal(errorCode)
+      })
+    })
+
+    describe('missing version upgrade type', () => {
+      it('should call axios with expected url', async () => {
+
+        await client.publishDataset(datasetId)
+
+        assert.calledOnce(axiosPostStub)
+        assert.calledWithExactly(axiosPostStub,
+          `${host}/api/datasets/${datasetId}/actions/:publish?type=${DatasetVersionUpgradeType.MAJOR}`,
+          JSON.stringify(''),
+          { headers: { 'X-Dataverse-key': apiToken } })
+      })
+
+      it('should call axios with expected headers when no apiToken provided', async () => {
+        client = new DataverseClient(host)
+        await client.publishDataset(datasetId)
+
+        assert.calledOnce(axiosPostStub)
+        assert.calledWithExactly(axiosPostStub, `${host}/api/datasets/${datasetId}/actions/:publish?type=${DatasetVersionUpgradeType.MAJOR}`,
+          JSON.stringify(''),
+          { headers: { 'X-Dataverse-key': '' } })
+      })
+
+      it('should return expected response', async () => {
+        const randomValue = random.word()
+        const expectedResponse = {
+          ...mockResponse,
+          'test': randomValue
+        }
+        axiosPostStub
+          .withArgs(`${host}/api/datasets/${datasetId}/actions/:publish?type=${DatasetVersionUpgradeType.MAJOR}`, JSON.stringify(''), { headers: { 'X-Dataverse-key': apiToken } })
+          .resolves({ ...mockResponse, 'test': randomValue })
+
+        const response = await client.publishDataset(datasetId)
+
+        expect(response).to.be.deep.eq(expectedResponse)
+      })
+
+      it('should throw expected error', async () => {
+        const errorMessage = random.words()
+        const errorCode = random.number()
+        axiosPostStub.rejects({ response: { status: errorCode, data: { message: errorMessage } } })
+
+        let error: DataverseException = undefined
+
+        await client.publishDataset(datasetId).catch(e => error = e)
+
+        expect(error).to.be.instanceOf(Error)
+        expect(error.message).to.be.equal(errorMessage)
+        expect(error.errorCode).to.be.equal(errorCode)
+      })
     })
   })
 })


### PR DESCRIPTION
## Description
Creates new endpoint for publishing datasets

## Changes
- adds new endpoint for publishing datasets
- Add unit tests
- Creates new enum for version upgrade types

## Tests
- Manual tests
- Unit tests

## Checklist
[x] The project builds
[x] The project passes lint checks
[x] The project passes format checks
[x] The project passes unit tests
[x] I've manually tested the functionality

## Screenshots

## Additional information

