### PR TITLE
Add extra parameter to transform or not html to markdown

### DIFF
--- a/docs/useCases.md
+++ b/docs/useCases.md
@@ -287,7 +287,7 @@ The optional `datasetVersionId` parameter can correspond to a numeric version id
 
 There is an optional third parameter called `includeDeaccessioned`, which indicates whether to consider deaccessioned versions or not in the dataset search. If not set, the default value is `false`.
 
-There is an optional fourth parameter called `keepRawFields`, which indicates whether or not to keep the metadata fields as they are and avoid the transformation to markdown. The default value is `false`.
+There is an optional fourth parameter called `keepRawFields`, which indicates whether or not to keep the metadata fields as they are and avoid the transformation to Markdown. The default value is `false`.
 
 #### Get Dataset By Private URL Token
 

--- a/docs/useCases.md
+++ b/docs/useCases.md
@@ -309,7 +309,7 @@ getPrivateUrlDataset.execute(token).then((dataset: Dataset) => {
 
 _See [use case](../src/datasets/domain/useCases/GetPrivateUrlDataset.ts)_ definition.
 
-There is an optional second parameter called `keepRawFields`, which indicates whether or not to keep the metadata fields as they are and avoid the transformation to markdown. The default value is `false`.
+There is an optional second parameter called `keepRawFields`, which indicates whether or not to keep the metadata fields as they are and avoid the transformation to Markdown. The default value is `false`.
 
 #### Get Dataset Citation Text
 

--- a/docs/useCases.md
+++ b/docs/useCases.md
@@ -287,6 +287,8 @@ The optional `datasetVersionId` parameter can correspond to a numeric version id
 
 There is an optional third parameter called `includeDeaccessioned`, which indicates whether to consider deaccessioned versions or not in the dataset search. If not set, the default value is `false`.
 
+There is an optional fourth parameter called `keepRawFields`, which indicates whether or not to keep the metadata fields as they are and avoid the transformation to markdown. The default value is `false`.
+
 #### Get Dataset By Private URL Token
 
 Returns a [Dataset](../src/datasets/domain/models/Dataset.ts) instance, given an associated Private URL Token.
@@ -306,6 +308,8 @@ getPrivateUrlDataset.execute(token).then((dataset: Dataset) => {
 ```
 
 _See [use case](../src/datasets/domain/useCases/GetPrivateUrlDataset.ts)_ definition.
+
+There is an optional second parameter called `keepRawFields`, which indicates whether or not to keep the metadata fields as they are and avoid the transformation to markdown. The default value is `false`.
 
 #### Get Dataset Citation Text
 

--- a/src/datasets/domain/repositories/IDatasetsRepository.ts
+++ b/src/datasets/domain/repositories/IDatasetsRepository.ts
@@ -10,7 +10,8 @@ export interface IDatasetsRepository {
   getDataset(
     datasetId: number | string,
     datasetVersionId: string,
-    includeDeaccessioned: boolean
+    includeDeaccessioned: boolean,
+    keepRawFields: boolean
   ): Promise<Dataset>
   getDatasetLocks(datasetId: number | string): Promise<DatasetLock[]>
   getDatasetCitation(
@@ -18,7 +19,7 @@ export interface IDatasetsRepository {
     datasetVersionId: string,
     includeDeaccessioned: boolean
   ): Promise<string>
-  getPrivateUrlDataset(token: string): Promise<Dataset>
+  getPrivateUrlDataset(token: string, keepRawFields: boolean): Promise<Dataset>
   getAllDatasetPreviews(
     limit?: number,
     offset?: number,

--- a/src/datasets/domain/useCases/GetDataset.ts
+++ b/src/datasets/domain/useCases/GetDataset.ts
@@ -16,17 +16,20 @@ export class GetDataset implements UseCase<Dataset> {
    * @param {number | string} [datasetId] - The dataset identifier, which can be a string (for persistent identifiers), or a number (for numeric identifiers).
    * @param {string | DatasetNotNumberedVersion} [datasetVersionId=DatasetNotNumberedVersion.LATEST] - The dataset version identifier, which can be a version-specific numeric string (for example, 1.0) or a DatasetNotNumberedVersion enum value. If this parameter is not set, the default value is: DatasetNotNumberedVersion.LATEST
    * @param {boolean} [includeDeaccessioned=false] - Indicates whether to consider deaccessioned versions in the dataset search or not. The default value is false
+   * @param {boolean} [keepRawFields=false] - Indicates whether or not the use case should keep the metadata fields as they are and avoid the transformation to markdown. The default value is false.
    * @returns {Promise<Dataset>}
    */
   async execute(
     datasetId: number | string,
     datasetVersionId: string | DatasetNotNumberedVersion = DatasetNotNumberedVersion.LATEST,
-    includeDeaccessioned = false
+    includeDeaccessioned = false,
+    keepRawFields = false
   ): Promise<Dataset> {
     return await this.datasetsRepository.getDataset(
       datasetId,
       datasetVersionId,
-      includeDeaccessioned
+      includeDeaccessioned,
+      keepRawFields
     )
   }
 }

--- a/src/datasets/domain/useCases/GetPrivateUrlDataset.ts
+++ b/src/datasets/domain/useCases/GetPrivateUrlDataset.ts
@@ -13,9 +13,10 @@ export class GetPrivateUrlDataset implements UseCase<Dataset> {
    * Returns a Dataset instance, given an associated Private URL Token.
    *
    * @param {string} [token] - A Private URL token.
+   * @param {boolean} [keepRawFields=false] - Indicates whether or not the use case should keep the metadata fields as they are and avoid the transformation to markdown. The default value is false.
    * @returns {Promise<Dataset>}
    */
-  async execute(token: string): Promise<Dataset> {
-    return await this.datasetsRepository.getPrivateUrlDataset(token)
+  async execute(token: string, keepRawFields = false): Promise<Dataset> {
+    return await this.datasetsRepository.getPrivateUrlDataset(token, keepRawFields)
   }
 }

--- a/src/datasets/infra/repositories/DatasetsRepository.ts
+++ b/src/datasets/infra/repositories/DatasetsRepository.ts
@@ -33,7 +33,7 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
       })
   }
 
-  public async getPrivateUrlDataset(token: string): Promise<Dataset> {
+  public async getPrivateUrlDataset(token: string, keepRawFields: boolean): Promise<Dataset> {
     return this.doGet(
       this.buildApiEndpoint(this.datasetsResourceName, `privateUrlDatasetVersion/${token}`),
       false,
@@ -41,7 +41,7 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
         returnOwners: true
       }
     )
-      .then((response) => transformVersionResponseToDataset(response))
+      .then((response) => transformVersionResponseToDataset(response, keepRawFields))
       .catch((error) => {
         throw error
       })
@@ -50,7 +50,8 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
   public async getDataset(
     datasetId: number | string,
     datasetVersionId: string,
-    includeDeaccessioned: boolean
+    includeDeaccessioned: boolean,
+    keepRawFields: boolean
   ): Promise<Dataset> {
     return this.doGet(
       this.buildApiEndpoint(this.datasetsResourceName, `versions/${datasetVersionId}`, datasetId),
@@ -61,7 +62,7 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
         returnOwners: true
       }
     )
-      .then((response) => transformVersionResponseToDataset(response))
+      .then((response) => transformVersionResponseToDataset(response, keepRawFields))
       .catch((error) => {
         throw error
       })

--- a/src/files/infra/repositories/transformers/fileTransformers.ts
+++ b/src/files/infra/repositories/transformers/fileTransformers.ts
@@ -27,7 +27,7 @@ export const transformFileResponseToFile = (
   if (returnDatasetVersion) {
     return [
       transformFilePayloadToFile(filePayload),
-      transformVersionPayloadToDataset(filePayload.datasetVersion)
+      transformVersionPayloadToDataset(filePayload.datasetVersion, false)
     ]
   }
   return transformFilePayloadToFile(filePayload)

--- a/test/functional/datasets/GetDataset.test.ts
+++ b/test/functional/datasets/GetDataset.test.ts
@@ -1,0 +1,109 @@
+import { ApiConfig, createDataset, getDataset, ReadError } from '../../../src'
+import { DataverseApiAuthMechanism } from '../../../src/core/infra/repositories/ApiConfig'
+import { DatasetDescription } from '../../../src/datasets/domain/models/Dataset'
+import { deleteUnpublishedDatasetViaApi } from '../../testHelpers/datasets/datasetHelper'
+import { TestConstants } from '../../testHelpers/TestConstants'
+
+const testNewDataset = {
+  metadataBlockValues: [
+    {
+      name: 'citation',
+      fields: {
+        title: 'Dataset created using the createDataset use case',
+        author: [
+          {
+            authorName: 'Admin, Dataverse',
+            authorAffiliation: 'Dataverse.org'
+          },
+          {
+            authorName: 'Owner, Dataverse',
+            authorAffiliation: 'Dataversedemo.org'
+          }
+        ],
+        datasetContact: [
+          {
+            datasetContactEmail: 'finch@mailinator.com',
+            datasetContactName: 'Finch, Fiona'
+          }
+        ],
+        dsDescription: [
+          {
+            dsDescriptionValue: 'Hello <b>world</b>'
+          }
+        ],
+        subject: ['Medicine, Health and Life Sciences']
+      }
+    }
+  ]
+}
+
+describe('execute', () => {
+  beforeEach(async () => {
+    ApiConfig.init(
+      TestConstants.TEST_API_URL,
+      DataverseApiAuthMechanism.API_KEY,
+      process.env.TEST_API_KEY
+    )
+  })
+
+  test('should successfully get a dataset when a valid id is sent', async () => {
+    const createdDatasetIdentifiers = await createDataset.execute(testNewDataset)
+
+    const dataset = await getDataset.execute(createdDatasetIdentifiers.numericId)
+    expect(dataset).not.toBeNull()
+    expect(dataset.id).toBe(createdDatasetIdentifiers.numericId)
+
+    await deleteUnpublishedDatasetViaApi(createdDatasetIdentifiers.numericId)
+  })
+
+  test('should successfully get a dataset when a valid persistent id is sent', async () => {
+    const createdDatasetIdentifiers = await createDataset.execute(testNewDataset)
+
+    const dataset = await getDataset.execute(createdDatasetIdentifiers.persistentId)
+    expect(dataset).not.toBeNull()
+    expect(dataset.id).toBe(createdDatasetIdentifiers.numericId)
+
+    await deleteUnpublishedDatasetViaApi(createdDatasetIdentifiers.numericId)
+  })
+
+  test('should throw an error when an invalid id is sent', async () => {
+    const nonExistentTestDatasetId = 'non-existent-dataset'
+    const expectedError = new ReadError(`[400] Bad dataset ID number: ${nonExistentTestDatasetId}.`)
+
+    await expect(getDataset.execute(nonExistentTestDatasetId)).rejects.toThrow(expectedError)
+  })
+
+  test('should return metadata fields in markdown format when keepRawFields is false', async () => {
+    const createdDatasetIdentifiers = await createDataset.execute(testNewDataset)
+
+    const dataset = await getDataset.execute(
+      createdDatasetIdentifiers.numericId,
+      undefined,
+      false,
+      false
+    )
+
+    expect(
+      (dataset.metadataBlocks[0].fields.dsDescription[0] as DatasetDescription).dsDescriptionValue
+    ).toBe('Hello **world**')
+
+    await deleteUnpublishedDatasetViaApi(createdDatasetIdentifiers.numericId)
+  })
+
+  test('should not return metadata fields in markdown format when keepRawFields is true', async () => {
+    const createdDatasetIdentifiers = await createDataset.execute(testNewDataset)
+
+    const dataset = await getDataset.execute(
+      createdDatasetIdentifiers.numericId,
+      undefined,
+      false,
+      true
+    )
+
+    expect(
+      (dataset.metadataBlocks[0].fields.dsDescription[0] as DatasetDescription).dsDescriptionValue
+    ).toBe('Hello <b>world</b>')
+
+    await deleteUnpublishedDatasetViaApi(createdDatasetIdentifiers.numericId)
+  })
+})

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -157,6 +157,7 @@ describe('DatasetsRepository', () => {
         const actual = await sut.getDataset(
           testDatasetIds.numericId,
           DatasetNotNumberedVersion.LATEST,
+          false,
           false
         )
         expect(actual.id).toBe(testDatasetIds.numericId)
@@ -170,7 +171,8 @@ describe('DatasetsRepository', () => {
         const actual = await sut.getDataset(
           testDatasetIds.numericId,
           DatasetNotNumberedVersion.LATEST,
-          true
+          true,
+          false
         )
 
         expect(actual.id).toBe(testDatasetIds.numericId)
@@ -181,7 +183,8 @@ describe('DatasetsRepository', () => {
         const actual = await sut.getDataset(
           testDatasetIds.numericId,
           DatasetNotNumberedVersion.LATEST,
-          true
+          true,
+          false
         )
         expect(actual.id).toBe(testDatasetIds.numericId)
         ApiConfig.init(
@@ -196,7 +199,7 @@ describe('DatasetsRepository', () => {
           `[404] Dataset version ${DatasetNotNumberedVersion.LATEST} of dataset ${testDatasetIds.numericId} not found`
         )
         await expect(
-          sut.getDataset(testDatasetIds.numericId, DatasetNotNumberedVersion.LATEST, false)
+          sut.getDataset(testDatasetIds.numericId, DatasetNotNumberedVersion.LATEST, false, false)
         ).rejects.toThrow(expectedError)
       })
 
@@ -206,7 +209,7 @@ describe('DatasetsRepository', () => {
         )
 
         await expect(
-          sut.getDataset(nonExistentTestDatasetId, DatasetNotNumberedVersion.LATEST, false)
+          sut.getDataset(nonExistentTestDatasetId, DatasetNotNumberedVersion.LATEST, false, false)
         ).rejects.toThrow(expectedError)
       })
     })
@@ -226,11 +229,13 @@ describe('DatasetsRepository', () => {
         const createdDataset = await sut.getDataset(
           testDatasetIds.numericId,
           DatasetNotNumberedVersion.LATEST,
+          false,
           false
         )
         const actual = await sut.getDataset(
           createdDataset.persistentId,
           DatasetNotNumberedVersion.LATEST,
+          false,
           false
         )
         expect(actual.id).toBe(testDatasetIds.numericId)
@@ -242,7 +247,7 @@ describe('DatasetsRepository', () => {
           `[400] Bad dataset ID number: ${testWrongPersistentId}.`
         )
         await expect(
-          sut.getDataset(testWrongPersistentId, DatasetNotNumberedVersion.LATEST, false)
+          sut.getDataset(testWrongPersistentId, DatasetNotNumberedVersion.LATEST, false, false)
         ).rejects.toThrow(expectedError)
       })
     })
@@ -263,6 +268,7 @@ describe('DatasetsRepository', () => {
         const actual = await sut.getDataset(
           createdDatasetNumericId,
           DatasetNotNumberedVersion.LATEST,
+          false,
           false
         )
 
@@ -294,13 +300,13 @@ describe('DatasetsRepository', () => {
 
     describe('getPrivateUrlDataset', () => {
       test('should return dataset when token is valid', async () => {
-        const actual = await sut.getPrivateUrlDataset(privateUrlToken)
+        const actual = await sut.getPrivateUrlDataset(privateUrlToken, false)
         expect(actual.id).toBe(testDatasetIds.numericId)
       })
 
       test('should return error when token is not valid', async () => {
         const expectedError = new ReadError(expectedErrorInvalidToken)
-        await expect(sut.getPrivateUrlDataset('invalidToken')).rejects.toThrow(expectedError)
+        await expect(sut.getPrivateUrlDataset('invalidToken', false)).rejects.toThrow(expectedError)
       })
     })
 
@@ -471,6 +477,7 @@ describe('DatasetsRepository', () => {
       const actualCreatedDataset = await sut.getDataset(
         createdDataset.numericId,
         DatasetNotNumberedVersion.LATEST,
+        false,
         false
       )
 
@@ -528,6 +535,7 @@ describe('DatasetsRepository', () => {
       const newDatasetVersion = await sut.getDataset(
         testDatasetIds.numericId,
         DatasetNotNumberedVersion.LATEST,
+        false,
         false
       )
 
@@ -568,6 +576,7 @@ describe('DatasetsRepository', () => {
       const datasetAfterFirstPublish = await sut.getDataset(
         testDatasetIds.numericId,
         DatasetNotNumberedVersion.LATEST,
+        false,
         false
       )
 
@@ -587,6 +596,7 @@ describe('DatasetsRepository', () => {
       const datasetAfterUpdatingCurrentVersion = await sut.getDataset(
         testDatasetIds.numericId,
         DatasetNotNumberedVersion.LATEST,
+        false,
         false
       )
 
@@ -651,6 +661,7 @@ describe('DatasetsRepository', () => {
       const actualCreatedDataset = await sut.getDataset(
         createdDataset.numericId,
         DatasetNotNumberedVersion.LATEST,
+        false,
         false
       )
 
@@ -668,6 +679,7 @@ describe('DatasetsRepository', () => {
       const actualUpdatedDataset = await sut.getDataset(
         createdDataset.numericId,
         DatasetNotNumberedVersion.LATEST,
+        false,
         false
       )
 

--- a/test/unit/datasets/DatasetsRepository.test.ts
+++ b/test/unit/datasets/DatasetsRepository.test.ts
@@ -125,7 +125,8 @@ describe('DatasetsRepository', () => {
         let actual = await sut.getDataset(
           testDatasetModel.id,
           testVersionId,
-          testIncludeDeaccessioned
+          testIncludeDeaccessioned,
+          false
         )
 
         expect(axios.get).toHaveBeenCalledWith(expectedApiEndpoint, expectedRequestConfigApiKey)
@@ -133,7 +134,12 @@ describe('DatasetsRepository', () => {
 
         // Session cookie auth
         ApiConfig.init(TestConstants.TEST_API_URL, DataverseApiAuthMechanism.SESSION_COOKIE)
-        actual = await sut.getDataset(testDatasetModel.id, testVersionId, testIncludeDeaccessioned)
+        actual = await sut.getDataset(
+          testDatasetModel.id,
+          testVersionId,
+          testIncludeDeaccessioned,
+          false
+        )
         expect(axios.get).toHaveBeenCalledWith(
           expectedApiEndpoint,
           expectedRequestConfigSessionCookie
@@ -154,7 +160,8 @@ describe('DatasetsRepository', () => {
         const actual = await sut.getDataset(
           testDatasetModel.id,
           testVersionId,
-          testIncludeDeaccessioned
+          testIncludeDeaccessioned,
+          false
         )
 
         expect(axios.get).toHaveBeenCalledWith(
@@ -177,7 +184,8 @@ describe('DatasetsRepository', () => {
         const actual = await sut.getDataset(
           testDatasetModel.id,
           testVersionId,
-          testIncludeDeaccessioned
+          testIncludeDeaccessioned,
+          false
         )
 
         expect(axios.get).toHaveBeenCalledWith(
@@ -203,7 +211,8 @@ describe('DatasetsRepository', () => {
         const actual = await sut.getDataset(
           testDatasetModel.id,
           testVersionId,
-          testIncludeDeaccessioned
+          testIncludeDeaccessioned,
+          false
         )
 
         expect(axios.get).toHaveBeenCalledWith(
@@ -218,7 +227,7 @@ describe('DatasetsRepository', () => {
 
         let error = undefined as unknown as ReadError
         await sut
-          .getDataset(testDatasetModel.id, testVersionId, testIncludeDeaccessioned)
+          .getDataset(testDatasetModel.id, testVersionId, testIncludeDeaccessioned, false)
           .catch((e) => (error = e))
 
         expect(axios.get).toHaveBeenCalledWith(
@@ -237,7 +246,8 @@ describe('DatasetsRepository', () => {
         let actual = await sut.getDataset(
           testDatasetModel.persistentId,
           testVersionId,
-          testIncludeDeaccessioned
+          testIncludeDeaccessioned,
+          false
         )
 
         expect(axios.get).toHaveBeenCalledWith(expectedApiEndpoint, expectedRequestConfigApiKey)
@@ -249,7 +259,8 @@ describe('DatasetsRepository', () => {
         actual = await sut.getDataset(
           testDatasetModel.persistentId,
           testVersionId,
-          testIncludeDeaccessioned
+          testIncludeDeaccessioned,
+          false
         )
 
         expect(axios.get).toHaveBeenCalledWith(
@@ -264,7 +275,7 @@ describe('DatasetsRepository', () => {
 
         let error = undefined as unknown as ReadError
         await sut
-          .getDataset(testDatasetModel.persistentId, testVersionId, testIncludeDeaccessioned)
+          .getDataset(testDatasetModel.persistentId, testVersionId, testIncludeDeaccessioned, false)
           .catch((e) => (error = e))
 
         expect(axios.get).toHaveBeenCalledWith(
@@ -284,7 +295,7 @@ describe('DatasetsRepository', () => {
     test('should return Dataset when response is successful', async () => {
       jest.spyOn(axios, 'get').mockResolvedValue(testDatasetVersionSuccessfulResponse)
 
-      const actual = await sut.getPrivateUrlDataset(testPrivateUrlToken)
+      const actual = await sut.getPrivateUrlDataset(testPrivateUrlToken, false)
 
       expect(axios.get).toHaveBeenCalledWith(
         `${TestConstants.TEST_API_URL}/datasets/privateUrlDatasetVersion/${testPrivateUrlToken}`,
@@ -297,7 +308,7 @@ describe('DatasetsRepository', () => {
       jest.spyOn(axios, 'get').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
 
       let error = undefined as unknown as ReadError
-      await sut.getPrivateUrlDataset(testPrivateUrlToken).catch((e) => (error = e))
+      await sut.getPrivateUrlDataset(testPrivateUrlToken, false).catch((e) => (error = e))
 
       expect(axios.get).toHaveBeenCalledWith(
         `${TestConstants.TEST_API_URL}/datasets/privateUrlDatasetVersion/${testPrivateUrlToken}`,
@@ -821,7 +832,7 @@ describe('DatasetsRepository', () => {
     test('should return error result on error response', async () => {
       jest.spyOn(axios, 'post').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
 
-      let error: WriteError = undefined
+      let error: WriteError | undefined = undefined
       await sut.publishDataset(testDatasetModel.id, testVersionUpdateType).catch((e) => (error = e))
 
       expect(axios.post).toHaveBeenCalledWith(
@@ -878,7 +889,7 @@ describe('DatasetsRepository', () => {
     test('should return error result on error response', async () => {
       jest.spyOn(axios, 'put').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
 
-      let error: WriteError = undefined
+      let error: WriteError | undefined = undefined
       await sut
         .updateDataset(testDatasetModel.id, testNewDataset, testMetadataBlocks)
         .catch((e) => (error = e))

--- a/test/unit/datasets/GetPrivateUrlDataset.test.ts
+++ b/test/unit/datasets/GetPrivateUrlDataset.test.ts
@@ -15,7 +15,10 @@ describe('execute', () => {
     const actual = await sut.execute(testPrivateUrlToken)
 
     expect(actual).toEqual(testDataset)
-    expect(datasetsRepositoryStub.getPrivateUrlDataset).toHaveBeenCalledWith(testPrivateUrlToken)
+    expect(datasetsRepositoryStub.getPrivateUrlDataset).toHaveBeenCalledWith(
+      testPrivateUrlToken,
+      false
+    )
   })
 
   test('should return error result on repository error', async () => {


### PR DESCRIPTION
## What this PR does / why we need it:
An additional parameter is added to the `getDataset` and `getPrivateUrlDataset` use cases to configure whether we want the values of the metadata fields containing html to be transformed into markup or not.

## Which issue(s) this PR closes:

- Closes #203 

## Suggestions on how to test this:
Code visual inspection. Run tests.
