### PR TITLE
Change file creation date and publication date in FileModel from date object to string type

### DIFF
--- a/src/files/domain/models/FileModel.ts
+++ b/src/files/domain/models/FileModel.ts
@@ -28,8 +28,8 @@ export interface FileModel {
   checksum?: FileChecksum
   metadataId?: number
   tabularTags?: string[]
-  creationDate?: Date
-  publicationDate?: Date
+  creationDate?: string
+  publicationDate?: string
   deleted: boolean
   tabularData: boolean
   fileAccessRequest?: boolean

--- a/src/files/infra/repositories/transformers/fileTransformers.ts
+++ b/src/files/infra/repositories/transformers/fileTransformers.ts
@@ -81,10 +81,10 @@ const transformFilePayloadToFile = (filePayload: FilePayload): FileModel => {
     ...(filePayload.dataFile.fileMetadataId && { metadataId: filePayload.dataFile.fileMetadataId }),
     ...(filePayload.dataFile.tabularTags && { tabularTags: filePayload.dataFile.tabularTags }),
     ...(filePayload.dataFile.creationDate && {
-      creationDate: new Date(filePayload.dataFile.creationDate)
+      creationDate: filePayload.dataFile.creationDate
     }),
     ...(filePayload.dataFile.publicationDate && {
-      publicationDate: new Date(filePayload.dataFile.publicationDate)
+      publicationDate: filePayload.dataFile.publicationDate
     }),
     deleted: filePayload.dataFile.deleted,
     tabularData: filePayload.dataFile.tabularData,

--- a/test/testHelpers/files/filesHelper.ts
+++ b/test/testHelpers/files/filesHelper.ts
@@ -32,7 +32,7 @@ export const createFileModel = (): FileModel => {
     previousDataFileId: 4,
     md5: '29e413e0c881e17314ce8116fed4d1a7',
     metadataId: 4,
-    creationDate: new Date('2023-07-11'),
+    creationDate: '2023-07-11',
     embargo: {
       dateAvailable: new Date('2023-07-11'),
       reason: 'test'
@@ -59,7 +59,7 @@ export const createFileModel = (): FileModel => {
     originalSize: 127426,
     originalName: 'originalName',
     tabularTags: ['tag1', 'tag2'],
-    publicationDate: new Date('2023-07-11')
+    publicationDate: '2023-07-11'
   }
 }
 


### PR DESCRIPTION
## What this PR does / why we need it:
Change the e file creation date and publication date from Date object to string type(as same as the payload format) to avoid a date conflict

## Which issue(s) this PR closes:

- Closes #223 

## Related Dataverse PRs:

- Depends on #

## Special notes for your reviewer:

## Suggestions on how to test this:
- run unit test and integration test on it

## Is there a release notes update needed for this change?:

## Additional documentation:
