### PR TITLE
Create new functions to allow version types

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,17 @@ const response = await client.getDataverseInformation('myDataverseAlias')
 
 `public async getFileMetadata(fileId: string, draftVersion: boolean = false): Promise<AxiosResponse> {`
 
+`public async getLatestPublishedDatasetInformation(datasetId: string): Promise<AxiosResponse> {`
+
 `public async getLatestDatasetInformation(datasetId: string): Promise<AxiosResponse> {`
 
+`public async getDraftDatasetInformation(datasetId: string): Promise<AxiosResponse> {`
+
+`public async getLatestPublishedDatasetInformationFromDOI(doi: string): Promise<AxiosResponse> {`
+
 `public async getLatestDatasetInformationFromDOI(doi: string): Promise<AxiosResponse> {`
+
+`public async getDraftDatasetInformationFromDOI(doi: string): Promise<AxiosResponse> {`
 
 `public async getDatasetVersions(datasetId: string): Promise<AxiosResponse> {`
 
@@ -44,6 +52,8 @@ public async getDatasetVersion(datasetId: string, version: string): Promise<Axio
 Note: Version must be published, e.g.:
 http://demo.dataverse.org/api/datasets/389608/versions/1
 ```
+
+`public async getDatasetVersionFromDOI(doi: string, version: string): Promise<AxiosResponse> {`
 
 `public async listDataverseRoleAssignments(dataverseAlias: string): Promise<AxiosResponse> {`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-dataverse",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "description": "A Dataverse module for JavaScript/TypeScript",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/@types/datasetVersionType.ts
+++ b/src/@types/datasetVersionType.ts
@@ -1,0 +1,5 @@
+export enum DatasetVersionType {
+  LATEST_PUBLISHED = ':latest-published',
+  LATEST = ':latest',
+  DRAFT = ':draft'
+}

--- a/src/dataverseClient.ts
+++ b/src/dataverseClient.ts
@@ -7,6 +7,7 @@ import { BasicDatasetInformation } from './@types/basicDataset'
 import { DatasetUtil } from './utils/datasetUtil'
 import request from 'request-promise'
 import { DatasetVersionUpgradeType } from './@types/datasetVersionUpgradeType'
+import { DatasetVersionType } from "./@types/datasetVersionType"
 
 export class DataverseClient {
   private readonly host: string
@@ -63,14 +64,28 @@ export class DataverseClient {
     return this.getRequest(url)
   }
 
+  public async getLatestPublishedDatasetInformation(datasetId: string): Promise<AxiosResponse> {
+    return this.getDatasetVersion(datasetId, DatasetVersionType.LATEST_PUBLISHED)
+  }
+
   public async getLatestDatasetInformation(datasetId: string): Promise<AxiosResponse> {
-    const url = `${this.host}/api/datasets/${datasetId}`
-    return this.getRequest(url)
+    return this.getDatasetVersion(datasetId, DatasetVersionType.LATEST)
+  }
+
+  public async getDraftDatasetInformation(datasetId: string): Promise<AxiosResponse> {
+    return this.getDatasetVersion(datasetId, DatasetVersionType.DRAFT)
+  }
+
+  public async getLatestPublishedDatasetInformationFromDOI(doi: string): Promise<AxiosResponse> {
+    return this.getDatasetVersionFromDOI(doi, DatasetVersionType.LATEST_PUBLISHED)
   }
 
   public async getLatestDatasetInformationFromDOI(doi: string): Promise<AxiosResponse> {
-    const url = `${this.host}/api/datasets/:persistentId?persistentId=doi:${doi}`
-    return this.getRequest(url)
+    return this.getDatasetVersionFromDOI(doi, DatasetVersionType.LATEST)
+  }
+
+  public async getDraftDatasetInformationFromDOI(doi: string): Promise<AxiosResponse> {
+    return this.getDatasetVersionFromDOI(doi, DatasetVersionType.DRAFT)
   }
 
   public async getDatasetVersions(datasetId: string): Promise<AxiosResponse> {
@@ -80,6 +95,11 @@ export class DataverseClient {
 
   public async getDatasetVersion(datasetId: string, version: string): Promise<AxiosResponse> {
     const url = `${this.host}/api/datasets/${datasetId}/versions/${version}`
+    return this.getRequest(url)
+  }
+
+  public async getDatasetVersionFromDOI(doi: string, version: string): Promise<AxiosResponse> {
+    const url = `${this.host}/api/datasets/:persistentId/versions/${version}?persistentId=doi:${doi}`
     return this.getRequest(url)
   }
 

--- a/src/dataverseClient.ts
+++ b/src/dataverseClient.ts
@@ -7,7 +7,7 @@ import { BasicDatasetInformation } from './@types/basicDataset'
 import { DatasetUtil } from './utils/datasetUtil'
 import request from 'request-promise'
 import { DatasetVersionUpgradeType } from './@types/datasetVersionUpgradeType'
-import { DatasetVersionType } from "./@types/datasetVersionType"
+import { DatasetVersionType } from './@types/datasetVersionType'
 
 export class DataverseClient {
   private readonly host: string

--- a/test/dataverseClient.spec.ts
+++ b/test/dataverseClient.spec.ts
@@ -562,108 +562,117 @@ describe('DataverseClient', () => {
     })
   })
 
+  describe('getLatestPublishedDatasetInformation', () => {
+    let mockDatasetId: string
+
+    let getDatasetVersionStub: SinonStub
+
+    beforeEach(() => {
+      mockDatasetId = random.number().toString()
+
+      getDatasetVersionStub = sandbox.stub(DataverseClient.prototype, 'getDatasetVersion')
+    })
+
+    it('should call getDatasetVersion with expected input', async () => {
+      await client.getLatestPublishedDatasetInformation(mockDatasetId)
+
+      assert.calledOnce(getDatasetVersionStub)
+      assert.calledWithExactly(getDatasetVersionStub, mockDatasetId, ':latest-published')
+    })
+  })
+
   describe('getLatestDatasetInformation', () => {
-    it('should call axios with expected url', async () => {
-      const datasetId: string = random.number().toString()
+    let mockDatasetId: string
 
-      await client.getLatestDatasetInformation(datasetId)
+    let getDatasetVersionStub: SinonStub
 
-      assert.calledOnce(axiosGetStub)
-      assert.calledWithExactly(axiosGetStub, `${host}/api/datasets/${datasetId}`, { headers: { 'X-Dataverse-key': apiToken } })
+    beforeEach(() => {
+      mockDatasetId = random.number().toString()
+
+      getDatasetVersionStub = sandbox.stub(DataverseClient.prototype, 'getDatasetVersion')
     })
 
-    it('should call axios with expected headers when no apiToken provided', async () => {
-      client = new DataverseClient(host)
-      const datasetId: string = random.number().toString()
+    it('should call getDatasetVersion with expected input', async () => {
+      await client.getLatestDatasetInformation(mockDatasetId)
 
-      await client.getLatestDatasetInformation(datasetId)
+      assert.calledOnce(getDatasetVersionStub)
+      assert.calledWithExactly(getDatasetVersionStub, mockDatasetId, ':latest')
+    })
+  })
 
-      assert.calledOnce(axiosGetStub)
-      assert.calledWithExactly(axiosGetStub, `${host}/api/datasets/${datasetId}`, { headers: { 'X-Dataverse-key': '' } })
+  describe('getDraftDatasetInformation', () => {
+    let mockDatasetId: string
+
+    let getDatasetVersionStub: SinonStub
+
+    beforeEach(() => {
+      mockDatasetId = random.number().toString()
+
+      getDatasetVersionStub = sandbox.stub(DataverseClient.prototype, 'getDatasetVersion')
     })
 
-    it('should return expected response', async () => {
-      const datasetId: string = random.number().toString()
-      const randomValue = random.word()
-      const expectedResponse = {
-        ...mockResponse,
-        'test': randomValue
-      }
-      axiosGetStub
-        .withArgs(`${host}/api/datasets/${datasetId}`, { headers: { 'X-Dataverse-key': apiToken } })
-        .resolves({ ...mockResponse, 'test': randomValue })
+    it('should call getDatasetVersion with expected input', async () => {
+      await client.getDraftDatasetInformation(mockDatasetId)
 
-      const response = await client.getLatestDatasetInformation(datasetId)
+      assert.calledOnce(getDatasetVersionStub)
+      assert.calledWithExactly(getDatasetVersionStub, mockDatasetId, ':draft')
+    })
+  })
 
-      expect(response).to.be.deep.equal(expectedResponse)
+  describe('getLatestPublishedDatasetInformationFromDOI', () => {
+    let mockDatasetId: string
+
+    let getDatasetVersionFromDOIStub: SinonStub
+
+    beforeEach(() => {
+      mockDatasetId = random.number().toString()
+
+      getDatasetVersionFromDOIStub = sandbox.stub(DataverseClient.prototype, 'getDatasetVersionFromDOI')
     })
 
-    it('should throw expected error', async () => {
-      const datasetId: string = random.number().toString()
-      const errorMessage = random.words()
-      const errorCode = random.number()
-      axiosGetStub.rejects({ response: { status: errorCode, data: { message: errorMessage } } })
+    it('should call getDatasetVersionFromDOI with expected input', async () => {
+      await client.getLatestPublishedDatasetInformationFromDOI(mockDatasetId)
 
-      let error: DataverseException = undefined
-
-      await client.getLatestDatasetInformation(datasetId).catch(e => error = e)
-
-      expect(error).to.be.instanceOf(Error)
-      expect(error.message).to.be.equal(errorMessage)
-      expect(error.errorCode).to.be.equal(errorCode)
+      assert.calledOnce(getDatasetVersionFromDOIStub)
+      assert.calledWithExactly(getDatasetVersionFromDOIStub, mockDatasetId, ':latest-published')
     })
   })
 
   describe('getLatestDatasetInformationFromDOI', () => {
-    let doi: string
+    let mockDoi: string
+
+    let getDatasetVersionFromDOIStub: SinonStub
 
     beforeEach(() => {
-      doi = `${random.number()}.${random.number()}/${random.word()}/${random.word()}`
+      mockDoi = `${random.number()}.${random.number()}/${random.word()}/${random.word()}`
+
+      getDatasetVersionFromDOIStub = sandbox.stub(DataverseClient.prototype, 'getDatasetVersionFromDOI')
     })
 
-    it('should call axios with expected url', async () => {
-      await client.getLatestDatasetInformationFromDOI(doi)
+    it('should call getDatasetVersionFromDOI with expected input', async () => {
+      await client.getLatestDatasetInformationFromDOI(mockDoi)
 
-      assert.calledOnce(axiosGetStub)
-      assert.calledWithExactly(axiosGetStub, `${host}/api/datasets/:persistentId?persistentId=doi:${doi}`, { headers: { 'X-Dataverse-key': apiToken } })
+      assert.calledOnce(getDatasetVersionFromDOIStub)
+      assert.calledWithExactly(getDatasetVersionFromDOIStub, mockDoi, ':latest')
+    })
+  })
+
+  describe('getDraftDatasetInformationFromDOI', () => {
+    let mockDoi: string
+
+    let getDatasetVersionFromDOIStub: SinonStub
+
+    beforeEach(() => {
+      mockDoi = `${random.number()}.${random.number()}/${random.word()}/${random.word()}`
+
+      getDatasetVersionFromDOIStub = sandbox.stub(DataverseClient.prototype, 'getDatasetVersionFromDOI')
     })
 
-    it('should call axios with expected headers when no apiToken provided', async () => {
-      client = new DataverseClient(host)
+    it('should call getDatasetVersionFromDOI with expected input', async () => {
+      await client.getDraftDatasetInformationFromDOI(mockDoi)
 
-      await client.getLatestDatasetInformationFromDOI(doi)
-
-      assert.calledOnce(axiosGetStub)
-      assert.calledWithExactly(axiosGetStub, `${host}/api/datasets/:persistentId?persistentId=doi:${doi}`, { headers: { 'X-Dataverse-key': '' } })
-    })
-
-    it('should return expected response', async () => {
-      const randomValue = random.word()
-      const expectedResponse = {
-        ...mockResponse,
-        'test': randomValue
-      }
-      axiosGetStub
-        .withArgs(`${host}/api/datasets/:persistentId?persistentId=doi:${doi}`, { headers: { 'X-Dataverse-key': apiToken } })
-        .resolves({ ...mockResponse, 'test': randomValue })
-
-      const response = await client.getLatestDatasetInformationFromDOI(doi)
-
-      expect(response).to.be.deep.equal(expectedResponse)
-    })
-
-    it('should throw expected error', async () => {
-      const errorMessage = random.words()
-      const errorCode = random.number()
-      axiosGetStub.rejects({ response: { status: errorCode, data: { message: errorMessage } } })
-
-      let error: DataverseException = undefined
-
-      await client.getLatestDatasetInformationFromDOI(doi).catch(e => error = e)
-
-      expect(error).to.be.instanceOf(Error)
-      expect(error.message).to.be.equal(errorMessage)
-      expect(error.errorCode).to.be.equal(errorCode)
+      assert.calledOnce(getDatasetVersionFromDOIStub)
+      assert.calledWithExactly(getDatasetVersionFromDOIStub, mockDoi, ':draft')
     })
   })
 
@@ -768,6 +777,61 @@ describe('DataverseClient', () => {
       let error: DataverseException = undefined
 
       await client.getDatasetVersion(datasetId, version).catch(e => error = e)
+
+      expect(error).to.be.instanceOf(Error)
+      expect(error.message).to.be.equal(errorMessage)
+      expect(error.errorCode).to.be.equal(errorCode)
+    })
+  })
+
+  describe('getDatasetVersionFromDOI', () => {
+    let mockDoi: string
+    let mockVersion: string
+
+    beforeEach(() => {
+      mockDoi = `${random.number()}.${random.number()}/${random.word()}/${random.word()}`
+      mockVersion = random.number().toString()
+    })
+
+    it('should call axios with expected url', async () => {
+      await client.getDatasetVersionFromDOI(mockDoi, mockVersion)
+
+      assert.calledOnce(axiosGetStub)
+      assert.calledWithExactly(axiosGetStub, `${host}/api/datasets/:persistentId/versions/${mockVersion}?persistentId=doi:${mockDoi}`, { headers: { 'X-Dataverse-key': apiToken } })
+    })
+
+    it('should call axios with expected headers when no apiToken provided', async () => {
+      client = new DataverseClient(host)
+
+      await client.getDatasetVersionFromDOI(mockDoi, mockVersion)
+
+      assert.calledOnce(axiosGetStub)
+      assert.calledWithExactly(axiosGetStub, `${host}/api/datasets/:persistentId/versions/${mockVersion}?persistentId=doi:${mockDoi}`, { headers: { 'X-Dataverse-key': '' } })
+    })
+
+    it('should return expected response', async () => {
+      const randomValue = random.word()
+      const expectedResponse = {
+        ...mockResponse,
+        'test': randomValue
+      }
+      axiosGetStub
+        .withArgs(`${host}/api/datasets/:persistentId/versions/${mockVersion}?persistentId=doi:${mockDoi}`, { headers: { 'X-Dataverse-key': apiToken } })
+        .resolves({ ...mockResponse, 'test': randomValue })
+
+      const response = await client.getDatasetVersionFromDOI(mockDoi, mockVersion)
+
+      expect(response).to.be.deep.equal(expectedResponse)
+    })
+
+    it('should throw expected error', async () => {
+      const errorMessage = random.words()
+      const errorCode = random.number()
+      axiosGetStub.rejects({ response: { status: errorCode, data: { message: errorMessage } } })
+
+      let error: DataverseException = undefined
+
+      await client.getDatasetVersionFromDOI(mockDoi, mockVersion).catch(e => error = e)
 
       expect(error).to.be.instanceOf(Error)
       expect(error.message).to.be.equal(errorMessage)


### PR DESCRIPTION
## Description
Creates new functions to retrieve the latest published and draft dataset information from a dataset id or from a dataset DOI

## Changes
- Refactors code
- Create new functions
- Adds unit tests

## Tests
- Manual test
- Unit tests

## Checklist
[x] The project builds
[x] The project passes lint checks
[x] The project passes format checks
[x] The project passes unit tests
[x] I've manually tested the functionality

## Screenshots

## Additional information

