### PR TITLE
HASI-000 allow searching only published data

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,17 @@ const response = await client.getDataverseInformation('myDataverseAlias')
 
 `public async search(options: SearchOptions): Promise<AxiosResponse> {`
 
+`public async searchOnlyPublished(options: SearchOptions): Promise<AxiosResponse> {`
+
 `public async getFile(fileId: string): Promise<AxiosResponse> {`
 
 `public async getFileMetadata(fileId: string, draftVersion: boolean = false): Promise<AxiosResponse> {`
 
 `public async getLatestDatasetInformation(datasetId: string): Promise<AxiosResponse> {`
+
+`public async getLatestPublishedDatasetVersion(datasetId: string): Promise<AxiosResponse> {`
+
+`public async getDraftDatasetVersion(datasetId: string): Promise<AxiosResponse> {`
 
 `public async getLatestDatasetInformationFromDOI(doi: string): Promise<AxiosResponse> {`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-dataverse",
-  "version": "1.0.29",
+  "version": "1.0.32",
   "description": "A Dataverse module for JavaScript/TypeScript",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/@types/datasetVersionType.ts
+++ b/src/@types/datasetVersionType.ts
@@ -1,0 +1,5 @@
+export enum DatasetVersionType {
+  LATEST_PUBLISHED = ':latest-published',
+  LATEST = ':latest',
+  DRAFT = ':draft'
+}

--- a/src/@types/dataverseHeaders.ts
+++ b/src/@types/dataverseHeaders.ts
@@ -1,4 +1,4 @@
 export interface DataverseHeaders {
-  'X-Dataverse-key': string,
+  'X-Dataverse-key'?: string,
   'Content-Type'?: string
 }

--- a/src/dataverseClient.ts
+++ b/src/dataverseClient.ts
@@ -7,6 +7,7 @@ import { BasicDatasetInformation } from './@types/basicDataset'
 import { DatasetUtil } from './utils/datasetUtil'
 import request from 'request-promise'
 import { DatasetVersionUpgradeType } from './@types/datasetVersionUpgradeType'
+import { DatasetVersionType } from "./@types/datasetVersionType"
 
 export class DataverseClient {
   private readonly host: string
@@ -44,10 +45,14 @@ export class DataverseClient {
     })
   }
 
-  public async search(options: SearchOptions): Promise<AxiosResponse> {
+  public async search(options: SearchOptions, headers: DataverseHeaders = this.getHeaders()): Promise<AxiosResponse> {
     const url = `${this.host}/api/search`
     const requestOptions: DataverseSearchOptions = this.mapSearchOptions(options)
-    return this.getRequest(url, { params: requestOptions })
+    return this.getRequest(url, { params: requestOptions, headers: headers })
+  }
+
+  public async searchOnlyPublished(options: SearchOptions): Promise<AxiosResponse> {
+    return this.search(options, {})
   }
 
   public async getFile(fileId: string): Promise<AxiosResponse> {
@@ -66,6 +71,14 @@ export class DataverseClient {
   public async getLatestDatasetInformation(datasetId: string): Promise<AxiosResponse> {
     const url = `${this.host}/api/datasets/${datasetId}`
     return this.getRequest(url)
+  }
+
+  public async getLatestPublishedDatasetVersion(datasetId: string): Promise<AxiosResponse> {
+    return this.getDatasetVersion(datasetId, DatasetVersionType.LATEST_PUBLISHED)
+  }
+
+  public async getDraftDatasetVersion(datasetId: string): Promise<AxiosResponse> {
+    return this.getDatasetVersion(datasetId, DatasetVersionType.DRAFT)
   }
 
   public async getLatestDatasetInformationFromDOI(doi: string): Promise<AxiosResponse> {

--- a/src/dataverseClient.ts
+++ b/src/dataverseClient.ts
@@ -7,7 +7,7 @@ import { BasicDatasetInformation } from './@types/basicDataset'
 import { DatasetUtil } from './utils/datasetUtil'
 import request from 'request-promise'
 import { DatasetVersionUpgradeType } from './@types/datasetVersionUpgradeType'
-import { DatasetVersionType } from "./@types/datasetVersionType"
+import { DatasetVersionType } from './@types/datasetVersionType'
 
 export class DataverseClient {
   private readonly host: string


### PR DESCRIPTION
## Description
Creates new functions for searching only published data and retrieving specific dataset versions

## Changes
- Creates new function for searching only published data
- Creates new function for getting latest published dataset version
- Creates new function for getting draft dataset version
- Update unit tests

## Tests
- Unit tests
- Manual tests

## Checklist
[x] The project builds
[x] The project passes lint checks
[x] The project passes format checks
[x] The project passes unit tests
[x] I've manually tested the functionality

## Screenshots

## Additional information

