### PR TITLE
Adds new use case GetAllMetadataBlocks

### DIFF
--- a/docs/useCases.md
+++ b/docs/useCases.md
@@ -43,6 +43,7 @@ The different use cases currently available in the package are classified below,
     - [File Uploading Use Cases](#file-uploading-use-cases)
 - [Metadata Blocks](#metadata-blocks)
   - [Metadata Blocks read use cases](#metadata-blocks-read-use-cases)
+    - [Get All Metadata Blocks](#get-all-metadata-blocks)
     - [Get Metadata Block By Name](#get-metadata-block-by-name)
     - [Get Collection Metadata Blocks](#get-collection-metadata-blocks)
 - [Users](#Users)
@@ -964,6 +965,26 @@ The following error might arise from the `AddUploadedFileToDataset` use case:
 ## Metadata Blocks
 
 ### Metadata Blocks read use cases
+
+#### Get All Metadata Blocks
+
+Returns a [MetadataBlock](../src/metadataBlocks/domain/models/MetadataBlock.ts) array containing the metadata blocks defined in the installation.
+
+##### Example call:
+
+```typescript
+import { getAllMetadataBlocks } from '@iqss/dataverse-client-javascript'
+
+/* ... */
+
+getAllMetadataBlocks.execute().then((metadataBlocks: MetadataBlock[]) => {
+  /* ... */
+})
+
+/* ... */
+```
+
+_See [use case](../src/metadataBlocks/domain/useCases/GetAllMetadataBlocks.ts) implementation_.
 
 #### Get Metadata Block By Name
 

--- a/src/metadataBlocks/domain/repositories/IMetadataBlocksRepository.ts
+++ b/src/metadataBlocks/domain/repositories/IMetadataBlocksRepository.ts
@@ -7,4 +7,6 @@ export interface IMetadataBlocksRepository {
     collectionIdOrAlias: number | string,
     onlyDisplayedOnCreate: boolean
   ): Promise<MetadataBlock[]>
+
+  getAllMetadataBlocks(): Promise<MetadataBlock[]>
 }

--- a/src/metadataBlocks/domain/useCases/GetAllMetadataBlocks.ts
+++ b/src/metadataBlocks/domain/useCases/GetAllMetadataBlocks.ts
@@ -1,0 +1,20 @@
+import { UseCase } from '../../../core/domain/useCases/UseCase'
+import { MetadataBlock } from '../..'
+import { IMetadataBlocksRepository } from '../repositories/IMetadataBlocksRepository'
+
+export class GetAllMetadataBlocks implements UseCase<MetadataBlock[]> {
+  private metadataBlocksRepository: IMetadataBlocksRepository
+
+  constructor(metadataBlocksRepository: IMetadataBlocksRepository) {
+    this.metadataBlocksRepository = metadataBlocksRepository
+  }
+
+  /**
+   * Returns a MetadataBlock array containing the metadata blocks defined in the installation.
+   *
+   * @returns {Promise<MetadataBlock[]>}
+   */
+  async execute(): Promise<MetadataBlock[]> {
+    return await this.metadataBlocksRepository.getAllMetadataBlocks()
+  }
+}

--- a/src/metadataBlocks/index.ts
+++ b/src/metadataBlocks/index.ts
@@ -1,13 +1,15 @@
 import { GetMetadataBlockByName } from './domain/useCases/GetMetadataBlockByName'
 import { MetadataBlocksRepository } from './infra/repositories/MetadataBlocksRepository'
 import { GetCollectionMetadataBlocks } from './domain/useCases/GetCollectionMetadataBlocks'
+import { GetAllMetadataBlocks } from './domain/useCases/GetAllMetadataBlocks'
 
 const metadataBlocksRepository = new MetadataBlocksRepository()
 
 const getMetadataBlockByName = new GetMetadataBlockByName(metadataBlocksRepository)
 const getCollectionMetadataBlocks = new GetCollectionMetadataBlocks(metadataBlocksRepository)
+const getAllMetadataBlocks = new GetAllMetadataBlocks(metadataBlocksRepository)
 
-export { getMetadataBlockByName, getCollectionMetadataBlocks }
+export { getMetadataBlockByName, getCollectionMetadataBlocks, getAllMetadataBlocks }
 export {
   MetadataBlock,
   MetadataFieldInfo,

--- a/src/metadataBlocks/infra/repositories/MetadataBlocksRepository.ts
+++ b/src/metadataBlocks/infra/repositories/MetadataBlocksRepository.ts
@@ -28,4 +28,14 @@ export class MetadataBlocksRepository extends ApiRepository implements IMetadata
         throw error
       })
   }
+
+  public async getAllMetadataBlocks(): Promise<MetadataBlock[]> {
+    return this.doGet('/metadatablocks', false, {
+      returnDatasetFieldTypes: true
+    })
+      .then((response) => transformMetadataBlocksResponseToMetadataBlocks(response))
+      .catch((error) => {
+        throw error
+      })
+  }
 }

--- a/test/functional/metadataBlocks/GetAllMetadataBlocks.test.ts
+++ b/test/functional/metadataBlocks/GetAllMetadataBlocks.test.ts
@@ -1,0 +1,26 @@
+import { ApiConfig, getAllMetadataBlocks, MetadataBlock } from '../../../src'
+import { TestConstants } from '../../testHelpers/TestConstants'
+import { DataverseApiAuthMechanism } from '../../../src/core/infra/repositories/ApiConfig'
+
+describe('execute', () => {
+  beforeEach(async () => {
+    ApiConfig.init(
+      TestConstants.TEST_API_URL,
+      DataverseApiAuthMechanism.API_KEY,
+      process.env.TEST_API_KEY
+    )
+  })
+
+  test('should successfully return metadatablocks', async () => {
+    let metadataBlocks: MetadataBlock[] = null
+    try {
+      metadataBlocks = await getAllMetadataBlocks.execute()
+    } catch (error) {
+      throw new Error('Should not raise an error')
+    } finally {
+      expect(metadataBlocks).not.toBeNull()
+      expect(metadataBlocks.length).toBe(6)
+      expect(metadataBlocks[0].metadataFields.title.name).toBe('title')
+    }
+  })
+})

--- a/test/integration/metadataBlocks/MetadataBlocksRepository.test.ts
+++ b/test/integration/metadataBlocks/MetadataBlocksRepository.test.ts
@@ -6,38 +6,51 @@ import {
 } from '../../../src/core/infra/repositories/ApiConfig'
 import { TestConstants } from '../../testHelpers/TestConstants'
 
-describe('getMetadataBlockByName', () => {
-  const sut: MetadataBlocksRepository = new MetadataBlocksRepository()
+describe('MetadataBlocksRepository', () => {
   const citationMetadataBlockName = 'citation'
+  const sut: MetadataBlocksRepository = new MetadataBlocksRepository()
 
-  ApiConfig.init(
-    TestConstants.TEST_API_URL,
-    DataverseApiAuthMechanism.API_KEY,
-    process.env.TEST_API_KEY
-  )
-
-  test('should return error when metadata block does not exist', async () => {
-    const nonExistentMetadataBlockName = 'nonExistentMetadataBlock'
-    const errorExpected: ReadError = new ReadError(
-      `[404] Can't find metadata block '${nonExistentMetadataBlockName}'`
-    )
-
-    await expect(sut.getMetadataBlockByName(nonExistentMetadataBlockName)).rejects.toThrow(
-      errorExpected
+  beforeAll(async () => {
+    ApiConfig.init(
+      TestConstants.TEST_API_URL,
+      DataverseApiAuthMechanism.API_KEY,
+      process.env.TEST_API_KEY
     )
   })
 
-  test('should return metadata block when it exists', async () => {
-    const actual = await sut.getMetadataBlockByName(citationMetadataBlockName)
+  describe('getMetadataBlockByName', () => {
+    test('should return error when metadata block does not exist', async () => {
+      const nonExistentMetadataBlockName = 'nonExistentMetadataBlock'
+      const errorExpected: ReadError = new ReadError(
+        `[404] Can't find metadata block '${nonExistentMetadataBlockName}'`
+      )
 
-    expect(actual.name).toBe(citationMetadataBlockName)
+      await expect(sut.getMetadataBlockByName(nonExistentMetadataBlockName)).rejects.toThrow(
+        errorExpected
+      )
+    })
+
+    test('should return metadata block when it exists', async () => {
+      const actual = await sut.getMetadataBlockByName(citationMetadataBlockName)
+
+      expect(actual.name).toBe(citationMetadataBlockName)
+    })
+
+    test('should return collection metadata blocks', async () => {
+      const actual = await sut.getCollectionMetadataBlocks('root', true)
+
+      expect(actual.length).toBe(1)
+      expect(actual[0].name).toBe(citationMetadataBlockName)
+      expect(actual[0].metadataFields.title.name).toBe('title')
+    })
   })
 
-  test('should return collection metadata blocks', async () => {
-    const actual = await sut.getCollectionMetadataBlocks('root', true)
-
-    expect(actual.length).toBe(1)
-    expect(actual[0].name).toBe(citationMetadataBlockName)
-    expect(actual[0].metadataFields.title.name).toBe('title')
+  describe('getAllMetadataBlocks', () => {
+    test('should return all metadata blocks', async () => {
+      const actual = await sut.getAllMetadataBlocks()
+      expect(actual.length).toBe(6)
+      expect(actual[0].name).toBe(citationMetadataBlockName)
+      expect(actual[0].metadataFields.title.name).toBe('title')
+    })
   })
 })

--- a/test/unit/metadataBlocks/GetAllMetadataBlocks.test.ts
+++ b/test/unit/metadataBlocks/GetAllMetadataBlocks.test.ts
@@ -1,0 +1,27 @@
+import { ReadError } from '../../../src'
+import { createMetadataBlockModel } from '../../testHelpers/metadataBlocks/metadataBlockHelper'
+import { IMetadataBlocksRepository } from '../../../src/metadataBlocks/domain/repositories/IMetadataBlocksRepository'
+import { GetAllMetadataBlocks } from '../../../src/metadataBlocks/domain/useCases/GetAllMetadataBlocks'
+
+describe('execute', () => {
+  test('should return metadata blocks on repository success', async () => {
+    const testMetadataBlocks = [createMetadataBlockModel()]
+    const metadataBlocksRepositoryStub: IMetadataBlocksRepository = {} as IMetadataBlocksRepository
+    metadataBlocksRepositoryStub.getAllMetadataBlocks = jest
+      .fn()
+      .mockResolvedValue(testMetadataBlocks)
+    const testGetAllMetadataBlocks = new GetAllMetadataBlocks(metadataBlocksRepositoryStub)
+
+    const actual = await testGetAllMetadataBlocks.execute()
+
+    expect(actual).toEqual(testMetadataBlocks)
+  })
+
+  test('should return error result on repository error', async () => {
+    const metadataBlocksRepositoryStub: IMetadataBlocksRepository = {} as IMetadataBlocksRepository
+    metadataBlocksRepositoryStub.getAllMetadataBlocks = jest.fn().mockRejectedValue(new ReadError())
+    const testGetCollectionMetadataBlocks = new GetAllMetadataBlocks(metadataBlocksRepositoryStub)
+
+    await expect(testGetCollectionMetadataBlocks.execute()).rejects.toThrow(ReadError)
+  })
+})


### PR DESCRIPTION
## What this PR does / why we need it:

Adds new use case GetAllMetadataBlocks

## Which issue(s) this PR closes:

- Closes #168 

## Related Dataverse PRs:

None

## Special notes for your reviewer:

None

## Suggestions on how to test this:

Visual inspection and actions execution
