### PR TITLE
added `getDatasetFiles($datasetId)` to download files

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ http://demo.dataverse.org/api/datasets/389608/versions/1
 
 `public async deleteDataset(datasetId: string): Promise<AxiosResponse> {`
 
+`public async getDatasetFiles(datasetId: string): Promise<AxiosResponse> {`
+
 ## Build project
 
 In order to build the project, we need to run the following command:

--- a/src/dataverseClient.ts
+++ b/src/dataverseClient.ts
@@ -190,6 +190,14 @@ export class DataverseClient {
     return this.deleteRequest(url)
   }
 
+  public async getDatasetFiles(datasetId: string): Promise<AxiosResponse> {
+    const url = `${this.host}/api/access/dataset/:persistentId/?persistentId=${datasetId}`
+    return this.getRequest(url, {
+      headers: this.getHeaders(),
+      responseType: 'arraybuffer'
+    })
+  }
+
   private async getRequest(url: string, options: { params?: object, headers?: DataverseHeaders, responseType?: ResponseType } = { headers: this.getHeaders() }): Promise<AxiosResponse> {
     return await axios.get(url, options).catch(error => {
       throw new DataverseException(error.response.status, error.response.data ? error.response.data.message : '')

--- a/test/dataverseClient.spec.ts
+++ b/test/dataverseClient.spec.ts
@@ -1526,4 +1526,18 @@ describe('DataverseClient', () => {
     })
   })
 
+  describe('getDatasetFiles()', () => {
+    it('should call axios with expected url', async () => {
+      const datasetId: string = random.number.toString()
+
+      await client.getDatasetFiles(datasetId)
+
+      assert.calledOnce(axiosGetStub)
+      assert.calledWithExactly(axiosGetStub, `${host}/api/access/dataset/:persistentId/?persistentId=${datasetId}`, {
+        headers: { 'X-Dataverse-key': apiToken },
+        responseType: 'arraybuffer'
+      })
+    })
+  })
+
 })


### PR DESCRIPTION
## Description

this new method download all files from the latest version of a dataset as a
zipped bundle, even if the latest version is in DRAFT state, the zip file
includes also a MANIFEST.txt containing some metadata about the downloaded
files

See Dataverse API doc for details:

* https://guides.dataverse.org/en/latest/api/dataaccess.html


## Changes
* Added a new method `getDatasetFiles()`

## Tests
* Create a new dataset
* Added some files to the new dataset
* Call the `getDatasetFiles($datasetId)` passing the persistendId as $datasetId argument
* The method should return a zipped bundle file named `dataverse_files.zip` containing in it all files from the latest version of the dataset $datasetId

## Checklist
- [ ] The project builds
- [ ] The project passes lint checks
- [ ] The project passes format checks
- [ ] The project passes unit tests
- [ ] I've manually tested the functionality
