### PR TITLE
Support publish dataset with update current version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ node_modules
 # intellij
 .idea
 
+# Visual Studio
+/.vscode
+
 # unit tests
 coverage
 

--- a/docs/useCases.md
+++ b/docs/useCases.md
@@ -478,15 +478,16 @@ publishDataset.execute(datasetId, versionUpdateType)
 _See [use case](../src/datasets/domain/useCases/PublishDataset.ts) implementation_.
 
 The above example publishes the dataset with the specified identifier and performs a minor version update. If the response
-is successful, the use case does not return the dataset object, but the HTTP status code `200`. Otherwise, it throws an error.
-If you want to perform a major version update, you must set the `versionUpdateType` parameter to `VersionUpdateType.MAJOR`.
-
+is successful, the use case does not return the dataset object, but the HTTP status code `200`. Otherwise, it throws an error.\
+If you want to perform a major version update, you must set the `versionUpdateType` parameter to `VersionUpdateType.MAJOR`.\
+Superusers can pass `VersionUpdateType.UPDATE_CURRENT` to update metadata without changing the version number. This will overwrite the latest published version and therefore will only work for a dataset that has been published at least once.\
 The `datasetId` parameter can be a string, for persistent identifiers, or a number, for numeric identifiers.
 
 The `versionUpdateType` parameter can be a [VersionUpdateType](../src/datasets/domain/models/VersionUpdateType.ts) enum value, which can be one of the following:
 
 - `VersionUpdateType.MINOR`
 - `VersionUpdateType.MAJOR`
+- `VersionUpdateType.UPDATE_CURRENT`
 
 ## Files
 

--- a/docs/useCases.md
+++ b/docs/useCases.md
@@ -480,7 +480,7 @@ _See [use case](../src/datasets/domain/useCases/PublishDataset.ts) implementatio
 The above example publishes the dataset with the specified identifier and performs a minor version update. If the response
 is successful, the use case does not return the dataset object, but the HTTP status code `200`. Otherwise, it throws an error.\
 If you want to perform a major version update, you must set the `versionUpdateType` parameter to `VersionUpdateType.MAJOR`.\
-Superusers can pass `VersionUpdateType.UPDATE_CURRENT` to update metadata without changing the version number. This will overwrite the latest published version and therefore will only work for a dataset that has been published at least once.\
+Superusers can pass `VersionUpdateType.UPDATE_CURRENT` to update metadata without changing the version number. This will overwrite the latest published version and therefore will only work for a dataset that has been published at least once. \*Note that this will only work also if there were no file changes in the update.\
 The `datasetId` parameter can be a string, for persistent identifiers, or a number, for numeric identifiers.
 
 The `versionUpdateType` parameter can be a [VersionUpdateType](../src/datasets/domain/models/VersionUpdateType.ts) enum value, which can be one of the following:

--- a/src/datasets/domain/models/Dataset.ts
+++ b/src/datasets/domain/models/Dataset.ts
@@ -186,5 +186,6 @@ interface Software extends DatasetMetadataSubField {
 
 export enum VersionUpdateType {
   MAJOR = 'major',
-  MINOR = 'minor'
+  MINOR = 'minor',
+  UPDATE_CURRENT = 'updatecurrent'
 }

--- a/src/datasets/domain/useCases/PublishDataset.ts
+++ b/src/datasets/domain/useCases/PublishDataset.ts
@@ -13,7 +13,7 @@ export class PublishDataset implements UseCase<void> {
    * Publishes a dataset, given its identifier and the type of version update type.
    *
    * @param {number | string} [datasetId] - The dataset identifier, which can be a string (for persistent identifiers), or a number (for numeric identifiers).
-   * @param {VersionUpdateType} versionUpdateType - Specifies the type of version update, 'major' or 'minor'.
+   * @param {VersionUpdateType} versionUpdateType - Specifies the type of version update, 'major', 'minor' or 'updatecurrent'
    * @returns {Promise<void>} - This method does not return anything upon successful completion.
    */
   async execute(datasetId: number | string, versionUpdateType: VersionUpdateType): Promise<void> {


### PR DESCRIPTION
## What this PR does / why we need it:
Adds support to publish dataset use case updating current version for superusers.

## Which issue(s) this PR closes:

- Closes #159

## Special notes for your reviewer:
The `.gitignore` modification is to ignore my vscode folder on my end where I'm using settings to auto format on save with prettier.

## Suggestions on how to test this:
Visual inspection and run tests.

## Is there a release notes update needed for this change?:
N/A
## Additional documentation:
N/A