### PR TITLE
HASI-000 allow specifying json data

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ http://demo.dataverse.org/api/datasets/389608/versions/1
 
 `public async getMetricByCountry(datasetId: string, metricType: DataverseMetricType, countryCode?: string, yearMonth?: string) {`
 
-`public async replaceFile(fileId: string, filename: string, fileBuffer: Buffer): Promise<any> {`
+`  public async replaceFile(fileId: string, filename: string, fileBuffer: Buffer, jsonData: object = {}): Promise<any> {`
 
 `public async publishDataset(datasetId: string, versionUpgradeType: DatasetVersionUpgradeType = DatasetVersionUpgradeType.MAJOR): Promise<AxiosResponse> {`
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ http://demo.dataverse.org/api/datasets/389608/versions/1
 
 `public async getMetricByCountry(datasetId: string, metricType: DataverseMetricType, countryCode?: string, yearMonth?: string) {`
 
-`  public async replaceFile(fileId: string, filename: string, fileBuffer: Buffer, jsonData: object = {}): Promise<any> {`
+`public async replaceFile(fileId: string, filename: string, fileBuffer: Buffer, jsonData: object = {}): Promise<any> {`
 
 `public async publishDataset(datasetId: string, versionUpgradeType: DatasetVersionUpgradeType = DatasetVersionUpgradeType.MAJOR): Promise<AxiosResponse> {`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-dataverse",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "A Dataverse module for JavaScript/TypeScript",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/dataverseClient.ts
+++ b/src/dataverseClient.ts
@@ -144,7 +144,7 @@ export class DataverseClient {
     return this.getRequest(url)
   }
 
-  public async replaceFile(fileId: string, filename: string, fileBuffer: Buffer): Promise<any> {
+  public async replaceFile(fileId: string, filename: string, fileBuffer: Buffer, jsonData: object = {}): Promise<any> {
     const url = `${this.host}/api/files/${fileId}/replace`
 
     const options = {
@@ -155,14 +155,15 @@ export class DataverseClient {
           value: fileBuffer,
           options: {
             filename: filename
-          }
-        }
+          },
+        },
+        jsonData: JSON.stringify(jsonData)
       },
       resolveWithFullResponse: true
     }
 
     return request.post(options).catch(error => {
-      throw new DataverseException(error.response.statusCode, error.response.body ? JSON.parse(error.response.body).message : '')
+      throw new DataverseException(error.response.statusCode, error.response.body ? error.response.body.message : '')
     })
   }
 


### PR DESCRIPTION
## Description
Adds new optional argument, jsonData to allow updating metadata about the file as well as forcing replacecement of a file

## Changes
- Adds new argument to existing `replaceFile` function
- Update tests

## Tests
- Manual test
- Unit tests

## Checklist
[x] The project builds
[x] The project passes lint checks
[x] The project passes format checks
[x] The project passes unit tests
[x] I've manually tested the functionality

## Screenshots

## Additional information

