### PR TITLE
remove test step from pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "format",
     "typecheck",
     "lint:fix",
-    "git:add",
-    "test:coverage:check"
+    "git:add"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What this PR does / why we need it:
The test step in the pre-commit hook is very time consuming. So for the sake of efficiency, we want to remove the test step (since it can be done on demand locally, and will also be triggered in Github Actions).  The other checks for linting and formatting are much faster, so they have been kept

## Which issue(s) this PR closes:

- Closes #209 

## Related Dataverse PRs:

- Depends on #

## Special notes for your reviewer:

## Suggestions on how to test this:
Inspect the code change, optionally try a local commit and see that the other checks run.

## Is there a release notes update needed for this change?:
No
## Additional documentation:
