### PR TITLE
102 get dataset citation deaccessioned

### DIFF
--- a/src/datasets/domain/repositories/IDatasetsRepository.ts
+++ b/src/datasets/domain/repositories/IDatasetsRepository.ts
@@ -6,7 +6,7 @@ export interface IDatasetsRepository {
   getDatasetSummaryFieldNames(): Promise<string[]>;
   getDataset(datasetId: number | string, datasetVersionId: string, includeDeaccessioned: boolean): Promise<Dataset>;
   getPrivateUrlDataset(token: string): Promise<Dataset>;
-  getDatasetCitation(datasetId: number, datasetVersionId: string): Promise<string>;
+  getDatasetCitation(datasetId: number, datasetVersionId: string, includeDeaccessioned: boolean): Promise<string>;
   getPrivateUrlDatasetCitation(token: string): Promise<string>;
   getDatasetUserPermissions(datasetId: number | string): Promise<DatasetUserPermissions>;
   getDatasetLocks(datasetId: number | string): Promise<DatasetLock[]>;

--- a/src/datasets/domain/useCases/GetDatasetCitation.ts
+++ b/src/datasets/domain/useCases/GetDatasetCitation.ts
@@ -12,7 +12,8 @@ export class GetDatasetCitation implements UseCase<string> {
   async execute(
     datasetId: number,
     datasetVersionId: string | DatasetNotNumberedVersion = DatasetNotNumberedVersion.LATEST,
+    includeDeaccessioned: boolean = false,
   ): Promise<string> {
-    return await this.datasetsRepository.getDatasetCitation(datasetId, datasetVersionId);
+    return await this.datasetsRepository.getDatasetCitation(datasetId, datasetVersionId, includeDeaccessioned)
   }
 }

--- a/src/datasets/infra/repositories/DatasetsRepository.ts
+++ b/src/datasets/infra/repositories/DatasetsRepository.ts
@@ -50,14 +50,12 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
 
 
 
-  public async getDatasetCitation(datasetId: number, datasetVersionId: string): Promise<string> {
-      const queryParams: GetCitationQueryParams = {
-          includeDeaccessioned: true,
+  public async getDatasetCitation(datasetId: number, datasetVersionId: string,
+                                  includeDeaccessioned: boolean): Promise<string> {
 
-      };
     return this.doGet(
       this.buildApiEndpoint(this.datasetsResourceName, `versions/${datasetVersionId}/citation`, datasetId),
-      true,queryParams
+      true, { includeDeaccessioned: includeDeaccessioned}
     )
       .then((response) => response.data.data.message)
       .catch((error) => {

--- a/src/datasets/infra/repositories/DatasetsRepository.ts
+++ b/src/datasets/infra/repositories/DatasetsRepository.ts
@@ -7,6 +7,9 @@ import { transformDatasetUserPermissionsResponseToDatasetUserPermissions } from 
 import { DatasetLock } from '../../domain/models/DatasetLock';
 import { transformDatasetLocksResponseToDatasetLocks } from './transformers/datasetLocksTransformers';
 
+export interface GetCitationQueryParams {
+    includeDeaccessioned: boolean;
+}
 export class DatasetsRepository extends ApiRepository implements IDatasetsRepository {
   private readonly datasetsResourceName: string = 'datasets';
 
@@ -45,10 +48,16 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
       });
   }
 
+
+
   public async getDatasetCitation(datasetId: number, datasetVersionId: string): Promise<string> {
+      const queryParams: GetCitationQueryParams = {
+          includeDeaccessioned: true,
+
+      };
     return this.doGet(
       this.buildApiEndpoint(this.datasetsResourceName, `versions/${datasetVersionId}/citation`, datasetId),
-      true,
+      true,queryParams
     )
       .then((response) => response.data.data.message)
       .catch((error) => {

--- a/src/datasets/infra/repositories/DatasetsRepository.ts
+++ b/src/datasets/infra/repositories/DatasetsRepository.ts
@@ -7,9 +7,7 @@ import { transformDatasetUserPermissionsResponseToDatasetUserPermissions } from 
 import { DatasetLock } from '../../domain/models/DatasetLock';
 import { transformDatasetLocksResponseToDatasetLocks } from './transformers/datasetLocksTransformers';
 
-export interface GetCitationQueryParams {
-    includeDeaccessioned: boolean;
-}
+
 export class DatasetsRepository extends ApiRepository implements IDatasetsRepository {
   private readonly datasetsResourceName: string = 'datasets';
 

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -6,8 +6,8 @@ import {
   createDatasetViaApi,
   createPrivateUrlViaApi,
   publishDatasetViaApi,
-  deaccessionDatasetViaApi
- // , waitForNoLocks
+  deaccessionDatasetViaApi,
+  waitForNoLocks
 } from '../../testHelpers/datasets/datasetHelper';
 import { ReadError } from '../../../src/core/domain/repositories/ReadError';
 import { DatasetNotNumberedVersion, DatasetLockType } from '../../../src/datasets';
@@ -110,8 +110,8 @@ describe('DatasetsRepository', () => {
           .catch(() => {
             assert.fail('Error while publishing test Dataset');
           });
-
-   //   await waitForNoLocks(createdDatasetId,2)
+      
+      await waitForNoLocks(createdDatasetId, 10)
       let locks = await sut.getDatasetLocks(createdDatasetId);
       const maxTries = 10;
       let tries = 0;

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -82,14 +82,14 @@ describe('DatasetsRepository', () => {
       const actualDatasetCitation = await sut.getDatasetCitation(
         TestConstants.TEST_CREATED_DATASET_ID,
         latestVersionId,
+        false,
       );
       expect(typeof actualDatasetCitation).toBe('string');
     });
 
     test('should return error when dataset does not exist', async () => {
       let error: ReadError = undefined;
-
-      await sut.getDatasetCitation(nonExistentTestDatasetId, latestVersionId).catch((e) => (error = e));
+      await sut.getDatasetCitation(nonExistentTestDatasetId, latestVersionId,false).catch((e) => (error = e));
 
       assert.match(
         error.message,
@@ -131,6 +131,7 @@ describe('DatasetsRepository', () => {
       const actualDatasetCitation = await sut.getDatasetCitation(
           createdDatasetId,
           latestVersionId,
+          true,
       );
       expect(typeof actualDatasetCitation).toBe('string');
 

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -6,7 +6,8 @@ import {
   createDatasetViaApi,
   createPrivateUrlViaApi,
   publishDatasetViaApi,
-    deaccessionDatasetViaApi
+  deaccessionDatasetViaApi
+ // , waitForNoLocks
 } from '../../testHelpers/datasets/datasetHelper';
 import { ReadError } from '../../../src/core/domain/repositories/ReadError';
 import { DatasetNotNumberedVersion, DatasetLockType } from '../../../src/datasets';
@@ -110,13 +111,14 @@ describe('DatasetsRepository', () => {
             assert.fail('Error while publishing test Dataset');
           });
 
+   //   await waitForNoLocks(createdDatasetId,2)
       let locks = await sut.getDatasetLocks(createdDatasetId);
       const maxTries = 10;
       let tries = 0;
       while (locks.length > 0 && tries < maxTries) {
-            await new Promise(resolve => setTimeout(resolve, 1000));
-            locks = await sut.getDatasetLocks(createdDatasetId);
-            tries++
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        locks = await sut.getDatasetLocks(createdDatasetId);
+        tries++
       }
       if (tries >= maxTries && locks.length > 0) {
         assert.fail('Error while waiting for locks to be released');

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -112,17 +112,10 @@ describe('DatasetsRepository', () => {
           });
       
       await waitForNoLocks(createdDatasetId, 10)
-      let locks = await sut.getDatasetLocks(createdDatasetId);
-      const maxTries = 10;
-      let tries = 0;
-      while (locks.length > 0 && tries < maxTries) {
-        await new Promise(resolve => setTimeout(resolve, 1000));
-        locks = await sut.getDatasetLocks(createdDatasetId);
-        tries++
-      }
-      if (tries >= maxTries && locks.length > 0) {
-        assert.fail('Error while waiting for locks to be released');
-      }
+            .then()
+            .catch(() => {
+                assert.fail('Error while waiting for no locks');
+            });
       await deaccessionDatasetViaApi(createdDatasetId,'1.0')
             .then()
             .catch((error) => {

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -6,6 +6,7 @@ import {
   createDatasetViaApi,
   createPrivateUrlViaApi,
   publishDatasetViaApi,
+    deaccessionDatasetViaApi
 } from '../../testHelpers/datasets/datasetHelper';
 import { ReadError } from '../../../src/core/domain/repositories/ReadError';
 import { DatasetNotNumberedVersion, DatasetLockType } from '../../../src/datasets';
@@ -94,6 +95,23 @@ describe('DatasetsRepository', () => {
         error.message,
         `There was an error when reading the resource. Reason was: [404] Dataset with ID ${nonExistentTestDatasetId} not found.`,
       );
+    });
+    test('should return citation when dataset is deaccessioned', async () => {
+      await publishDatasetViaApi(TestConstants.TEST_CREATED_DATASET_ID).then((response) =>
+      {  console.log(JSON.stringify(response.data.data))})
+      await deaccessionDatasetViaApi(TestConstants.TEST_CREATED_DATASET_ID,'1.0')
+            .then()
+            .catch((error) => {
+                console.log(JSON.stringify(error));
+                assert.fail('Error while deaccessioning test Dataset');
+            });
+
+      const actualDatasetCitation = await sut.getDatasetCitation(
+          TestConstants.TEST_CREATED_DATASET_ID,
+          latestVersionId,
+      );
+      expect(typeof actualDatasetCitation).toBe('string');
+
     });
   });
 

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -111,9 +111,15 @@ describe('DatasetsRepository', () => {
           });
 
       let locks = await sut.getDatasetLocks(createdDatasetId);
-      while (locks.length > 0) {
+      const maxTries = 10;
+      let tries = 0;
+      while (locks.length > 0 && tries < maxTries) {
             await new Promise(resolve => setTimeout(resolve, 1000));
             locks = await sut.getDatasetLocks(createdDatasetId);
+            tries++
+      }
+      if (tries >= maxTries && locks.length > 0) {
+        assert.fail('Error while waiting for locks to be released');
       }
       await deaccessionDatasetViaApi(createdDatasetId,'1.0')
             .then()

--- a/test/testHelpers/TestConstants.ts
+++ b/test/testHelpers/TestConstants.ts
@@ -15,9 +15,23 @@ export class TestConstants {
       'X-Dataverse-Key': TestConstants.TEST_DUMMY_API_KEY,
     },
   };
+  static readonly TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY_INCLUDE_DEACCESSIONED = {
+    params: { includeDeaccessioned: true },
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Dataverse-Key': TestConstants.TEST_DUMMY_API_KEY,
+    },
+  };
   static readonly TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE = {
     withCredentials: true,
     params: {},
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  };
+  static readonly TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE_INCLUDE_DEACCESSIONED = {
+    withCredentials: true,
+    params: { includeDeaccessioned: true },
     headers: {
       'Content-Type': 'application/json',
     },

--- a/test/testHelpers/datasets/datasetHelper.ts
+++ b/test/testHelpers/datasets/datasetHelper.ts
@@ -212,6 +212,13 @@ export const publishDatasetViaApi = async (datasetId: number): Promise<AxiosResp
   );
 };
 
+export const deaccessionDatasetViaApi = async (datasetId: number,versionId: string): Promise<AxiosResponse> => {
+    return await axios.post(
+        `${TestConstants.TEST_API_URL}/datasets/${datasetId}/versions/${versionId}/deaccession`,
+        {},
+        DATAVERSE_API_REQUEST_HEADERS,
+    );
+}
 export const createPrivateUrlViaApi = async (datasetId: number): Promise<AxiosResponse> => {
   return await axios.post(
     `${TestConstants.TEST_API_URL}/datasets/${datasetId}/privateUrl`,

--- a/test/testHelpers/datasets/datasetHelper.ts
+++ b/test/testHelpers/datasets/datasetHelper.ts
@@ -213,9 +213,10 @@ export const publishDatasetViaApi = async (datasetId: number): Promise<AxiosResp
 };
 
 export const deaccessionDatasetViaApi = async (datasetId: number,versionId: string): Promise<AxiosResponse> => {
+    const data = { deaccessionReason: 'Test reason.'};
     return await axios.post(
         `${TestConstants.TEST_API_URL}/datasets/${datasetId}/versions/${versionId}/deaccession`,
-        {},
+        JSON.stringify(data),
         DATAVERSE_API_REQUEST_HEADERS,
     );
 }

--- a/test/testHelpers/datasets/datasetHelper.ts
+++ b/test/testHelpers/datasets/datasetHelper.ts
@@ -227,3 +227,22 @@ export const createPrivateUrlViaApi = async (datasetId: number): Promise<AxiosRe
     DATAVERSE_API_REQUEST_HEADERS,
   );
 };
+export const getLocksViaApi = async (persistentId: string): Promise<any> => {
+   return axios.get(`${TestConstants.TEST_API_URL}/datasets/:persistentId/locks?persistentId=${persistentId}`).then((response) => {
+        return response.data.data;
+    })
+}
+
+export const waitForNoLocks = async (persistentId: string, maxRetries = 20, delay = 1000): Promise<void> => {
+   for (let retry = 0; retry < maxRetries; retry++) {
+        await getLocksViaApi(persistentId)
+            .then(
+            response => {
+          if (Object.keys(response).length === 1) {
+          return;
+        }})
+    await new Promise(resolve => setTimeout(resolve, delay));
+  }
+  throw new Error('Max retries reached.');
+};
+

--- a/test/unit/datasets/DatasetsRepository.test.ts
+++ b/test/unit/datasets/DatasetsRepository.test.ts
@@ -242,7 +242,7 @@ describe('DatasetsRepository', () => {
       assert.calledWithExactly(
         axiosGetStub,
         expectedApiEndpoint,
-        TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY,
+        TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY_INCLUDE_DEACCESSIONED,
       );
       assert.match(actual, testCitation);
 
@@ -254,7 +254,7 @@ describe('DatasetsRepository', () => {
       assert.calledWithExactly(
         axiosGetStub,
         expectedApiEndpoint,
-        TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE,
+        TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE_INCLUDE_DEACCESSIONED,
       );
       assert.match(actual, testCitation);
     });
@@ -268,7 +268,7 @@ describe('DatasetsRepository', () => {
       assert.calledWithExactly(
         axiosGetStub,
         `${TestConstants.TEST_API_URL}/datasets/${testDatasetModel.id}/versions/${testVersionId}/citation`,
-        TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY,
+        TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY_INCLUDE_DEACCESSIONED,
       );
       expect(error).to.be.instanceOf(Error);
     });

--- a/test/unit/datasets/DatasetsRepository.test.ts
+++ b/test/unit/datasets/DatasetsRepository.test.ts
@@ -232,12 +232,13 @@ describe('DatasetsRepository', () => {
   });
 
   describe('getDatasetCitation', () => {
+    const testIncludeDeaccessioned = true;
     test('should return citation when response is successful', async () => {
       const axiosGetStub = sandbox.stub(axios, 'get').resolves(testCitationSuccessfulResponse);
       const expectedApiEndpoint = `${TestConstants.TEST_API_URL}/datasets/${testDatasetModel.id}/versions/${testVersionId}/citation`;
 
       // API Key auth
-      let actual = await sut.getDatasetCitation(testDatasetModel.id, testVersionId);
+      let actual = await sut.getDatasetCitation(testDatasetModel.id, testVersionId, testIncludeDeaccessioned);
 
       assert.calledWithExactly(
         axiosGetStub,
@@ -249,7 +250,7 @@ describe('DatasetsRepository', () => {
       // Session cookie auth
       ApiConfig.init(TestConstants.TEST_API_URL, DataverseApiAuthMechanism.SESSION_COOKIE);
 
-      actual = await sut.getDatasetCitation(testDatasetModel.id, testVersionId);
+      actual = await sut.getDatasetCitation(testDatasetModel.id, testVersionId, testIncludeDeaccessioned);
 
       assert.calledWithExactly(
         axiosGetStub,
@@ -263,7 +264,7 @@ describe('DatasetsRepository', () => {
       const axiosGetStub = sandbox.stub(axios, 'get').rejects(TestConstants.TEST_ERROR_RESPONSE);
 
       let error: ReadError = undefined;
-      await sut.getDatasetCitation(1, testVersionId).catch((e) => (error = e));
+      await sut.getDatasetCitation(1, testVersionId,testIncludeDeaccessioned).catch((e) => (error = e));
 
       assert.calledWithExactly(
         axiosGetStub,

--- a/test/unit/datasets/GetDatasetCitation.test.ts
+++ b/test/unit/datasets/GetDatasetCitation.test.ts
@@ -23,7 +23,7 @@ describe('execute', () => {
     const actual = await sut.execute(testId);
 
     assert.match(actual, testCitation);
-    assert.calledWithExactly(getDatasetCitationStub, testId, DatasetNotNumberedVersion.LATEST);
+    assert.calledWithExactly(getDatasetCitationStub, testId, DatasetNotNumberedVersion.LATEST, false);
   });
 
   test('should return error result on repository error', async () => {


### PR DESCRIPTION
## What this PR does / why we need it:
This PR modifies the call to the get citation API, to return citation for a deaccessioned dataset.
## Which issue(s) this PR closes:

- Closes #102 

## Related Dataverse PRs:

- Depends on #

## Special notes for your reviewer:

## Suggestions on how to test this: 
Run the integration test, which gets the citation for a deaccessioned dataset.

## Is there a release notes update needed for this change?:
no

## Additional documentation:
