### PR TITLE
GitHub package registry deployment action

### DIFF
--- a/.github/workflows/deploy_pr.yml
+++ b/.github/workflows/deploy_pr.yml
@@ -1,0 +1,51 @@
+name: deploy_pr
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 19
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm run test:unit
+
+  publish-gpr:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 19
+          registry-url: https://npm.pkg.github.com/
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build package
+        run: npm run build
+
+      - name: Update package version
+        run: npm version '${{ github.event.number }}.${{ github.run_number }}.0' --no-git-tag-version
+
+      - name: Publish package
+        run: |
+          echo "$(jq '.publishConfig.registry = "https://npm.pkg.github.com"' package.json)" > package.json
+          echo "$( jq '.name = "@gportas/dataverse-client-javascript"' package.json )" > package.json
+          npm publish --@gportas:registry=https://npm.pkg.github.com
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy_pr.yml
+++ b/.github/workflows/deploy_pr.yml
@@ -38,9 +38,12 @@ jobs:
 
       - name: Build package
         run: npm run build
-
+      
       - name: Update package version
-        run: npm version '${{ github.event.number }}.${{ github.run_number }}.0' --no-git-tag-version
+        run: |      
+          SHORT_SHA=$(git rev-parse --short "${{ github.event.pull_request.head.sha }}")
+          CURRENT_PACKAGE_VERSION=$(cat package.json | jq -r '.version')
+          npm version "${CURRENT_PACKAGE_VERSION}-pr${{ github.event.number }}.${SHORT_SHA}" --no-git-tag-version
 
       - name: Publish package
         run: |

--- a/.github/workflows/deploy_pr.yml
+++ b/.github/workflows/deploy_pr.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Publish package
         run: |
           echo "$(jq '.publishConfig.registry = "https://npm.pkg.github.com"' package.json)" > package.json
-          echo "$( jq '.name = "@gportas/dataverse-client-javascript"' package.json )" > package.json
-          npm publish --@gportas:registry=https://npm.pkg.github.com
+          echo "$( jq '.name = "@IQSS/dataverse-client-javascript"' package.json )" > package.json
+          npm publish --@IQSS:registry=https://npm.pkg.github.com
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   ],
   "scripts": {
     "build": "tsc",
-    "publish": "tsc && npm publish",
     "test": "jest -c jest.config.js",
     "test:unit": "jest -c jest.config.unit.js",
     "test:integration": "jest -c jest.config.integration.js",


### PR DESCRIPTION
## What this PR does / why we need it:

Introduces an automated GitHub action to be executed on PR commits.

The action builds and deploys the package to a new GitHub npm registry (https://github.com/IQSS/dataverse-client-javascript/pkgs/npm/dataverse-client-javascript), dedicated to development images from PRs only. This way the SPA can use these versions to test the changes developed in the package during the PRs.

## Which issue(s) this PR closes:

- Partially completes #https://github.com/IQSS/dataverse-frontend/issues/77

## Special notes for your reviewer:

Versioning format followed for the pushed packages:

**<NEXT_RELEASE_VERSION>-pr<PR_NUMBER>.<SHORTENED_COMMIT_HASH>**

Example:

**2.0.0-pr61.8ac5f25**

## Suggestions on how to test this:

N/A

## Is there a release notes update needed for this change?:

No

## Additional documentation:

N/A
