### PR TITLE
Add use case to get all datasets previews with pagination

### DIFF
--- a/src/datasets/domain/models/DatasetPreview.ts
+++ b/src/datasets/domain/models/DatasetPreview.ts
@@ -1,0 +1,4 @@
+export interface DatasetPreview {
+  id: number;
+  title: string;
+}

--- a/src/datasets/domain/models/DatasetPreview.ts
+++ b/src/datasets/domain/models/DatasetPreview.ts
@@ -1,4 +1,10 @@
+import { DatasetVersionInfo } from './Dataset';
+
 export interface DatasetPreview {
-  id: number;
+  persistentId: string;
   title: string;
+  versionId: number;
+  versionInfo: DatasetVersionInfo;
+  citation: string;
+  description: string;
 }

--- a/src/datasets/domain/models/DatasetPreviewSubset.ts
+++ b/src/datasets/domain/models/DatasetPreviewSubset.ts
@@ -1,0 +1,6 @@
+import { DatasetPreview } from './DatasetPreview';
+
+export interface DatasetPreviewSubset {
+  datasetPreviews: DatasetPreview[];
+  totalDatasetCount: number;
+}

--- a/src/datasets/domain/repositories/IDatasetsRepository.ts
+++ b/src/datasets/domain/repositories/IDatasetsRepository.ts
@@ -11,9 +11,5 @@ export interface IDatasetsRepository {
   getPrivateUrlDatasetCitation(token: string): Promise<string>;
   getDatasetUserPermissions(datasetId: number | string): Promise<DatasetUserPermissions>;
   getDatasetLocks(datasetId: number | string): Promise<DatasetLock[]>;
-  getCollectionDatasetPreviews(
-    collectionId: number | string,
-    limit?: number,
-    offset?: number,
-  ): Promise<DatasetPreview[]>;
+  getAllDatasetPreviews(limit?: number, offset?: number): Promise<DatasetPreview[]>;
 }

--- a/src/datasets/domain/repositories/IDatasetsRepository.ts
+++ b/src/datasets/domain/repositories/IDatasetsRepository.ts
@@ -1,7 +1,7 @@
 import { Dataset } from '../models/Dataset';
 import { DatasetUserPermissions } from '../models/DatasetUserPermissions';
 import { DatasetLock } from '../models/DatasetLock';
-import { DatasetPreview } from '../models/DatasetPreview';
+import { DatasetPreviewSubset } from '../models/DatasetPreviewSubset';
 
 export interface IDatasetsRepository {
   getDatasetSummaryFieldNames(): Promise<string[]>;
@@ -11,5 +11,5 @@ export interface IDatasetsRepository {
   getPrivateUrlDatasetCitation(token: string): Promise<string>;
   getDatasetUserPermissions(datasetId: number | string): Promise<DatasetUserPermissions>;
   getDatasetLocks(datasetId: number | string): Promise<DatasetLock[]>;
-  getAllDatasetPreviews(limit?: number, offset?: number): Promise<DatasetPreview[]>;
+  getAllDatasetPreviews(limit?: number, offset?: number): Promise<DatasetPreviewSubset>;
 }

--- a/src/datasets/domain/repositories/IDatasetsRepository.ts
+++ b/src/datasets/domain/repositories/IDatasetsRepository.ts
@@ -11,5 +11,9 @@ export interface IDatasetsRepository {
   getPrivateUrlDatasetCitation(token: string): Promise<string>;
   getDatasetUserPermissions(datasetId: number | string): Promise<DatasetUserPermissions>;
   getDatasetLocks(datasetId: number | string): Promise<DatasetLock[]>;
-  getCollectionDatasetPreviews(collectionId: number | string): Promise<DatasetPreview[]>;
+  getCollectionDatasetPreviews(
+    collectionId: number | string,
+    limit?: number,
+    offset?: number,
+  ): Promise<DatasetPreview[]>;
 }

--- a/src/datasets/domain/repositories/IDatasetsRepository.ts
+++ b/src/datasets/domain/repositories/IDatasetsRepository.ts
@@ -1,6 +1,7 @@
 import { Dataset } from '../models/Dataset';
 import { DatasetUserPermissions } from '../models/DatasetUserPermissions';
 import { DatasetLock } from '../models/DatasetLock';
+import { DatasetPreview } from '../models/DatasetPreview';
 
 export interface IDatasetsRepository {
   getDatasetSummaryFieldNames(): Promise<string[]>;
@@ -10,4 +11,5 @@ export interface IDatasetsRepository {
   getPrivateUrlDatasetCitation(token: string): Promise<string>;
   getDatasetUserPermissions(datasetId: number | string): Promise<DatasetUserPermissions>;
   getDatasetLocks(datasetId: number | string): Promise<DatasetLock[]>;
+  getCollectionDatasetPreviews(collectionId: number | string): Promise<DatasetPreview[]>;
 }

--- a/src/datasets/domain/useCases/GetAllDatasetPreviews.ts
+++ b/src/datasets/domain/useCases/GetAllDatasetPreviews.ts
@@ -1,15 +1,15 @@
 import { UseCase } from '../../../core/domain/useCases/UseCase';
-import { DatasetPreview } from '../models/DatasetPreview';
 import { IDatasetsRepository } from '../repositories/IDatasetsRepository';
+import { DatasetPreviewSubset } from '../models/DatasetPreviewSubset';
 
-export class GetAllDatasetPreviews implements UseCase<DatasetPreview[]> {
+export class GetAllDatasetPreviews implements UseCase<DatasetPreviewSubset> {
   private datasetsRepository: IDatasetsRepository;
 
   constructor(datasetsRepository: IDatasetsRepository) {
     this.datasetsRepository = datasetsRepository;
   }
 
-  async execute(limit?: number, offset?: number): Promise<DatasetPreview[]> {
+  async execute(limit?: number, offset?: number): Promise<DatasetPreviewSubset> {
     return await this.datasetsRepository.getAllDatasetPreviews(limit, offset);
   }
 }

--- a/src/datasets/domain/useCases/GetAllDatasetPreviews.ts
+++ b/src/datasets/domain/useCases/GetAllDatasetPreviews.ts
@@ -2,14 +2,14 @@ import { UseCase } from '../../../core/domain/useCases/UseCase';
 import { DatasetPreview } from '../models/DatasetPreview';
 import { IDatasetsRepository } from '../repositories/IDatasetsRepository';
 
-export class GetCollectionDatasetPreviews implements UseCase<DatasetPreview[]> {
+export class GetAllDatasetPreviews implements UseCase<DatasetPreview[]> {
   private datasetsRepository: IDatasetsRepository;
 
   constructor(datasetsRepository: IDatasetsRepository) {
     this.datasetsRepository = datasetsRepository;
   }
 
-  async execute(collectionId: number | string, limit?: number, offset?: number): Promise<DatasetPreview[]> {
-    return await this.datasetsRepository.getCollectionDatasetPreviews(collectionId, limit, offset);
+  async execute(limit?: number, offset?: number): Promise<DatasetPreview[]> {
+    return await this.datasetsRepository.getAllDatasetPreviews(limit, offset);
   }
 }

--- a/src/datasets/domain/useCases/GetCollectionDatasetPreviews.ts
+++ b/src/datasets/domain/useCases/GetCollectionDatasetPreviews.ts
@@ -1,0 +1,15 @@
+import { UseCase } from '../../../core/domain/useCases/UseCase';
+import { DatasetPreview } from '../models/DatasetPreview';
+import { IDatasetsRepository } from '../repositories/IDatasetsRepository';
+
+export class GetCollectionDatasetPreviews implements UseCase<DatasetPreview[]> {
+  private datasetsRepository: IDatasetsRepository;
+
+  constructor(datasetsRepository: IDatasetsRepository) {
+    this.datasetsRepository = datasetsRepository;
+  }
+
+  async execute(collectionId: number | string): Promise<DatasetPreview[]> {
+    return await this.datasetsRepository.getCollectionDatasetPreviews(collectionId);
+  }
+}

--- a/src/datasets/domain/useCases/GetCollectionDatasetPreviews.ts
+++ b/src/datasets/domain/useCases/GetCollectionDatasetPreviews.ts
@@ -9,7 +9,7 @@ export class GetCollectionDatasetPreviews implements UseCase<DatasetPreview[]> {
     this.datasetsRepository = datasetsRepository;
   }
 
-  async execute(collectionId: number | string): Promise<DatasetPreview[]> {
-    return await this.datasetsRepository.getCollectionDatasetPreviews(collectionId);
+  async execute(collectionId: number | string, limit?: number, offset?: number): Promise<DatasetPreview[]> {
+    return await this.datasetsRepository.getCollectionDatasetPreviews(collectionId, limit, offset);
   }
 }

--- a/src/datasets/index.ts
+++ b/src/datasets/index.ts
@@ -44,3 +44,4 @@ export {
   DatasetMetadataSubField,
 } from './domain/models/Dataset';
 export { DatasetPreview } from './domain/models/DatasetPreview';
+export { DatasetPreviewSubset } from './domain/models/DatasetPreviewSubset';

--- a/src/datasets/index.ts
+++ b/src/datasets/index.ts
@@ -6,7 +6,7 @@ import { GetDatasetCitation } from './domain/useCases/GetDatasetCitation';
 import { GetPrivateUrlDatasetCitation } from './domain/useCases/GetPrivateUrlDatasetCitation';
 import { GetDatasetUserPermissions } from './domain/useCases/GetDatasetUserPermissions';
 import { GetDatasetLocks } from './domain/useCases/GetDatasetLocks';
-import { GetCollectionDatasetPreviews } from './domain/useCases/GetCollectionDatasetPreviews';
+import { GetAllDatasetPreviews } from './domain/useCases/GetAllDatasetPreviews';
 
 const datasetsRepository = new DatasetsRepository();
 
@@ -17,7 +17,7 @@ const getDatasetCitation = new GetDatasetCitation(datasetsRepository);
 const getPrivateUrlDatasetCitation = new GetPrivateUrlDatasetCitation(datasetsRepository);
 const getDatasetUserPermissions = new GetDatasetUserPermissions(datasetsRepository);
 const getDatasetLocks = new GetDatasetLocks(datasetsRepository);
-const getCollectionDatasetPreviews = new GetCollectionDatasetPreviews(datasetsRepository);
+const getAllDatasetPreviews = new GetAllDatasetPreviews(datasetsRepository);
 
 export {
   getDatasetSummaryFieldNames,
@@ -27,7 +27,7 @@ export {
   getPrivateUrlDatasetCitation,
   getDatasetUserPermissions,
   getDatasetLocks,
-  getCollectionDatasetPreviews,
+  getAllDatasetPreviews,
 };
 export { DatasetNotNumberedVersion } from './domain/models/DatasetNotNumberedVersion';
 export { DatasetUserPermissions } from './domain/models/DatasetUserPermissions';

--- a/src/datasets/index.ts
+++ b/src/datasets/index.ts
@@ -6,6 +6,7 @@ import { GetDatasetCitation } from './domain/useCases/GetDatasetCitation';
 import { GetPrivateUrlDatasetCitation } from './domain/useCases/GetPrivateUrlDatasetCitation';
 import { GetDatasetUserPermissions } from './domain/useCases/GetDatasetUserPermissions';
 import { GetDatasetLocks } from './domain/useCases/GetDatasetLocks';
+import { GetCollectionDatasetPreviews } from './domain/useCases/GetCollectionDatasetPreviews';
 
 const datasetsRepository = new DatasetsRepository();
 
@@ -16,6 +17,7 @@ const getDatasetCitation = new GetDatasetCitation(datasetsRepository);
 const getPrivateUrlDatasetCitation = new GetPrivateUrlDatasetCitation(datasetsRepository);
 const getDatasetUserPermissions = new GetDatasetUserPermissions(datasetsRepository);
 const getDatasetLocks = new GetDatasetLocks(datasetsRepository);
+const getCollectionDatasetPreviews = new GetCollectionDatasetPreviews(datasetsRepository);
 
 export {
   getDatasetSummaryFieldNames,
@@ -25,6 +27,7 @@ export {
   getPrivateUrlDatasetCitation,
   getDatasetUserPermissions,
   getDatasetLocks,
+  getCollectionDatasetPreviews,
 };
 export { DatasetNotNumberedVersion } from './domain/models/DatasetNotNumberedVersion';
 export { DatasetUserPermissions } from './domain/models/DatasetUserPermissions';
@@ -40,3 +43,4 @@ export {
   DatasetMetadataFieldValue,
   DatasetMetadataSubField,
 } from './domain/models/Dataset';
+export { DatasetPreview } from './domain/models/DatasetPreview';

--- a/src/datasets/infra/repositories/DatasetsRepository.ts
+++ b/src/datasets/infra/repositories/DatasetsRepository.ts
@@ -95,7 +95,7 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
     if (offset !== undefined) {
       queryParams.offset = offset;
     }
-    return this.doGet('/search?q=*&type=datasets', true, queryParams)
+    return this.doGet('/search?q=*&type=dataset', true, queryParams)
       .then((response) => transformDatasetPreviewsResponseToPreviews(response))
       .catch((error) => {
         throw error;

--- a/src/datasets/infra/repositories/DatasetsRepository.ts
+++ b/src/datasets/infra/repositories/DatasetsRepository.ts
@@ -10,8 +10,8 @@ import { DatasetPreview } from '../../domain/models/DatasetPreview';
 import { transformDatasetPreviewsResponseToPreviews } from './transformers/datasetPreviewsTransformers';
 
 export interface GetAllDatasetPreviewsQueryParams {
-  limit?: number;
-  offset?: number;
+  per_page?: number;
+  start?: number;
 }
 
 export class DatasetsRepository extends ApiRepository implements IDatasetsRepository {
@@ -90,10 +90,10 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
   public async getAllDatasetPreviews(limit?: number, offset?: number): Promise<DatasetPreview[]> {
     const queryParams: GetAllDatasetPreviewsQueryParams = {};
     if (limit !== undefined) {
-      queryParams.limit = limit;
+      queryParams.per_page = limit;
     }
     if (offset !== undefined) {
-      queryParams.offset = offset;
+      queryParams.start = offset;
     }
     return this.doGet('/search?q=*&type=dataset', true, queryParams)
       .then((response) => transformDatasetPreviewsResponseToPreviews(response))

--- a/src/datasets/infra/repositories/DatasetsRepository.ts
+++ b/src/datasets/infra/repositories/DatasetsRepository.ts
@@ -6,8 +6,8 @@ import { DatasetUserPermissions } from '../../domain/models/DatasetUserPermissio
 import { transformDatasetUserPermissionsResponseToDatasetUserPermissions } from './transformers/datasetUserPermissionsTransformers';
 import { DatasetLock } from '../../domain/models/DatasetLock';
 import { transformDatasetLocksResponseToDatasetLocks } from './transformers/datasetLocksTransformers';
-import { DatasetPreview } from '../../domain/models/DatasetPreview';
-import { transformDatasetPreviewsResponseToPreviews } from './transformers/datasetPreviewsTransformers';
+import { transformDatasetPreviewsResponseToDatasetPreviewSubset } from './transformers/datasetPreviewsTransformers';
+import { DatasetPreviewSubset } from '../../domain/models/DatasetPreviewSubset';
 
 export interface GetAllDatasetPreviewsQueryParams {
   per_page?: number;
@@ -92,7 +92,7 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
       });
   }
 
-  public async getAllDatasetPreviews(limit?: number, offset?: number): Promise<DatasetPreview[]> {
+  public async getAllDatasetPreviews(limit?: number, offset?: number): Promise<DatasetPreviewSubset> {
     const queryParams: GetAllDatasetPreviewsQueryParams = {};
     if (limit !== undefined) {
       queryParams.per_page = limit;
@@ -100,8 +100,8 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
     if (offset !== undefined) {
       queryParams.start = offset;
     }
-    return this.doGet('/search?q=*&type=dataset', true, queryParams)
-      .then((response) => transformDatasetPreviewsResponseToPreviews(response))
+    return this.doGet('/search?q=*&type=dataset&sort=date&order=desc', true, queryParams)
+      .then((response) => transformDatasetPreviewsResponseToDatasetPreviewSubset(response))
       .catch((error) => {
         throw error;
       });

--- a/src/datasets/infra/repositories/DatasetsRepository.ts
+++ b/src/datasets/infra/repositories/DatasetsRepository.ts
@@ -7,6 +7,12 @@ import { transformDatasetUserPermissionsResponseToDatasetUserPermissions } from 
 import { DatasetLock } from '../../domain/models/DatasetLock';
 import { transformDatasetLocksResponseToDatasetLocks } from './transformers/datasetLocksTransformers';
 import { DatasetPreview } from '../../domain/models/DatasetPreview';
+import { transformDatasetPreviewsResponseToPreviews } from './transformers/datasetPreviewsTransformers';
+
+export interface GetAllDatasetPreviewsQueryParams {
+  limit?: number;
+  offset?: number;
+}
 
 export class DatasetsRepository extends ApiRepository implements IDatasetsRepository {
   private readonly datasetsResourceName: string = 'datasets';
@@ -82,7 +88,17 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
   }
 
   public async getAllDatasetPreviews(limit?: number, offset?: number): Promise<DatasetPreview[]> {
-    console.log(limit + offset);
-    return [];
+    const queryParams: GetAllDatasetPreviewsQueryParams = {};
+    if (limit !== undefined) {
+      queryParams.limit = limit;
+    }
+    if (offset !== undefined) {
+      queryParams.offset = offset;
+    }
+    return this.doGet('/search?q=*&type=datasets', true, queryParams)
+      .then((response) => transformDatasetPreviewsResponseToPreviews(response))
+      .catch((error) => {
+        throw error;
+      });
   }
 }

--- a/src/datasets/infra/repositories/DatasetsRepository.ts
+++ b/src/datasets/infra/repositories/DatasetsRepository.ts
@@ -81,8 +81,8 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
       });
   }
 
-  public async getCollectionDatasetPreviews(collectionId: string | number): Promise<DatasetPreview[]> {
-    console.log(collectionId);
-    return null;
+  public async getAllDatasetPreviews(limit?: number, offset?: number): Promise<DatasetPreview[]> {
+    console.log(limit + offset);
+    return [];
   }
 }

--- a/src/datasets/infra/repositories/DatasetsRepository.ts
+++ b/src/datasets/infra/repositories/DatasetsRepository.ts
@@ -6,6 +6,7 @@ import { DatasetUserPermissions } from '../../domain/models/DatasetUserPermissio
 import { transformDatasetUserPermissionsResponseToDatasetUserPermissions } from './transformers/datasetUserPermissionsTransformers';
 import { DatasetLock } from '../../domain/models/DatasetLock';
 import { transformDatasetLocksResponseToDatasetLocks } from './transformers/datasetLocksTransformers';
+import { DatasetPreview } from '../../domain/models/DatasetPreview';
 
 export class DatasetsRepository extends ApiRepository implements IDatasetsRepository {
   private readonly datasetsResourceName: string = 'datasets';
@@ -36,7 +37,7 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
       true,
       {
         includeDeaccessioned: includeDeaccessioned,
-        includeFiles: false
+        includeFiles: false,
       },
     )
       .then((response) => transformVersionResponseToDataset(response))
@@ -78,5 +79,10 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
       .catch((error) => {
         throw error;
       });
+  }
+
+  public async getCollectionDatasetPreviews(collectionId: string | number): Promise<DatasetPreview[]> {
+    console.log(collectionId);
+    return null;
   }
 }

--- a/src/datasets/infra/repositories/transformers/datasetLocksTransformers.ts
+++ b/src/datasets/infra/repositories/transformers/datasetLocksTransformers.ts
@@ -1,18 +1,24 @@
 import { AxiosResponse } from 'axios';
 import { DatasetLock, DatasetLockType } from '../../../domain/models/DatasetLock';
 
+export interface DatasetLockPayload {
+  lockType: string;
+  date?: string;
+  user: string;
+  dataset: string;
+  message?: string;
+}
+
 export const transformDatasetLocksResponseToDatasetLocks = (response: AxiosResponse): DatasetLock[] => {
   const datasetLocks: DatasetLock[] = [];
   const datasetLocksPayload = response.data.data;
-  // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-  datasetLocksPayload.forEach(function (datasetLockPayload: any) {
+  datasetLocksPayload.forEach(function (datasetLockPayload: DatasetLockPayload) {
     datasetLocks.push(transformDatasetLockPayloadToDatasetLock(datasetLockPayload));
   });
   return datasetLocks;
 };
 
-// eslint-disable-next-line  @typescript-eslint/no-explicit-any
-const transformDatasetLockPayloadToDatasetLock = (datasetLockPayload: any): DatasetLock => {
+const transformDatasetLockPayloadToDatasetLock = (datasetLockPayload: DatasetLockPayload): DatasetLock => {
   return {
     lockType: datasetLockPayload.lockType as DatasetLockType,
     ...(datasetLockPayload.date && { date: datasetLockPayload.date }),

--- a/src/datasets/infra/repositories/transformers/datasetPreviewsTransformers.ts
+++ b/src/datasets/infra/repositories/transformers/datasetPreviewsTransformers.ts
@@ -1,6 +1,7 @@
 import { AxiosResponse } from 'axios';
 import { DatasetPreview } from '../../../domain/models/DatasetPreview';
 import { DatasetVersionState } from '../../../domain/models/Dataset';
+import { DatasetPreviewSubset } from '../../../domain/models/DatasetPreviewSubset';
 
 export interface DatasetPreviewPayload {
   global_id: string;
@@ -16,13 +17,19 @@ export interface DatasetPreviewPayload {
   description: string;
 }
 
-export const transformDatasetPreviewsResponseToPreviews = (response: AxiosResponse): DatasetPreview[] => {
+export const transformDatasetPreviewsResponseToDatasetPreviewSubset = (
+  response: AxiosResponse,
+): DatasetPreviewSubset => {
+  const responseDataPayload = response.data.data;
+  const datasetPreviewsPayload = responseDataPayload.items;
   const datasetPreviews: DatasetPreview[] = [];
-  const datasetPreviewsPayload = response.data.data.items;
   datasetPreviewsPayload.forEach(function (datasetPreviewPayload: DatasetPreviewPayload) {
     datasetPreviews.push(transformDatasetPreviewPayloadToDatasetPreview(datasetPreviewPayload));
   });
-  return datasetPreviews;
+  return {
+    datasetPreviews: datasetPreviews,
+    totalDatasetCount: responseDataPayload.total_count,
+  };
 };
 
 const transformDatasetPreviewPayloadToDatasetPreview = (

--- a/src/datasets/infra/repositories/transformers/datasetPreviewsTransformers.ts
+++ b/src/datasets/infra/repositories/transformers/datasetPreviewsTransformers.ts
@@ -1,0 +1,32 @@
+import { AxiosResponse } from 'axios';
+import { DatasetPreview } from '../../../domain/models/DatasetPreview';
+import { DatasetVersionState } from '../../../domain/models/Dataset';
+
+export const transformDatasetPreviewsResponseToPreviews = (response: AxiosResponse): DatasetPreview[] => {
+  const datasetPreviews: DatasetPreview[] = [];
+  const datasetPreviewsPayload = response.data.items;
+  // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+  datasetPreviewsPayload.forEach(function (datasetPreviewPayload: any) {
+    datasetPreviews.push(transformDatasetPreviewPayloadToDatasetPreview(datasetPreviewPayload));
+  });
+  return datasetPreviews;
+};
+
+// eslint-disable-next-line  @typescript-eslint/no-explicit-any
+const transformDatasetPreviewPayloadToDatasetPreview = (datasetPreviewPayload: any): DatasetPreview => {
+  return {
+    persistentId: datasetPreviewPayload.global_id,
+    title: datasetPreviewPayload.name,
+    versionId: datasetPreviewPayload.versionId,
+    versionInfo: {
+      majorNumber: datasetPreviewPayload.majorVersion,
+      minorNumber: datasetPreviewPayload.minorVersion,
+      state: datasetPreviewPayload.versionState as DatasetVersionState,
+      createTime: new Date(datasetPreviewPayload.createdAt),
+      lastUpdateTime: new Date(datasetPreviewPayload.updatedAt),
+      ...(datasetPreviewPayload.published_at && { releaseTime: new Date(datasetPreviewPayload.published_at) }),
+    },
+    citation: datasetPreviewPayload.citation,
+    description: datasetPreviewPayload.description,
+  };
+};

--- a/src/datasets/infra/repositories/transformers/datasetPreviewsTransformers.ts
+++ b/src/datasets/infra/repositories/transformers/datasetPreviewsTransformers.ts
@@ -4,7 +4,7 @@ import { DatasetVersionState } from '../../../domain/models/Dataset';
 
 export const transformDatasetPreviewsResponseToPreviews = (response: AxiosResponse): DatasetPreview[] => {
   const datasetPreviews: DatasetPreview[] = [];
-  const datasetPreviewsPayload = response.data.items;
+  const datasetPreviewsPayload = response.data.data.items;
   // eslint-disable-next-line  @typescript-eslint/no-explicit-any
   datasetPreviewsPayload.forEach(function (datasetPreviewPayload: any) {
     datasetPreviews.push(transformDatasetPreviewPayloadToDatasetPreview(datasetPreviewPayload));

--- a/src/datasets/infra/repositories/transformers/datasetPreviewsTransformers.ts
+++ b/src/datasets/infra/repositories/transformers/datasetPreviewsTransformers.ts
@@ -2,18 +2,32 @@ import { AxiosResponse } from 'axios';
 import { DatasetPreview } from '../../../domain/models/DatasetPreview';
 import { DatasetVersionState } from '../../../domain/models/Dataset';
 
+export interface DatasetPreviewPayload {
+  global_id: string;
+  name: string;
+  versionId: number;
+  majorVersion: number;
+  minorVersion: number;
+  versionState: string;
+  createdAt: string;
+  updatedAt: string;
+  published_at?: string;
+  citation: string;
+  description: string;
+}
+
 export const transformDatasetPreviewsResponseToPreviews = (response: AxiosResponse): DatasetPreview[] => {
   const datasetPreviews: DatasetPreview[] = [];
   const datasetPreviewsPayload = response.data.data.items;
-  // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-  datasetPreviewsPayload.forEach(function (datasetPreviewPayload: any) {
+  datasetPreviewsPayload.forEach(function (datasetPreviewPayload: DatasetPreviewPayload) {
     datasetPreviews.push(transformDatasetPreviewPayloadToDatasetPreview(datasetPreviewPayload));
   });
   return datasetPreviews;
 };
 
-// eslint-disable-next-line  @typescript-eslint/no-explicit-any
-const transformDatasetPreviewPayloadToDatasetPreview = (datasetPreviewPayload: any): DatasetPreview => {
+const transformDatasetPreviewPayloadToDatasetPreview = (
+  datasetPreviewPayload: DatasetPreviewPayload,
+): DatasetPreview => {
   return {
     persistentId: datasetPreviewPayload.global_id,
     title: datasetPreviewPayload.name,

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -8,8 +8,7 @@ import {
   waitForNoLocks,
 } from '../../testHelpers/datasets/datasetHelper';
 import { ReadError } from '../../../src/core/domain/repositories/ReadError';
-import { DatasetNotNumberedVersion, DatasetLockType } from '../../../src/datasets';
-import { DatasetPreview } from '../../../src/datasets/domain/models/DatasetPreview';
+import { DatasetNotNumberedVersion, DatasetLockType, DatasetPreviewSubset } from '../../../src/datasets';
 import { fail } from 'assert';
 import { ApiConfig } from '../../../src';
 import { DataverseApiAuthMechanism } from '../../../src/core/infra/repositories/ApiConfig';
@@ -218,26 +217,30 @@ describe('DatasetsRepository', () => {
     const expectedDatasetTitle = "Darwin's Finches";
 
     test('should return all datasets when no pagination params are defined', async () => {
-      const actual: DatasetPreview[] = await sut.getAllDatasetPreviews();
-      assert.match(actual.length, 2);
-      assert.match(actual[0].title, expectedDatasetTitle);
+      const actual: DatasetPreviewSubset = await sut.getAllDatasetPreviews();
+      assert.match(actual.datasetPreviews.length, 2);
+      assert.match(actual.datasetPreviews[0].title, expectedDatasetTitle);
+      assert.match(actual.totalDatasetCount, 2);
     });
 
     test('should return dataset pages correctly when pagination params are defined', async () => {
       // First page
       let actual = await sut.getAllDatasetPreviews(1, 0);
-      assert.match(actual.length, 1);
-      assert.match(actual[0].title, expectedDatasetTitle);
-      const firstDatasetPid = actual[0].persistentId;
+      assert.match(actual.datasetPreviews.length, 1);
+      assert.match(actual.datasetPreviews[0].title, expectedDatasetTitle);
+      assert.match(actual.totalDatasetCount, 2);
+      const firstDatasetPid = actual.datasetPreviews[0].persistentId;
       // Second page
       actual = await sut.getAllDatasetPreviews(1, 1);
-      assert.match(actual.length, 1);
-      assert.match(actual[0].title, expectedDatasetTitle);
-      const secondDatasetPid = actual[0].persistentId;
+      assert.match(actual.datasetPreviews.length, 1);
+      assert.match(actual.datasetPreviews[0].title, expectedDatasetTitle);
+      assert.match(actual.totalDatasetCount, 2);
+      const secondDatasetPid = actual.datasetPreviews[0].persistentId;
       expect(secondDatasetPid == firstDatasetPid).toBe(false);
       // Third page
       actual = await sut.getAllDatasetPreviews(1, 2);
-      assert.match(actual.length, 0);
+      assert.match(actual.datasetPreviews.length, 0);
+      assert.match(actual.totalDatasetCount, 2);
     });
   });
 });

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -167,13 +167,6 @@ describe('DatasetsRepository', () => {
       });
     });
 
-    describe('getAllDatasetPreviews', () => {
-      test('should return dataset previews', async () => {
-        let actual: DatasetPreview[] = await sut.getAllDatasetPreviews();
-        assert.match(actual.length, 1);
-      });
-    });
-
     describe('getDatasetLocks', () => {
       test('should return list of dataset locks by dataset id for a dataset while publishing', async () => {
         let createdDatasetId = undefined;
@@ -205,6 +198,14 @@ describe('DatasetsRepository', () => {
           error.message,
           `There was an error when reading the resource. Reason was: [404] Dataset with ID ${nonExistentTestDatasetId} not found.`,
         );
+      });
+    });
+
+    describe('getAllDatasetPreviews', () => {
+      test('should return dataset previews', async () => {
+        let actual: DatasetPreview[] = await sut.getAllDatasetPreviews();
+        assert.pass(actual.length > 0);
+        assert.match(actual[0].title, "Darwin's Finches");
       });
     });
   });

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -19,6 +19,14 @@ describe('DatasetsRepository', () => {
     ApiConfig.init(TestConstants.TEST_API_URL, DataverseApiAuthMechanism.API_KEY, process.env.TEST_API_KEY);
   });
 
+  describe('getDatasetSummaryFieldNames', () => {
+    test('should return not empty field list on successful response', async () => {
+      const actual = await sut.getDatasetSummaryFieldNames();
+
+      assert.pass(actual.length > 0);
+    });
+  });
+
   describe('getDataset', () => {
     describe('by numeric id', () => {
       test('should return dataset when it exists filtering by id and version id', async () => {

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -9,6 +9,7 @@ import {
 } from '../../testHelpers/datasets/datasetHelper';
 import { ReadError } from '../../../src/core/domain/repositories/ReadError';
 import { DatasetNotNumberedVersion, DatasetLockType } from '../../../src/datasets';
+import { DatasetPreview } from '../../../src/datasets/domain/models/DatasetPreview';
 
 describe('DatasetsRepository', () => {
   const sut: DatasetsRepository = new DatasetsRepository();
@@ -163,6 +164,13 @@ describe('DatasetsRepository', () => {
           error.message,
           `There was an error when reading the resource. Reason was: [404] Dataset with ID ${nonExistentTestDatasetId} not found.`,
         );
+      });
+    });
+
+    describe('getAllDatasetPreviews', () => {
+      test('should return dataset previews', async () => {
+        let actual: DatasetPreview[] = await sut.getAllDatasetPreviews();
+        assert.match(actual.length, 1);
       });
     });
 

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -23,6 +23,37 @@ describe('DatasetsRepository', () => {
     ApiConfig.init(TestConstants.TEST_API_URL, DataverseApiAuthMechanism.API_KEY, process.env.TEST_API_KEY);
   });
 
+  describe('getAllDatasetPreviews', () => {
+    const testPageLimit = 1;
+
+    test('should return all dataset previews when no pagination params are defined', async () => {
+      const actual: DatasetPreviewSubset = await sut.getAllDatasetPreviews();
+      assert.match(actual.datasetPreviews.length, 2);
+      assert.match(actual.datasetPreviews[0].title, 'Second Dataset');
+      assert.match(actual.totalDatasetCount, 2);
+    });
+
+    test('should return first dataset preview page', async () => {
+      const actual = await sut.getAllDatasetPreviews(testPageLimit, 0);
+      assert.match(actual.datasetPreviews.length, 1);
+      assert.match(actual.datasetPreviews[0].title, 'Second Dataset');
+      assert.match(actual.totalDatasetCount, 2);
+    });
+
+    test('should return second dataset preview page', async () => {
+      const actual = await sut.getAllDatasetPreviews(testPageLimit, 1);
+      assert.match(actual.datasetPreviews.length, 1);
+      assert.match(actual.datasetPreviews[0].title, 'First Dataset');
+      assert.match(actual.totalDatasetCount, 2);
+    });
+
+    test('should return third dataset preview page', async () => {
+      const actual = await sut.getAllDatasetPreviews(testPageLimit, 2);
+      assert.match(actual.datasetPreviews.length, 0);
+      assert.match(actual.totalDatasetCount, 2);
+    });
+  });
+
   describe('getDatasetSummaryFieldNames', () => {
     test('should return not empty field list on successful response', async () => {
       const actual = await sut.getDatasetSummaryFieldNames();
@@ -210,37 +241,6 @@ describe('DatasetsRepository', () => {
         true,
       );
       expect(typeof actualDatasetCitation).toBe('string');
-    });
-  });
-
-  describe('getAllDatasetPreviews', () => {
-    const expectedDatasetTitle = "Darwin's Finches";
-
-    test('should return all datasets when no pagination params are defined', async () => {
-      const actual: DatasetPreviewSubset = await sut.getAllDatasetPreviews();
-      assert.match(actual.datasetPreviews.length, 2);
-      assert.match(actual.datasetPreviews[0].title, expectedDatasetTitle);
-      assert.match(actual.totalDatasetCount, 2);
-    });
-
-    test('should return dataset pages correctly when pagination params are defined', async () => {
-      // First page
-      let actual = await sut.getAllDatasetPreviews(1, 0);
-      assert.match(actual.datasetPreviews.length, 1);
-      assert.match(actual.datasetPreviews[0].title, expectedDatasetTitle);
-      assert.match(actual.totalDatasetCount, 2);
-      const firstDatasetPid = actual.datasetPreviews[0].persistentId;
-      // Second page
-      actual = await sut.getAllDatasetPreviews(1, 1);
-      assert.match(actual.datasetPreviews.length, 1);
-      assert.match(actual.datasetPreviews[0].title, expectedDatasetTitle);
-      assert.match(actual.totalDatasetCount, 2);
-      const secondDatasetPid = actual.datasetPreviews[0].persistentId;
-      expect(secondDatasetPid == firstDatasetPid).toBe(false);
-      // Third page
-      actual = await sut.getAllDatasetPreviews(1, 2);
-      assert.match(actual.datasetPreviews.length, 0);
-      assert.match(actual.totalDatasetCount, 2);
     });
   });
 });

--- a/test/integration/environment/.gitignore
+++ b/test/integration/environment/.gitignore
@@ -1,0 +1,1 @@
+docker-dev-volumes

--- a/test/integration/environment/docker-compose.yml
+++ b/test/integration/environment/docker-compose.yml
@@ -58,6 +58,9 @@ services:
       - sh
       - -c
       - 'fix-fs-perms.sh solr && cp -a /template/* /solr-template'
+    volumes:
+      - ./docker-dev-volumes/solr/data:/var/solr
+      - ./docker-dev-volumes/solr/conf:/solr-template
 
   test_solr:
     container_name: 'test_solr'
@@ -74,6 +77,9 @@ services:
       - 'solr-precreate'
       - 'collection1'
       - '/template'
+    volumes:
+      - ./docker-dev-volumes/solr/data:/var/solr
+      - ./docker-dev-volumes/solr/conf:/template
 
   test_smtp:
     container_name: 'test_smtp'

--- a/test/integration/environment/docker-compose.yml
+++ b/test/integration/environment/docker-compose.yml
@@ -67,7 +67,8 @@ services:
     hostname: 'solr'
     image: solr:${SOLR_VERSION}
     depends_on:
-      - test_solr_initializer
+      test_solr_initializer:
+        condition: service_completed_successfully
     restart: on-failure
     expose:
       - '8983'

--- a/test/integration/environment/setup.js
+++ b/test/integration/environment/setup.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const { DockerComposeEnvironment, Wait } = require('testcontainers');
 const axios = require('axios');
 const { TestConstants } = require('../../testHelpers/TestConstants');
@@ -15,6 +16,8 @@ const API_KEY_USER_ENDPOINT = '/builtin-users/dataverseAdmin/api-token';
 const API_KEY_USER_PASSWORD = 'admin1';
 
 module.exports = async () => {
+  console.log('Cleaning up old container volumes...');
+  fs.rmSync(`${__dirname}/docker-dev-volumes`, { recursive: true, force: true });
   console.log('Running test containers...');
   await new DockerComposeEnvironment(COMPOSE_FILE_PATH, COMPOSE_FILE)
     .withStartupTimeout(CONTAINERS_STARTUP_TIMEOUT)

--- a/test/integration/environment/setup.js
+++ b/test/integration/environment/setup.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const { DockerComposeEnvironment, Wait } = require('testcontainers');
 const axios = require('axios');
 const { TestConstants } = require('../../testHelpers/TestConstants');
+const datasetJson = require('../../testHelpers/datasets/test-dataset.json');
 
 const COMPOSE_FILE_PATH = './test/integration/environment';
 const COMPOSE_FILE = 'docker-compose.yml';
@@ -16,6 +17,12 @@ const API_KEY_USER_ENDPOINT = '/builtin-users/dataverseAdmin/api-token';
 const API_KEY_USER_PASSWORD = 'admin1';
 
 module.exports = async () => {
+  await setupContainers();
+  await setupApiKey();
+  await setupTestFixtures();
+};
+
+async function setupContainers() {
   console.log('Cleaning up old container volumes...');
   fs.rmSync(`${__dirname}/docker-dev-volumes`, { recursive: true, force: true });
   console.log('Running test containers...');
@@ -24,10 +31,73 @@ module.exports = async () => {
     .withWaitStrategy(CONTAINER_DATAVERSE_BOOTSTRAP_NAME, Wait.forLogMessage(CONTAINER_DATAVERSE_BOOTSTRAP_END_MESSAGE))
     .up();
   console.log('Test containers up and running');
+}
+
+async function setupApiKey() {
   console.log('Obtaining test API key...');
   await axios.put(`${TestConstants.TEST_API_URL}${ALLOW_API_TOKEN_LOOKUP_ENDPOINT}`, 'true');
   await axios
     .get(`${TestConstants.TEST_API_URL}${API_KEY_USER_ENDPOINT}?password=${API_KEY_USER_PASSWORD}`)
-    .then((response) => (process.env.TEST_API_KEY = response.data.data.message));
-  console.log('Test API key obtained');
-};
+    .then((response) => {
+      process.env.TEST_API_KEY = response.data.data.message;
+    })
+    .catch(() => {
+      console.error('Tests setup: Error while obtaining API key');
+    });
+  console.log('API key obtained');
+}
+
+async function setupTestFixtures() {
+  console.log('Creating test datasets...');
+  await createDatasetViaApi()
+    .then()
+    .catch((error) => {
+      console.error('Tests setup: Error while creating test Dataset 1');
+    });
+  await createDatasetViaApi()
+    .then()
+    .catch((error) => {
+      console.error('Tests setup: Error while creating test Dataset 2');
+    });
+  console.log('Test datasets created');
+  await waitForDatasetsIndexingInSolr();
+}
+
+async function createDatasetViaApi() {
+  return await axios.post(`${TestConstants.TEST_API_URL}/dataverses/root/datasets`, datasetJson, buildRequestHeaders());
+}
+
+async function waitForDatasetsIndexingInSolr() {
+  console.log('Waiting for datasets indexing in Solr...');
+  let datasetsIndexed = false;
+  let retry = 0;
+  while (!datasetsIndexed && retry < 10) {
+    await axios
+      .get(`${TestConstants.TEST_API_URL}/search?q=*&type=dataset`, buildRequestHeaders())
+      .then((response) => {
+        const nDatasets = response.data.data.items.length;
+        if (nDatasets == 2) {
+          datasetsIndexed = true;
+        }
+      })
+      .catch((error) => {
+        console.error(
+          `Tests setup: Error while waiting for datasets indexing in Solr: [${error.response.status}]${
+            error.response.data ? ` ${error.response.data.message}` : ''
+          }`,
+        );
+      });
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    retry++;
+  }
+  if (!datasetsIndexed) {
+    throw new Error('Tests setup: Timeout reached while waiting for datasets indexing in Solr');
+  }
+  console.log('Datasets indexed in Solr');
+}
+
+function buildRequestHeaders() {
+  return {
+    headers: { 'Content-Type': 'application/json', 'X-Dataverse-Key': process.env.TEST_API_KEY },
+  };
+}

--- a/test/integration/files/FilesRepository.test.ts
+++ b/test/integration/files/FilesRepository.test.ts
@@ -3,7 +3,6 @@ import { ApiConfig, DataverseApiAuthMechanism } from '../../../src/core/infra/re
 import { assert } from 'sinon';
 import { expect } from 'chai';
 import { TestConstants } from '../../testHelpers/TestConstants';
-import { createDatasetViaApi } from '../../testHelpers/datasets/datasetHelper';
 import { uploadFileViaApi } from '../../testHelpers/files/filesHelper';
 import { DatasetsRepository } from '../../../src/datasets/infra/repositories/DatasetsRepository';
 import { ReadError } from '../../../src/core/domain/repositories/ReadError';
@@ -11,6 +10,7 @@ import { FileSearchCriteria, FileAccessStatus, FileOrderCriteria } from '../../.
 import { DatasetNotNumberedVersion } from '../../../src/datasets';
 import { FileCounts } from '../../../src/files/domain/models/FileCounts';
 import { FileDownloadSizeMode } from '../../../src';
+import { fail } from 'assert';
 
 describe('FilesRepository', () => {
   const sut: FilesRepository = new FilesRepository();
@@ -29,34 +29,29 @@ describe('FilesRepository', () => {
 
   beforeAll(async () => {
     ApiConfig.init(TestConstants.TEST_API_URL, DataverseApiAuthMechanism.API_KEY, process.env.TEST_API_KEY);
-    await createDatasetViaApi()
-      .then()
-      .catch(() => {
-        fail('Test beforeAll(): Error while creating test Dataset');
-      });
     // Uploading test file 1 with some categories
-    await uploadFileViaApi(TestConstants.TEST_CREATED_DATASET_ID, testTextFile1Name, {categories: [testCategoryName]})
+    await uploadFileViaApi(TestConstants.TEST_CREATED_DATASET_1_ID, testTextFile1Name, { categories: [testCategoryName] })
       .then()
       .catch((e) => {
         console.log(e);
         fail(`Tests beforeAll(): Error while uploading file ${testTextFile1Name}`);
       });
     // Uploading test file 2
-    await uploadFileViaApi(TestConstants.TEST_CREATED_DATASET_ID, testTextFile2Name)
+    await uploadFileViaApi(TestConstants.TEST_CREATED_DATASET_1_ID, testTextFile2Name)
       .then()
       .catch((e) => {
         console.log(e);
         fail(`Tests beforeAll(): Error while uploading file ${testTextFile2Name}`);
       });
     // Uploading test file 3
-    await uploadFileViaApi(TestConstants.TEST_CREATED_DATASET_ID, testTextFile3Name)
+    await uploadFileViaApi(TestConstants.TEST_CREATED_DATASET_1_ID, testTextFile3Name)
       .then()
       .catch((e) => {
         console.log(e);
         fail(`Tests beforeAll(): Error while uploading file ${testTextFile3Name}`);
       });
     // Uploading test file 4
-    await uploadFileViaApi(TestConstants.TEST_CREATED_DATASET_ID, testTabFile4Name)
+    await uploadFileViaApi(TestConstants.TEST_CREATED_DATASET_1_ID, testTabFile4Name)
       .then()
       .catch((e) => {
         console.log(e);
@@ -72,7 +67,7 @@ describe('FilesRepository', () => {
     describe('by numeric id', () => {
       test('should return all files filtering by dataset id and version id', async () => {
         const actual = await sut.getDatasetFiles(
-          TestConstants.TEST_CREATED_DATASET_ID,
+          TestConstants.TEST_CREATED_DATASET_1_ID,
           latestDatasetVersionId,
           false,
           FileOrderCriteria.NAME_AZ,
@@ -86,7 +81,7 @@ describe('FilesRepository', () => {
 
       test('should return correct files filtering by dataset id, version id, and paginating', async () => {
         const actual = await sut.getDatasetFiles(
-          TestConstants.TEST_CREATED_DATASET_ID,
+          TestConstants.TEST_CREATED_DATASET_1_ID,
           latestDatasetVersionId,
           false,
           FileOrderCriteria.NAME_AZ,
@@ -100,7 +95,7 @@ describe('FilesRepository', () => {
 
       test('should return correct files filtering by dataset id, version id, and applying newest file criteria', async () => {
         let actual = await sut.getDatasetFiles(
-          TestConstants.TEST_CREATED_DATASET_ID,
+          TestConstants.TEST_CREATED_DATASET_1_ID,
           latestDatasetVersionId,
           false,
           FileOrderCriteria.NEWEST,
@@ -132,7 +127,7 @@ describe('FilesRepository', () => {
     describe('by persistent id', () => {
       test('should return all files filtering by persistent id and version id', async () => {
         const testDataset = await datasetRepository.getDataset(
-          TestConstants.TEST_CREATED_DATASET_ID,
+          TestConstants.TEST_CREATED_DATASET_1_ID,
           latestDatasetVersionId,
           false,
         );
@@ -151,7 +146,7 @@ describe('FilesRepository', () => {
 
       test('should return correct files filtering by persistent id, version id, and paginating', async () => {
         const testDataset = await datasetRepository.getDataset(
-          TestConstants.TEST_CREATED_DATASET_ID,
+          TestConstants.TEST_CREATED_DATASET_1_ID,
           latestDatasetVersionId,
           false,
         );
@@ -170,9 +165,9 @@ describe('FilesRepository', () => {
 
       test('should return correct files filtering by persistent id, version id, and applying newest file criteria', async () => {
         const testDataset = await datasetRepository.getDataset(
-          TestConstants.TEST_CREATED_DATASET_ID,
+          TestConstants.TEST_CREATED_DATASET_1_ID,
           latestDatasetVersionId,
-          false
+          false,
         );
         let actual = await sut.getDatasetFiles(
           testDataset.persistentId,
@@ -234,7 +229,7 @@ describe('FilesRepository', () => {
 
     test('should return file count filtering by numeric id', async () => {
       const actual = await sut.getDatasetFileCounts(
-        TestConstants.TEST_CREATED_DATASET_ID,
+        TestConstants.TEST_CREATED_DATASET_1_ID,
         latestDatasetVersionId,
         false,
       );
@@ -268,7 +263,7 @@ describe('FilesRepository', () => {
       };
       const testCriteria = new FileSearchCriteria().withCategoryName(testCategoryName);
       const actual = await sut.getDatasetFileCounts(
-        TestConstants.TEST_CREATED_DATASET_ID,
+        TestConstants.TEST_CREATED_DATASET_1_ID,
         latestDatasetVersionId,
         false,
         testCriteria,
@@ -281,9 +276,9 @@ describe('FilesRepository', () => {
 
     test('should return file count filtering by persistent id', async () => {
       const testDataset = await datasetRepository.getDataset(
-        TestConstants.TEST_CREATED_DATASET_ID,
+        TestConstants.TEST_CREATED_DATASET_1_ID,
         latestDatasetVersionId,
-        false
+        false,
       );
       const actual = await sut.getDatasetFileCounts(testDataset.persistentId, latestDatasetVersionId, false);
       assert.match(actual.total, expectedFileCounts.total);
@@ -298,7 +293,7 @@ describe('FilesRepository', () => {
 
     test('should return total download size filtering by numeric id and ignoring original tabular size', async () => {
       const actual = await sut.getDatasetFilesTotalDownloadSize(
-        TestConstants.TEST_CREATED_DATASET_ID,
+        TestConstants.TEST_CREATED_DATASET_1_ID,
         latestDatasetVersionId,
         false,
         FileDownloadSizeMode.ORIGINAL,
@@ -308,9 +303,9 @@ describe('FilesRepository', () => {
 
     test('should return total download size filtering by persistent id and ignoring original tabular size', async () => {
       const testDataset = await datasetRepository.getDataset(
-        TestConstants.TEST_CREATED_DATASET_ID,
+        TestConstants.TEST_CREATED_DATASET_1_ID,
         latestDatasetVersionId,
-        false
+        false,
       );
       const actual = await sut.getDatasetFilesTotalDownloadSize(
         testDataset.persistentId,
@@ -325,7 +320,7 @@ describe('FilesRepository', () => {
       const expectedTotalDownloadSizeForCriteria = 12; // 12 bytes
       const testCriteria = new FileSearchCriteria().withCategoryName(testCategoryName);
       const actual = await sut.getDatasetFilesTotalDownloadSize(
-        TestConstants.TEST_CREATED_DATASET_ID,
+        TestConstants.TEST_CREATED_DATASET_1_ID,
         latestDatasetVersionId,
         false,
         FileDownloadSizeMode.ORIGINAL,
@@ -338,7 +333,7 @@ describe('FilesRepository', () => {
   describe('getFileDownloadCount', () => {
     test('should return count filtering by file id and version id', async () => {
       const currentTestFiles = await sut.getDatasetFiles(
-        TestConstants.TEST_CREATED_DATASET_ID,
+        TestConstants.TEST_CREATED_DATASET_1_ID,
         latestDatasetVersionId,
         false,
         FileOrderCriteria.NAME_AZ,
@@ -363,7 +358,7 @@ describe('FilesRepository', () => {
   describe('getFileUserPermissions', () => {
     test('should return user permissions filtering by file id and version id', async () => {
       const currentTestFiles = await sut.getDatasetFiles(
-        TestConstants.TEST_CREATED_DATASET_ID,
+        TestConstants.TEST_CREATED_DATASET_1_ID,
         latestDatasetVersionId,
         false,
         FileOrderCriteria.NAME_AZ,
@@ -390,7 +385,7 @@ describe('FilesRepository', () => {
   describe('getFileDataTables', () => {
     test('should return data tables filtering by tabular file id and version id', async () => {
       const currentTestFiles = await sut.getDatasetFiles(
-        TestConstants.TEST_CREATED_DATASET_ID,
+        TestConstants.TEST_CREATED_DATASET_1_ID,
         latestDatasetVersionId,
         false,
         FileOrderCriteria.NAME_AZ,
@@ -402,7 +397,7 @@ describe('FilesRepository', () => {
 
     test('should return error when file is not tabular and version id', async () => {
       const currentTestFiles = await sut.getDatasetFiles(
-        TestConstants.TEST_CREATED_DATASET_ID,
+        TestConstants.TEST_CREATED_DATASET_1_ID,
         latestDatasetVersionId,
         false,
         FileOrderCriteria.NAME_AZ,

--- a/test/testHelpers/TestConstants.ts
+++ b/test/testHelpers/TestConstants.ts
@@ -28,5 +28,6 @@ export class TestConstants {
       'Content-Type': 'application/json',
     },
   };
-  static readonly TEST_CREATED_DATASET_ID = 2;
+  static readonly TEST_CREATED_DATASET_1_ID = 2;
+  static readonly TEST_CREATED_DATASET_2_ID = 3;
 }

--- a/test/testHelpers/datasets/datasetHelper.ts
+++ b/test/testHelpers/datasets/datasetHelper.ts
@@ -2,7 +2,6 @@ import { Dataset, DatasetVersionState, DatasetLicense } from '../../../src/datas
 import TurndownService from 'turndown';
 import axios, { AxiosResponse } from 'axios';
 import { TestConstants } from '../TestConstants';
-import datasetJson from './test-dataset.json';
 
 const turndownService = new TurndownService();
 
@@ -195,14 +194,6 @@ export const createDatasetLicenseModel = (withIconUri: boolean = true): DatasetL
     datasetLicense.iconUri = 'https://licensebuttons.net/p/zero/1.0/88x31.png';
   }
   return datasetLicense;
-};
-
-export const createDatasetViaApi = async (): Promise<AxiosResponse> => {
-  return await axios.post(
-    `${TestConstants.TEST_API_URL}/dataverses/root/datasets`,
-    datasetJson,
-    DATAVERSE_API_REQUEST_HEADERS,
-  );
 };
 
 export const publishDatasetViaApi = async (datasetId: number): Promise<AxiosResponse> => {

--- a/test/testHelpers/datasets/datasetHelper.ts
+++ b/test/testHelpers/datasets/datasetHelper.ts
@@ -70,6 +70,7 @@ export const createDatasetModel = (license?: DatasetLicense): Dataset => {
   return datasetModel;
 };
 
+// eslint-disable-next-line  @typescript-eslint/no-explicit-any
 export const createDatasetVersionPayload = (license?: DatasetLicense): any => {
   const datasetPayload: any = {
     id: 19,

--- a/test/testHelpers/datasets/datasetLockHelper.ts
+++ b/test/testHelpers/datasets/datasetLockHelper.ts
@@ -10,6 +10,7 @@ export const createDatasetLockModel = (): DatasetLock => {
   };
 };
 
+// eslint-disable-next-line  @typescript-eslint/no-explicit-any
 export const createDatasetLockPayload = (): any => {
   return {
     lockType: DatasetLockType.EDIT_IN_PROGRESS.toString(),

--- a/test/testHelpers/datasets/datasetLockHelper.ts
+++ b/test/testHelpers/datasets/datasetLockHelper.ts
@@ -1,4 +1,5 @@
 import { DatasetLock, DatasetLockType } from '../../../src/datasets/domain/models/DatasetLock';
+import { DatasetLockPayload } from '../../../src/datasets/infra/repositories/transformers/datasetLocksTransformers';
 
 export const createDatasetLockModel = (): DatasetLock => {
   return {
@@ -10,8 +11,7 @@ export const createDatasetLockModel = (): DatasetLock => {
   };
 };
 
-// eslint-disable-next-line  @typescript-eslint/no-explicit-any
-export const createDatasetLockPayload = (): any => {
+export const createDatasetLockPayload = (): DatasetLockPayload => {
   return {
     lockType: DatasetLockType.EDIT_IN_PROGRESS.toString(),
     date: '2023-05-15T08:21:03Z',

--- a/test/testHelpers/datasets/datasetPreviewHelper.ts
+++ b/test/testHelpers/datasets/datasetPreviewHelper.ts
@@ -1,9 +1,26 @@
 import { DatasetPreview } from '../../../src/datasets/domain/models/DatasetPreview';
+import { DatasetVersionState } from '../../../src/datasets/domain/models/Dataset';
+
+const DATASET_CREATE_TIME_STR = '2023-05-15T08:21:01Z';
+const DATASET_UPDATE_TIME_STR = '2023-05-15T08:21:03Z';
+const DATASET_RELEASE_TIME_STR = '2023-05-15T08:21:03Z';
 
 export const createDatasetPreviewModel = (): DatasetPreview => {
   const datasetPreviewModel: DatasetPreview = {
-    id: 1,
-    title: 'test'
-  }
+    persistentId: 'doi:10.5072/FK2/HC6KTB',
+    title: 'Test Dataset 1',
+    versionId: 19,
+    versionInfo: {
+      majorNumber: 1,
+      minorNumber: 0,
+      state: DatasetVersionState.RELEASED,
+      createTime: new Date(DATASET_CREATE_TIME_STR),
+      lastUpdateTime: new Date(DATASET_UPDATE_TIME_STR),
+      releaseTime: new Date(DATASET_RELEASE_TIME_STR),
+    },
+    citation:
+      'Doe, John, 2023, "Test Dataset 1", https://doi.org/10.5072/FK2/XXXXXX, Root, V1, UNF:6:AAc5A5tAI9AVodAAAsOysA== [fileUNF]',
+    description: 'test',
+  };
   return datasetPreviewModel;
 };

--- a/test/testHelpers/datasets/datasetPreviewHelper.ts
+++ b/test/testHelpers/datasets/datasetPreviewHelper.ts
@@ -5,6 +5,9 @@ const DATASET_CREATE_TIME_STR = '2023-05-15T08:21:01Z';
 const DATASET_UPDATE_TIME_STR = '2023-05-15T08:21:03Z';
 const DATASET_RELEASE_TIME_STR = '2023-05-15T08:21:03Z';
 
+const DATASET_CITATION =
+  'Doe, John, 2023, "Test Dataset 1", https://doi.org/10.5072/FK2/XXXXXX, Root, V1, UNF:6:AAc5A5tAI9AVodAAAsOysA== [fileUNF]';
+
 export const createDatasetPreviewModel = (): DatasetPreview => {
   const datasetPreviewModel: DatasetPreview = {
     persistentId: 'doi:10.5072/FK2/HC6KTB',
@@ -18,9 +21,25 @@ export const createDatasetPreviewModel = (): DatasetPreview => {
       lastUpdateTime: new Date(DATASET_UPDATE_TIME_STR),
       releaseTime: new Date(DATASET_RELEASE_TIME_STR),
     },
-    citation:
-      'Doe, John, 2023, "Test Dataset 1", https://doi.org/10.5072/FK2/XXXXXX, Root, V1, UNF:6:AAc5A5tAI9AVodAAAsOysA== [fileUNF]',
+    citation: DATASET_CITATION,
     description: 'test',
   };
   return datasetPreviewModel;
+};
+
+// eslint-disable-next-line  @typescript-eslint/no-explicit-any
+export const createDatasetPreviewPayload = (): any => {
+  return {
+    global_id: 'doi:10.5072/FK2/HC6KTB',
+    name: 'Test Dataset 1',
+    versionId: 19,
+    majorVersion: 1,
+    minorVersion: 0,
+    versionState: DatasetVersionState.RELEASED.toString(),
+    createdAt: DATASET_CREATE_TIME_STR,
+    updatedAt: DATASET_UPDATE_TIME_STR,
+    published_at: DATASET_RELEASE_TIME_STR,
+    citation: DATASET_CITATION,
+    description: 'test',
+  };
 };

--- a/test/testHelpers/datasets/datasetPreviewHelper.ts
+++ b/test/testHelpers/datasets/datasetPreviewHelper.ts
@@ -1,0 +1,9 @@
+import { DatasetPreview } from '../../../src/datasets/domain/models/DatasetPreview';
+
+export const createDatasetPreviewModel = (): DatasetPreview => {
+  const datasetPreviewModel: DatasetPreview = {
+    id: 1,
+    title: 'test'
+  }
+  return datasetPreviewModel;
+};

--- a/test/testHelpers/datasets/datasetPreviewHelper.ts
+++ b/test/testHelpers/datasets/datasetPreviewHelper.ts
@@ -1,5 +1,6 @@
 import { DatasetPreview } from '../../../src/datasets/domain/models/DatasetPreview';
 import { DatasetVersionState } from '../../../src/datasets/domain/models/Dataset';
+import { DatasetPreviewPayload } from '../../../src/datasets/infra/repositories/transformers/datasetPreviewsTransformers';
 
 const DATASET_CREATE_TIME_STR = '2023-05-15T08:21:01Z';
 const DATASET_UPDATE_TIME_STR = '2023-05-15T08:21:03Z';
@@ -27,8 +28,7 @@ export const createDatasetPreviewModel = (): DatasetPreview => {
   return datasetPreviewModel;
 };
 
-// eslint-disable-next-line  @typescript-eslint/no-explicit-any
-export const createDatasetPreviewPayload = (): any => {
+export const createDatasetPreviewPayload = (): DatasetPreviewPayload => {
   return {
     global_id: 'doi:10.5072/FK2/HC6KTB',
     name: 'Test Dataset 1',

--- a/test/testHelpers/datasets/test-dataset-1.json
+++ b/test/testHelpers/datasets/test-dataset-1.json
@@ -9,7 +9,7 @@
       "citation": {
         "fields": [
           {
-            "value": "Darwin's Finches",
+            "value": "First Dataset",
             "typeClass": "primitive",
             "multiple": false,
             "typeName": "title"
@@ -60,7 +60,7 @@
             "value": [
               {
                 "dsDescriptionValue": {
-                  "value": "Darwin's finches (also known as the Galápagos finches) are a group of about fifteen species of passerine birds.",
+                  "value": "This is the description of the first dataset.",
                   "multiple": false,
                   "typeClass": "primitive",
                   "typeName": "dsDescriptionValue"

--- a/test/testHelpers/datasets/test-dataset-2.json
+++ b/test/testHelpers/datasets/test-dataset-2.json
@@ -1,0 +1,85 @@
+{
+  "datasetVersion": {
+    "license": {
+      "name": "CC0 1.0",
+      "uri": "http://creativecommons.org/publicdomain/zero/1.0",
+      "iconUri": "https://licensebuttons.net/p/zero/1.0/88x31.png"
+    },
+    "metadataBlocks": {
+      "citation": {
+        "fields": [
+          {
+            "value": "Second Dataset",
+            "typeClass": "primitive",
+            "multiple": false,
+            "typeName": "title"
+          },
+          {
+            "value": [
+              {
+                "authorName": {
+                  "value": "Finch, Fiona",
+                  "typeClass": "primitive",
+                  "multiple": false,
+                  "typeName": "authorName"
+                },
+                "authorAffiliation": {
+                  "value": "Birds Inc.",
+                  "typeClass": "primitive",
+                  "multiple": false,
+                  "typeName": "authorAffiliation"
+                }
+              }
+            ],
+            "typeClass": "compound",
+            "multiple": true,
+            "typeName": "author"
+          },
+          {
+            "value": [
+              {
+                "datasetContactEmail": {
+                  "typeClass": "primitive",
+                  "multiple": false,
+                  "typeName": "datasetContactEmail",
+                  "value": "finch@mailinator.com"
+                },
+                "datasetContactName": {
+                  "typeClass": "primitive",
+                  "multiple": false,
+                  "typeName": "datasetContactName",
+                  "value": "Finch, Fiona"
+                }
+              }
+            ],
+            "typeClass": "compound",
+            "multiple": true,
+            "typeName": "datasetContact"
+          },
+          {
+            "value": [
+              {
+                "dsDescriptionValue": {
+                  "value": "This is the description of the second dataset.",
+                  "multiple": false,
+                  "typeClass": "primitive",
+                  "typeName": "dsDescriptionValue"
+                }
+              }
+            ],
+            "typeClass": "compound",
+            "multiple": true,
+            "typeName": "dsDescription"
+          },
+          {
+            "value": ["Medicine, Health and Life Sciences"],
+            "typeClass": "controlledVocabulary",
+            "multiple": true,
+            "typeName": "subject"
+          }
+        ],
+        "displayName": "Citation Metadata"
+      }
+    }
+  }
+}

--- a/test/unit/datasets/DatasetsRepository.test.ts
+++ b/test/unit/datasets/DatasetsRepository.test.ts
@@ -506,11 +506,13 @@ describe('DatasetsRepository', () => {
     const testDatasetPreviewsResponse = {
       data: {
         status: 'OK',
-        items: [createDatasetPreviewPayload()],
+        data: {
+          items: [createDatasetPreviewPayload()],
+        },
       },
     };
 
-    const expectedApiEndpoint = `${TestConstants.TEST_API_URL}/search?q=*&type=datasets`;
+    const expectedApiEndpoint = `${TestConstants.TEST_API_URL}/search?q=*&type=dataset`;
 
     test('should return dataset previews when response is successful', async () => {
       const axiosGetStub = sandbox.stub(axios, 'get').resolves(testDatasetPreviewsResponse);

--- a/test/unit/datasets/DatasetsRepository.test.ts
+++ b/test/unit/datasets/DatasetsRepository.test.ts
@@ -540,6 +540,43 @@ describe('DatasetsRepository', () => {
       assert.match(actual, testDatasetPreviews);
     });
 
+    test('should return dataset previews when providing pagination params and response is successful', async () => {
+      const axiosGetStub = sandbox.stub(axios, 'get').resolves(testDatasetPreviewsResponse);
+
+      const testLimit = 10;
+      const testOffset = 20;
+
+      // API Key auth
+      let actual = await sut.getAllDatasetPreviews(testLimit, testOffset);
+
+      const expectedRequestParamsWithPagination = {
+        per_page: testLimit,
+        start: testOffset,
+      };
+
+      const expectedRequestConfigApiKeyWithPagination = {
+        params: expectedRequestParamsWithPagination,
+        headers: TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY.headers,
+      };
+
+      assert.calledWithExactly(axiosGetStub, expectedApiEndpoint, expectedRequestConfigApiKeyWithPagination);
+      assert.match(actual, testDatasetPreviews);
+
+      // Session cookie auth
+      ApiConfig.init(TestConstants.TEST_API_URL, DataverseApiAuthMechanism.SESSION_COOKIE);
+
+      actual = await sut.getAllDatasetPreviews(testLimit, testOffset);
+
+      const expectedRequestConfigSessionCookieWithPagination = {
+        params: expectedRequestParamsWithPagination,
+        headers: TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE.headers,
+        withCredentials: TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE.withCredentials,
+      };
+
+      assert.calledWithExactly(axiosGetStub, expectedApiEndpoint, expectedRequestConfigSessionCookieWithPagination);
+      assert.match(actual, testDatasetPreviews);
+    });
+
     test('should return error result on error response', async () => {
       const axiosGetStub = sandbox.stub(axios, 'get').rejects(TestConstants.TEST_ERROR_RESPONSE);
 

--- a/test/unit/datasets/GetAllDatasetPreviews.test.ts
+++ b/test/unit/datasets/GetAllDatasetPreviews.test.ts
@@ -1,4 +1,4 @@
-import { GetCollectionDatasetPreviews } from '../../../src/datasets/domain/useCases/GetCollectionDatasetPreviews';
+import { GetAllDatasetPreviews } from '../../../src/datasets/domain/useCases/GetAllDatasetPreviews';
 import { assert, createSandbox, SinonSandbox } from 'sinon';
 import { ReadError } from '../../../src/core/domain/repositories/ReadError';
 import { DatasetPreview } from '../../../src/datasets/domain/models/DatasetPreview';
@@ -15,24 +15,24 @@ describe('execute', () => {
   test('should return dataset previews on repository success', async () => {
     const testDatasetPreviews: DatasetPreview[] = [createDatasetPreviewModel()];
     const datasetsRepositoryStub = <IDatasetsRepository>{};
-    const getCollectionDatasetPreviewsStub = sandbox.stub().returns(testDatasetPreviews);
-    datasetsRepositoryStub.getCollectionDatasetPreviews = getCollectionDatasetPreviewsStub;
-    const sut = new GetCollectionDatasetPreviews(datasetsRepositoryStub);
+    const getAllDatasetPreviewsStub = sandbox.stub().returns(testDatasetPreviews);
+    datasetsRepositoryStub.getAllDatasetPreviews = getAllDatasetPreviewsStub;
+    const sut = new GetAllDatasetPreviews(datasetsRepositoryStub);
 
-    const actual = await sut.execute(1);
+    const actual = await sut.execute();
 
     assert.match(actual, testDatasetPreviews);
-    assert.calledWithExactly(getCollectionDatasetPreviewsStub, 1, undefined, undefined);
+    assert.calledWithExactly(getAllDatasetPreviewsStub, undefined, undefined);
   });
 
   test('should return error result on repository error', async () => {
     const datasetsRepositoryStub = <IDatasetsRepository>{};
     const testReadError = new ReadError();
-    datasetsRepositoryStub.getCollectionDatasetPreviews = sandbox.stub().throwsException(testReadError);
-    const sut = new GetCollectionDatasetPreviews(datasetsRepositoryStub);
+    datasetsRepositoryStub.getAllDatasetPreviews = sandbox.stub().throwsException(testReadError);
+    const sut = new GetAllDatasetPreviews(datasetsRepositoryStub);
 
     let actualError: ReadError = undefined;
-    await sut.execute(1).catch((e: ReadError) => (actualError = e));
+    await sut.execute().catch((e: ReadError) => (actualError = e));
 
     assert.match(actualError, testReadError);
   });

--- a/test/unit/datasets/GetCollectionDatasetPreviews.test.ts
+++ b/test/unit/datasets/GetCollectionDatasetPreviews.test.ts
@@ -22,7 +22,7 @@ describe('execute', () => {
     const actual = await sut.execute(1);
 
     assert.match(actual, testDatasetPreviews);
-    assert.calledWithExactly(getCollectionDatasetPreviewsStub, 1);
+    assert.calledWithExactly(getCollectionDatasetPreviewsStub, 1, undefined, undefined);
   });
 
   test('should return error result on repository error', async () => {

--- a/test/unit/datasets/GetCollectionDatasetPreviews.test.ts
+++ b/test/unit/datasets/GetCollectionDatasetPreviews.test.ts
@@ -1,0 +1,39 @@
+import { GetCollectionDatasetPreviews } from '../../../src/datasets/domain/useCases/GetCollectionDatasetPreviews';
+import { assert, createSandbox, SinonSandbox } from 'sinon';
+import { ReadError } from '../../../src/core/domain/repositories/ReadError';
+import { DatasetPreview } from '../../../src/datasets/domain/models/DatasetPreview';
+import { createDatasetPreviewModel } from '../../testHelpers/datasets/datasetPreviewHelper';
+import { IDatasetsRepository } from '../../../src/datasets/domain/repositories/IDatasetsRepository';
+
+describe('execute', () => {
+  const sandbox: SinonSandbox = createSandbox();
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  test('should return dataset previews on repository success', async () => {
+    const testDatasetPreviews: DatasetPreview[] = [createDatasetPreviewModel()];
+    const datasetsRepositoryStub = <IDatasetsRepository>{};
+    const getCollectionDatasetPreviewsStub = sandbox.stub().returns(testDatasetPreviews);
+    datasetsRepositoryStub.getCollectionDatasetPreviews = getCollectionDatasetPreviewsStub;
+    const sut = new GetCollectionDatasetPreviews(datasetsRepositoryStub);
+
+    const actual = await sut.execute(1);
+
+    assert.match(actual, testDatasetPreviews);
+    assert.calledWithExactly(getCollectionDatasetPreviewsStub, 1);
+  });
+
+  test('should return error result on repository error', async () => {
+    const datasetsRepositoryStub = <IDatasetsRepository>{};
+    const testReadError = new ReadError();
+    datasetsRepositoryStub.getCollectionDatasetPreviews = sandbox.stub().throwsException(testReadError);
+    const sut = new GetCollectionDatasetPreviews(datasetsRepositoryStub);
+
+    let actualError: ReadError = undefined;
+    await sut.execute(1).catch((e: ReadError) => (actualError = e));
+
+    assert.match(actualError, testReadError);
+  });
+});


### PR DESCRIPTION
## What this PR does / why we need it:

Adds use case to get all dataset previews of the installation.

## Which issue(s) this PR closes:

- Closes #106 

## Special notes for your reviewer:

The integration testing environment setup has been modified, now creating the test datasets at that point, to ensure that they are correctly created and indexed in Solr when running the integration tests and that there are no race conditions between the tests, since for getAllDatasetPreviews the total number of retrieved datasets is checked.

## Suggestions on how to test this:

Visual inspection and execute integration tests.

## Is there a release notes update needed for this change?:

N/A

## Additional documentation:

None
