### PR TITLE
Modify getDataset repository API call to use 'excludeFiles' parameter

### DIFF
--- a/src/core/infra/repositories/ApiRepository.ts
+++ b/src/core/infra/repositories/ApiRepository.ts
@@ -56,7 +56,9 @@ export abstract class ApiRepository {
         requestConfig.withCredentials = true;
         break;
       case DataverseApiAuthMechanism.API_KEY:
-        requestConfig.headers['X-Dataverse-Key'] = ApiConfig.dataverseApiKey;
+        if (typeof ApiConfig.dataverseApiKey !== 'undefined') {
+          requestConfig.headers['X-Dataverse-Key'] = ApiConfig.dataverseApiKey;
+        }
         break;
     }
     return requestConfig;

--- a/src/datasets/infra/repositories/DatasetsRepository.ts
+++ b/src/datasets/infra/repositories/DatasetsRepository.ts
@@ -43,7 +43,7 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
       true,
       {
         includeDeaccessioned: includeDeaccessioned,
-        includeFiles: false,
+        excludeFiles: true,
       },
     )
       .then((response) => transformVersionResponseToDataset(response))

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -19,7 +19,11 @@ describe('DatasetsRepository', () => {
 
   const latestVersionId = DatasetNotNumberedVersion.LATEST;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
+    ApiConfig.init(TestConstants.TEST_API_URL, DataverseApiAuthMechanism.API_KEY, process.env.TEST_API_KEY);
+  });
+
+  afterEach(async () => {
     ApiConfig.init(TestConstants.TEST_API_URL, DataverseApiAuthMechanism.API_KEY, process.env.TEST_API_KEY);
   });
 
@@ -104,6 +108,12 @@ describe('DatasetsRepository', () => {
 
         const actual = await sut.getDataset(TestConstants.TEST_CREATED_DATASET_2_ID, latestVersionId, true);
 
+        expect(actual.id).toBe(TestConstants.TEST_CREATED_DATASET_2_ID);
+      });
+
+      test('should return dataset when it is deaccessioned, includeDeaccessioned param is set, and user is unauthenticated', async () => {
+        ApiConfig.init(TestConstants.TEST_API_URL, DataverseApiAuthMechanism.API_KEY, undefined);
+        const actual = await sut.getDataset(TestConstants.TEST_CREATED_DATASET_2_ID, latestVersionId, true);
         expect(actual.id).toBe(TestConstants.TEST_CREATED_DATASET_2_ID);
       });
 

--- a/test/integration/environment/setup.js
+++ b/test/integration/environment/setup.js
@@ -4,6 +4,7 @@ const axios = require('axios');
 const { TestConstants } = require('../../testHelpers/TestConstants');
 const datasetJson1 = require('../../testHelpers/datasets/test-dataset-1.json');
 const datasetJson2 = require('../../testHelpers/datasets/test-dataset-2.json');
+const datasetJson3 = require('../../testHelpers/datasets/test-dataset-3.json');
 
 const COMPOSE_FILE = 'docker-compose.yml';
 
@@ -59,6 +60,11 @@ async function setupTestFixtures() {
     .catch((error) => {
       console.error('Tests setup: Error while creating test Dataset 2');
     });
+  await createDatasetViaApi(datasetJson3)
+    .then()
+    .catch((error) => {
+      console.error('Tests setup: Error while creating test Dataset 3');
+    });
   console.log('Test datasets created');
   await waitForDatasetsIndexingInSolr();
 }
@@ -76,7 +82,7 @@ async function waitForDatasetsIndexingInSolr() {
       .get(`${TestConstants.TEST_API_URL}/search?q=*&type=dataset`, buildRequestHeaders())
       .then((response) => {
         const nDatasets = response.data.data.items.length;
-        if (nDatasets == 2) {
+        if (nDatasets == 3) {
           datasetsIndexed = true;
         }
       })

--- a/test/testHelpers/TestConstants.ts
+++ b/test/testHelpers/TestConstants.ts
@@ -44,4 +44,5 @@ export class TestConstants {
   };
   static readonly TEST_CREATED_DATASET_1_ID = 2;
   static readonly TEST_CREATED_DATASET_2_ID = 3;
+  static readonly TEST_CREATED_DATASET_3_ID = 4;
 }

--- a/test/testHelpers/datasets/test-dataset-3.json
+++ b/test/testHelpers/datasets/test-dataset-3.json
@@ -1,0 +1,85 @@
+{
+  "datasetVersion": {
+    "license": {
+      "name": "CC0 1.0",
+      "uri": "http://creativecommons.org/publicdomain/zero/1.0",
+      "iconUri": "https://licensebuttons.net/p/zero/1.0/88x31.png"
+    },
+    "metadataBlocks": {
+      "citation": {
+        "fields": [
+          {
+            "value": "Third Dataset",
+            "typeClass": "primitive",
+            "multiple": false,
+            "typeName": "title"
+          },
+          {
+            "value": [
+              {
+                "authorName": {
+                  "value": "Finch, Fiona",
+                  "typeClass": "primitive",
+                  "multiple": false,
+                  "typeName": "authorName"
+                },
+                "authorAffiliation": {
+                  "value": "Birds Inc.",
+                  "typeClass": "primitive",
+                  "multiple": false,
+                  "typeName": "authorAffiliation"
+                }
+              }
+            ],
+            "typeClass": "compound",
+            "multiple": true,
+            "typeName": "author"
+          },
+          {
+            "value": [
+              {
+                "datasetContactEmail": {
+                  "typeClass": "primitive",
+                  "multiple": false,
+                  "typeName": "datasetContactEmail",
+                  "value": "finch@mailinator.com"
+                },
+                "datasetContactName": {
+                  "typeClass": "primitive",
+                  "multiple": false,
+                  "typeName": "datasetContactName",
+                  "value": "Finch, Fiona"
+                }
+              }
+            ],
+            "typeClass": "compound",
+            "multiple": true,
+            "typeName": "datasetContact"
+          },
+          {
+            "value": [
+              {
+                "dsDescriptionValue": {
+                  "value": "This is the description of the third dataset.",
+                  "multiple": false,
+                  "typeClass": "primitive",
+                  "typeName": "dsDescriptionValue"
+                }
+              }
+            ],
+            "typeClass": "compound",
+            "multiple": true,
+            "typeName": "dsDescription"
+          },
+          {
+            "value": ["Medicine, Health and Life Sciences"],
+            "typeClass": "controlledVocabulary",
+            "multiple": true,
+            "typeName": "subject"
+          }
+        ],
+        "displayName": "Citation Metadata"
+      }
+    }
+  }
+}

--- a/test/unit/datasets/DatasetsRepository.test.ts
+++ b/test/unit/datasets/DatasetsRepository.test.ts
@@ -87,11 +87,11 @@ describe('DatasetsRepository', () => {
   describe('getDataset', () => {
     const testIncludeDeaccessioned = false;
     const expectedRequestConfigApiKey = {
-      params: { includeDeaccessioned: testIncludeDeaccessioned, includeFiles: false },
+      params: { includeDeaccessioned: testIncludeDeaccessioned, excludeFiles: true },
       headers: TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY.headers,
     };
     const expectedRequestConfigSessionCookie = {
-      params: { includeDeaccessioned: testIncludeDeaccessioned, includeFiles: false },
+      params: { includeDeaccessioned: testIncludeDeaccessioned, excludeFiles: true },
       withCredentials: TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE.withCredentials,
       headers: TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE.headers,
     };


### PR DESCRIPTION
## What this PR does / why we need it:

Modifies getDataset repository API call to use 'excludeFiles' parameter.

Also adds more test cases for deaccessioned datasets and getDataset repository method.

## Which issue(s) this PR closes:

- Closes #111

## Related Dataverse PRs:

- None

## Suggestions on how to test this:

- Run integration tests or review GitHub action execution
