### PR TITLE
keep configbaker in lock step with dataverse image

### DIFF
--- a/test/environment/docker-compose.yml
+++ b/test/environment/docker-compose.yml
@@ -33,7 +33,7 @@ services:
 
   test_dataverse_bootstrap:
     container_name: 'test_dataverse_bootstrap'
-    image: gdcc/configbaker:unstable
+    image: ${DATAVERSE_IMAGE_REGISTRY}/gdcc/configbaker:${DATAVERSE_IMAGE_TAG}
     restart: 'no'
     environment:
       - TIMEOUT=${DATAVERSE_BOOTSTRAP_TIMEOUT}


### PR DESCRIPTION
## What this PR does / why we need it:

After the following PR was merged...

- https://github.com/IQSS/dataverse/pull/10440

... `npm run test:integration` tests were failing if you switch `test/environment/.env` to a branch that was built before the PR was merged. For example:

```
DATAVERSE_IMAGE_REGISTRY=ghcr.io
DATAVERSE_IMAGE_TAG=add-isreleased-field-to-get-dataverse-api-response
```

This is because...

- a new "promote superuser" API was https://github.com/IQSS/dataverse/pull/10440
- the `add-isreleased-field-to-get-dataverse-api-response` image doesn't have it (too old)
- unstable configbaker was trying to use the new API and failing to promote the dataverseAdmin to superuser

As of this pull request, we switch configbaker to use the same tag as the dataverse image so they'll be compatible.

## Which issue(s) this PR closes:

- Closes #149

## Related Dataverse PRs:

- https://github.com/IQSS/dataverse/pull/10440

## Special notes for your reviewer:

Tested with @ekraffmiller looking over my shoulder.

If you are curious what the failure looked like (`You must be a superuser to change this setting`), see this PR:

- https://github.com/IQSS/dataverse-client-javascript/pull/148

## Suggestions on how to test this:

Test `test/environment/.env` with variations:

- as is (unstable)
- using a branch from https://github.com/orgs/gdcc/packages/container/package/dataverse

## Is there a release notes update needed for this change?:

No.

## Additional documentation:

No.
