### PR TITLE
HASI-552 get original file by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-dataverse",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "description": "A Dataverse module for JavaScript/TypeScript",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/dataverseClient.ts
+++ b/src/dataverseClient.ts
@@ -58,8 +58,8 @@ export class DataverseClient {
     })
   }
 
-  public async getFile(fileId: string): Promise<AxiosResponse> {
-    const url = `${this.host}/api/access/datafile/${fileId}`
+  public async getFile(fileId: string, getOriginal = true): Promise<AxiosResponse> {
+    const url = `${this.host}/api/access/datafile/${fileId}${getOriginal ? '?format=original' : ''}`
     return this.getRequest(url, {
       headers: this.getHeaders(),
       responseType: 'arraybuffer'

--- a/test/dataverseClient.spec.ts
+++ b/test/dataverseClient.spec.ts
@@ -434,9 +434,23 @@ describe('DataverseClient', () => {
       await client.getFile(fileId)
 
       assert.calledOnce(axiosGetStub)
-      assert.calledWithExactly(axiosGetStub, `${host}/api/access/datafile/${fileId}`, {
+      assert.calledWithExactly(axiosGetStub, `${host}/api/access/datafile/${fileId}?format=original`, {
         headers: { 'X-Dataverse-key': apiToken },
         responseType: 'arraybuffer'
+      })
+    })
+
+    describe('get ingested file', () => {
+      it('should call axios with expected url', async () => {
+        const fileId: string = random.number().toString()
+
+        await client.getFile(fileId, false)
+
+        assert.calledOnce(axiosGetStub)
+        assert.calledWithExactly(axiosGetStub, `${host}/api/access/datafile/${fileId}`, {
+          headers: { 'X-Dataverse-key': apiToken },
+          responseType: 'arraybuffer'
+        })
       })
     })
 
@@ -447,7 +461,7 @@ describe('DataverseClient', () => {
       await client.getFile(fileId)
 
       assert.calledOnce(axiosGetStub)
-      assert.calledWithExactly(axiosGetStub, `${host}/api/access/datafile/${fileId}`, {
+      assert.calledWithExactly(axiosGetStub, `${host}/api/access/datafile/${fileId}?format=original`, {
         headers: { 'X-Dataverse-key': '' },
         responseType: 'arraybuffer'
       })
@@ -461,7 +475,7 @@ describe('DataverseClient', () => {
         'test': randomValue
       }
       axiosGetStub
-        .withArgs(`${host}/api/access/datafile/${fileId}`, {
+        .withArgs(`${host}/api/access/datafile/${fileId}?format=original`, {
           headers: { 'X-Dataverse-key': apiToken },
           responseType: 'arraybuffer'
         })


### PR DESCRIPTION
## Description
Gets original file by default and adds a flag to retrieve ingested file

## Changes
- Modify getFile function to retrieve original file by default

## Tests
- Unit tests

## Checklist
[x] The project builds
[x] The project passes lint checks
[x] The project passes format checks
[x] The project passes unit tests
[x] I've manually tested the functionality

## Screenshots

## Additional information

