### PR TITLE
fix: change the data type of isReleased to boolean

### DIFF
--- a/src/collections/domain/models/Collection.ts
+++ b/src/collections/domain/models/Collection.ts
@@ -4,7 +4,7 @@ export interface Collection {
   id: number
   alias: string
   name: string
-  isReleased: string
+  isReleased: boolean
   affiliation?: string
   description?: string
   isPartOf: DvObjectOwnerNode

--- a/src/collections/infra/repositories/transformers/CollectionPayload.ts
+++ b/src/collections/infra/repositories/transformers/CollectionPayload.ts
@@ -5,7 +5,7 @@ export interface CollectionPayload {
   alias: string
   name: string
   affiliation?: string
-  isReleased: string
+  isReleased: boolean
   description?: string
   isPartOf: OwnerNodePayload
   inputLevels?: CollectionInputLevelPayload[]

--- a/test/testHelpers/collections/collectionHelper.ts
+++ b/test/testHelpers/collections/collectionHelper.ts
@@ -8,7 +8,7 @@ import { NewCollectionRequestPayload } from '../../../src/collections/infra/repo
 import { CollectionFacetPayload } from '../../../src/collections/infra/repositories/transformers/CollectionFacetPayload'
 
 const COLLECTION_ID = 11111
-const COLLECTION_IS_RELEASED = 'true'
+const COLLECTION_IS_RELEASED = true
 const COLLECTION_ALIAS_STR = 'secondCollection'
 const COLLECTION_NAME_STR = 'Laboratory Research'
 const COLLECTION_AFFILIATION_STR = 'Laboratory Research Corporation'


### PR DESCRIPTION
## What this PR does / why we need it:

The **isReleased** is supposed to be boolean, instead of string data type, in order to align with API responses.

## Which issue(s) this PR closes:

- Closes #189 

## Related Dataverse PRs:

- Depends on #

## Special notes for your reviewer:

After this work is done we should remove the hardcoded value from the frontend repo in [this part of the code](https://github.com/IQSS/dataverse-frontend/blob/develop/src/collection/infrastructure/mappers/JSCollectionMapper.ts#L17).

The isReleased property is correctly treated as a boolean in the frontend repo.

## Suggestions on how to test this:


## Is there a release notes update needed for this change?:
No

## Additional documentation:
