### PR TITLE
64 & 66 - Add optional dataset fields alternativePersistentId, publicationDate and citationDate

### DIFF
--- a/src/datasets/domain/models/Dataset.ts
+++ b/src/datasets/domain/models/Dataset.ts
@@ -4,6 +4,9 @@ export interface Dataset {
   versionId: number;
   versionInfo: DatasetVersionInfo;
   license?: DatasetLicense;
+  alternativePersistentId?: string;
+  publicationDate?: string;
+  citationDate?: string;
   metadataBlocks: DatasetMetadataBlocks;
 }
 

--- a/src/datasets/infra/repositories/transformers/datasetTransformers.ts
+++ b/src/datasets/infra/repositories/transformers/datasetTransformers.ts
@@ -35,6 +35,15 @@ const transformVersionPayloadToDataset = (versionPayload: any): Dataset => {
   if ('license' in versionPayload) {
     datasetModel.license = transformPayloadToDatasetLicense(versionPayload.license);
   }
+  if ('alternativePersistentId' in versionPayload) {
+    datasetModel.alternativePersistentId = versionPayload.alternativePersistentId;
+  }
+  if ('publicationDate' in versionPayload) {
+    datasetModel.publicationDate = versionPayload.publicationDate;
+  }
+  if ('citationDate' in versionPayload) {
+    datasetModel.citationDate = versionPayload.citationDate;
+  }
   return datasetModel;
 };
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any

--- a/test/testHelpers/datasets/datasetHelper.ts
+++ b/test/testHelpers/datasets/datasetHelper.ts
@@ -23,6 +23,7 @@ export const createDatasetModel = (license?: DatasetLicense): Dataset => {
       lastUpdateTime: new Date(DATASET_UPDATE_TIME_STR),
       releaseTime: new Date(DATASET_RELEASE_TIME_STR),
     },
+    publicationDate: '2023-05-15',
     metadataBlocks: [
       {
         name: 'citation',
@@ -43,10 +44,11 @@ export const createDatasetModel = (license?: DatasetLicense): Dataset => {
             {
               dsDescriptionValue: turndownService.turndown(DATASET_HTML_DESCRIPTION),
             },
-          ], datasetContact: [
+          ],
+          datasetContact: [
             {
-              datasetContactName:  'Admin, Dataverse',
-              datasetContactEmail: 'someemail@test.com'
+              datasetContactName: 'Admin, Dataverse',
+              datasetContactEmail: 'someemail@test.com',
             },
           ],
         },
@@ -70,6 +72,7 @@ export const createDatasetVersionPayload = (license?: DatasetLicense): any => {
     lastUpdateTime: DATASET_UPDATE_TIME_STR,
     releaseTime: DATASET_RELEASE_TIME_STR,
     createTime: DATASET_CREATE_TIME_STR,
+    publicationDate: '2023-05-15',
     license: {
       name: 'CC0 1.0',
       uri: 'https://creativecommons.org/publicdomain/zero/1.0/',
@@ -142,25 +145,25 @@ export const createDatasetVersionPayload = (license?: DatasetLicense): any => {
             ],
           },
           {
-            typeName: "datasetContact",
+            typeName: 'datasetContact',
             multiple: true,
-            typeClass: "compound",
+            typeClass: 'compound',
             value: [
               {
                 datasetContactName: {
-                  typeName: "datasetContactName",
+                  typeName: 'datasetContactName',
                   multiple: false,
-                  typeClass: "primitive",
+                  typeClass: 'primitive',
                   value: 'Admin, Dataverse',
                 },
                 datasetContactEmail: {
-                  typeName: "datasetContactEmail",
+                  typeName: 'datasetContactEmail',
                   multiple: false,
-                  typeClass: "primitive",
-                  value: 'someemail@test.com'
-                }
-              }
-            ]
+                  typeClass: 'primitive',
+                  value: 'someemail@test.com',
+                },
+              },
+            ],
           },
         ],
       },

--- a/test/testHelpers/datasets/datasetHelper.ts
+++ b/test/testHelpers/datasets/datasetHelper.ts
@@ -7,6 +7,8 @@ const DATASET_CREATE_TIME_STR = '2023-05-15T08:21:01Z';
 const DATASET_UPDATE_TIME_STR = '2023-05-15T08:21:03Z';
 const DATASET_RELEASE_TIME_STR = '2023-05-15T08:21:03Z';
 
+const DATASET_PUBLICATION_DATE_STR = '2023-05-15';
+
 const DATASET_HTML_DESCRIPTION =
   '<div><h1 class="test-class-to-ignore">Title 1</h1><p>Test paragraph 1</p><p>Test paragraph 2</p><p>Hello world</p><h2>Title 2</h2><h3>Title 3</h3></div>';
 
@@ -23,7 +25,7 @@ export const createDatasetModel = (license?: DatasetLicense): Dataset => {
       lastUpdateTime: new Date(DATASET_UPDATE_TIME_STR),
       releaseTime: new Date(DATASET_RELEASE_TIME_STR),
     },
-    publicationDate: '2023-05-15',
+    publicationDate: DATASET_PUBLICATION_DATE_STR,
     metadataBlocks: [
       {
         name: 'citation',
@@ -72,7 +74,7 @@ export const createDatasetVersionPayload = (license?: DatasetLicense): any => {
     lastUpdateTime: DATASET_UPDATE_TIME_STR,
     releaseTime: DATASET_RELEASE_TIME_STR,
     createTime: DATASET_CREATE_TIME_STR,
-    publicationDate: '2023-05-15',
+    publicationDate: DATASET_PUBLICATION_DATE_STR,
     license: {
       name: 'CC0 1.0',
       uri: 'https://creativecommons.org/publicdomain/zero/1.0/',


### PR DESCRIPTION
## What this PR does / why we need it:

This PR adds the optional fields alternativePersistentId, publicationDate and citationDate to the dataset model and their transformation in case they are returned from the API.

This branch is created from `65-modify-the-dataset-type-description-to-explicitly-declare-the-citation-metadata-fields` so PR https://github.com/IQSS/dataverse-client-javascript/pull/67 should be merged first.

## Which issue(s) this PR closes:

- Closes #64 
- Closes #66 

## Special notes for your reviewer:
Optional parameters need https://github.com/IQSS/dataverse/pull/9657 to work

## Suggestions on how to test this:
I've added one of the optional fields to the `datasetHelper.ts` test response payload and test model to test the model transformation when only one optional field is sent.

## Is there a release notes update needed for this change?:
No

## Additional documentation:
N/A