### PR TITLE
Fix date format validation on create & update dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ node_modules
 # intellij
 .idea
 
+# Visual Studio
+/.vscode
+
 # unit tests
 coverage
 

--- a/src/datasets/domain/useCases/validators/errors/DateFormatFieldError.ts
+++ b/src/datasets/domain/useCases/validators/errors/DateFormatFieldError.ts
@@ -4,6 +4,7 @@ export class DateFormatFieldError extends FieldValidationError {
   constructor(
     metadataFieldName: string,
     citationBlockName: string,
+    validDateFormat: string,
     parentMetadataFieldName?: string,
     fieldPosition?: number
   ) {
@@ -12,7 +13,7 @@ export class DateFormatFieldError extends FieldValidationError {
       citationBlockName,
       parentMetadataFieldName,
       fieldPosition,
-      'The field requires a valid date format (YYYY-MM-DD).'
+      `The field requires a valid date format (${validDateFormat}).`
     )
   }
 }

--- a/test/testHelpers/datasets/datasetHelper.ts
+++ b/test/testHelpers/datasets/datasetHelper.ts
@@ -360,7 +360,8 @@ export const createDatasetDTO = (
   alternativeRequiredTitleValue?: DatasetMetadataFieldValueDTO,
   timePeriodCoveredStartValue?: DatasetMetadataFieldValueDTO,
   contributorTypeValue?: DatasetMetadataFieldValueDTO,
-  license?: DatasetLicense
+  license?: DatasetLicense,
+  dateOfCreationValue?: DatasetMetadataFieldValueDTO
 ): DatasetDTO => {
   const validTitle = 'test dataset'
   const validAuthorFieldValue = [
@@ -388,6 +389,9 @@ export const createDatasetDTO = (
               : validAlternativeRequiredTitleValue,
           ...(timePeriodCoveredStartValue && {
             timePeriodCoveredStart: timePeriodCoveredStartValue
+          }),
+          ...(dateOfCreationValue && {
+            dateOfCreation: dateOfCreationValue
           }),
           ...(contributorTypeValue && {
             contributor: [
@@ -536,8 +540,23 @@ export const createDatasetMetadataBlockModel = (): MetadataBlock => {
         displayName: 'Time Period Start Date',
         title: 'Start Date',
         type: MetadataFieldType.Date,
-        watermark: MetadataFieldWatermark.Empty,
+        watermark: MetadataFieldWatermark.YYYYOrYYYYMMOrYYYYMMDD,
         description: 'The start date of the time period that the data refer to',
+        multiple: false,
+        isControlledVocabulary: false,
+        displayFormat: '#NAME: #VALUE ',
+        isRequired: false,
+        displayOrder: 5,
+        displayOnCreate: true,
+        typeClass: MetadataFieldTypeClass.Primitive
+      },
+      dateOfCreation: {
+        name: 'dateOfCreation',
+        displayName: 'Date of Creation',
+        title: 'Creation Date',
+        type: MetadataFieldType.Date,
+        watermark: MetadataFieldWatermark.YyyyMmDD,
+        description: 'The creation date of dataset',
         multiple: false,
         isControlledVocabulary: false,
         displayFormat: '#NAME: #VALUE ',

--- a/test/unit/datasets/DatasetResourceValidator.test.ts
+++ b/test/unit/datasets/DatasetResourceValidator.test.ts
@@ -34,7 +34,6 @@ describe('validate', () => {
       sut.validate(dataset, testMetadataBlocks)
       throw new Error('Validation should fail')
     } catch (error) {
-      console.log({ expectedMetadataFieldName })
       expect(error).toBeInstanceOf(FieldValidationError)
       expect(error.citationBlockName).toEqual('citation')
       expect(error.metadataFieldName).toEqual(expectedMetadataFieldName)


### PR DESCRIPTION
## What this PR does / why we need it:
Fixes date format validation.

> Not all metadata fields of all metadata blocks expect a date in the YYYY-MM-DD format. There are metadata fields that expect other date formats, defined by the watermark.

## Which issue(s) this PR closes:

- Closes #157 

## Related Dataverse PRs:
N/A

## Special notes for your reviewer:
The `.gitignore` modification is to ignore my vscode folder on my end where I'm using settings to auto format on save with prettier.
## Suggestions on how to test this:
Visual inspection and run tests.

## Is there a release notes update needed for this change?:
N/A
## Additional documentation:
N/A