### PR TITLE
added `deleteDataset($datasetId)` to destroy datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ http://demo.dataverse.org/api/datasets/389608/versions/1
 
 `public async publishDataset(datasetId: string, versionUpgradeType: DatasetVersionUpgradeType = DatasetVersionUpgradeType.MAJOR): Promise<AxiosResponse> {`
 
+`public async deleteDataset(datasetId: string): Promise<AxiosResponse> {`
+
 ## Build project
 
 In order to build the project, we need to run the following command:

--- a/src/dataverseClient.ts
+++ b/src/dataverseClient.ts
@@ -173,6 +173,11 @@ export class DataverseClient {
     return this.postRequest(url, '')
   }
 
+  public async deleteDataset(datasetId: string): Promise<AxiosResponse> {
+    const url = `${this.host}/api/datasets/:persistentId/destroy/?persistentId=${datasetId}`
+    return this.deleteRequest(url)
+  }
+
   private async getRequest(url: string, options: { params?: object, headers?: DataverseHeaders, responseType?: ResponseType } = { headers: this.getHeaders() }): Promise<AxiosResponse> {
     return await axios.get(url, options).catch(error => {
       throw new DataverseException(error.response.status, error.response.data ? error.response.data.message : '')
@@ -181,6 +186,12 @@ export class DataverseClient {
 
   private async postRequest(url: string, data: string | object, options: { params?: object, headers?: DataverseHeaders } = { headers: this.getHeaders() }): Promise<AxiosResponse> {
     return await axios.post(url, JSON.stringify(data), options).catch(error => {
+      throw new DataverseException(error.response.status, error.response.data ? error.response.data.message : '')
+    })
+  }
+
+  private async deleteRequest(url: string, options: { params?: object, headers?: DataverseHeaders, responseType?: ResponseType } = { headers: this.getHeaders() }): Promise<AxiosResponse> {
+    return await axios.delete(url, options).catch(error => {
       throw new DataverseException(error.response.status, error.response.data ? error.response.data.message : '')
     })
   }

--- a/test/dataverseClient.spec.ts
+++ b/test/dataverseClient.spec.ts
@@ -28,6 +28,7 @@ describe('DataverseClient', () => {
   let axiosGetStub: SinonStub
   let axiosPostStub: SinonStub
   let requestPostStub: SinonStub
+  let axiosDeleteStub: SinonStub
 
   let mapBasicDatasetInformationStub: SinonStub
   let getErrorMessageStub: SinonStub
@@ -63,6 +64,7 @@ describe('DataverseClient', () => {
     axiosGetStub = sandbox.stub(axios, 'get').resolves(mockResponse)
     axiosPostStub = sandbox.stub(axios, 'post').resolves(mockResponse)
     requestPostStub = sandbox.stub(request, 'post').resolves(mockResponse)
+    axiosDeleteStub = sandbox.stub(axios, 'delete').resolves(mockResponse)
 
     mapBasicDatasetInformationStub = sandbox.stub(DatasetUtil, 'mapBasicDatasetInformation').returns(mockDatasetInformation)
     getErrorMessageStub = sandbox.stub(ResponseUtil, 'getErrorMessage').returns(mockErrorMessage)
@@ -1480,5 +1482,18 @@ describe('DataverseClient', () => {
         expect(error.errorCode).to.be.equal(errorCode)
       })
     })
+
   })
+
+  describe('deleteDataset()', () => {
+    it('should call axios with expected url', async () => {
+      const datasetId: string = random.number().toString()
+
+      await client.deleteDataset(datasetId)
+
+      assert.calledOnce(axiosDeleteStub)
+      assert.calledWithExactly(axiosDeleteStub, `${host}/api/datasets/:persistentId/destroy/?persistentId=${datasetId}`, { headers: { 'X-Dataverse-key': apiToken } })
+    })
+  })
+
 })


### PR DESCRIPTION
## Description

This new method make a request to the following address:

* DELETE /api/datasets/:persistentId/destroy/?persistentId=$datasetId

This Dataverse API endpoint let superusers to remove published datasets and
ordinary users to remove draft/unpublished datasets as can see on the API spec
docs:

* https://guides.dataverse.org/en/latest/api/native-api.html#delete-published-dataset

## Changes
Added new method: `deleteDataset($datasetId)`.

## Tests

1. Create a new dataset, keep it unpublished/draft
1. Call the new method `deleteDataset($datasetId)` passing the persistendId of the dataset on $datasetId param
1. The dataset should be destroyed

## Checklist

- [ ] The project builds
- [ ] The project passes lint checks
- [ ] The project passes format checks
- [ ] The project passes unit tests
- [ ] I've manually tested the functionality

## Screenshots

![Captura de tela de 2020-11-02 15-38-19](https://user-images.githubusercontent.com/44172/97880501-89ebf280-1d21-11eb-9219-2e1efa3f576e.png)

![Captura de tela de 2020-11-02 15-38-33](https://user-images.githubusercontent.com/44172/97880499-89535c00-1d21-11eb-862f-85b33717afd6.png)
