### PR TITLE
Optimize GetDataset use case by using includeFiles=false

### DIFF
--- a/src/datasets/infra/repositories/DatasetsRepository.ts
+++ b/src/datasets/infra/repositories/DatasetsRepository.ts
@@ -36,6 +36,7 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
       true,
       {
         includeDeaccessioned: includeDeaccessioned,
+        includeFiles: false
       },
     )
       .then((response) => transformVersionResponseToDataset(response))

--- a/test/unit/datasets/DatasetsRepository.test.ts
+++ b/test/unit/datasets/DatasetsRepository.test.ts
@@ -83,11 +83,11 @@ describe('DatasetsRepository', () => {
   describe('getDataset', () => {
     const testIncludeDeaccessioned = false;
     const expectedRequestConfigApiKey = {
-      params: { includeDeaccessioned: testIncludeDeaccessioned },
+      params: { includeDeaccessioned: testIncludeDeaccessioned, includeFiles: false },
       headers: TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY.headers,
     };
     const expectedRequestConfigSessionCookie = {
-      params: { includeDeaccessioned: testIncludeDeaccessioned },
+      params: { includeDeaccessioned: testIncludeDeaccessioned, includeFiles: false },
       withCredentials: TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE.withCredentials,
       headers: TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE.headers,
     };


### PR DESCRIPTION
## What this PR does / why we need it:

Adds includeFiles=false query parameter to the repository method used by the GetDataset use case, since files are ignored and we don't need their lookup in the backend.

## Which issue(s) this PR closes:

- Closes #100 

## Related Dataverse PRs:

None