### PR TITLE
Update file restriction fields and tabular information to the file preview

### DIFF
--- a/src/datasets/domain/models/DatasetPreview.ts
+++ b/src/datasets/domain/models/DatasetPreview.ts
@@ -13,4 +13,5 @@ export interface DatasetPreview {
   publicationStatuses: PublicationStatus[]
   parentCollectionName: string
   parentCollectionAlias: string
+  imageUrl?: string
 }

--- a/src/datasets/infra/repositories/transformers/DatasetPreviewPayload.ts
+++ b/src/datasets/infra/repositories/transformers/DatasetPreviewPayload.ts
@@ -14,4 +14,5 @@ export interface DatasetPreviewPayload {
   publicationStatuses: string[]
   identifier_of_dataverse: string
   name_of_dataverse: string
+  image_url?: string
 }

--- a/src/datasets/infra/repositories/transformers/datasetPreviewsTransformers.ts
+++ b/src/datasets/infra/repositories/transformers/datasetPreviewsTransformers.ts
@@ -47,6 +47,9 @@ export const transformDatasetPreviewPayloadToDatasetPreview = (
     description: datasetPreviewPayload.description,
     publicationStatuses: publicationStatuses,
     parentCollectionAlias: datasetPreviewPayload.identifier_of_dataverse,
-    parentCollectionName: datasetPreviewPayload.name_of_dataverse
+    parentCollectionName: datasetPreviewPayload.name_of_dataverse,
+    ...(datasetPreviewPayload.image_url && {
+      imageUrl: datasetPreviewPayload.image_url
+    })
   }
 }

--- a/src/files/domain/models/FilePreview.ts
+++ b/src/files/domain/models/FilePreview.ts
@@ -23,7 +23,7 @@ export interface FilePreview {
   releaseOrCreateDate: Date
   restricted: boolean
   canDownloadFile: boolean
-  categories: string[]
+  categories?: string[]
   tabularTags?: string[]
   variables?: number
   observations?: number

--- a/src/files/domain/models/FilePreview.ts
+++ b/src/files/domain/models/FilePreview.ts
@@ -21,6 +21,12 @@ export interface FilePreview {
   datasetCitation: string
   publicationStatuses: PublicationStatus[]
   releaseOrCreateDate: Date
+  restricted: boolean
+  canDownloadFile: boolean
+  categories: string[]
+  tabularTags?: string[]
+  variables?: number
+  observations?: number
 }
 
 export interface FilePreviewChecksum {

--- a/src/files/infra/repositories/transformers/FilePreviewPayload.ts
+++ b/src/files/infra/repositories/transformers/FilePreviewPayload.ts
@@ -19,6 +19,12 @@ export interface FilePreviewPayload {
   dataset_citation: string
   publicationStatuses: string[]
   releaseOrCreateDate: string
+  restricted: boolean
+  canDownloadFile: boolean
+  categories: string[]
+  tabularTags?: string[]
+  variables?: number
+  observations?: number
 }
 
 export interface FilePreviewChecksumPayload {

--- a/src/files/infra/repositories/transformers/FilePreviewPayload.ts
+++ b/src/files/infra/repositories/transformers/FilePreviewPayload.ts
@@ -21,7 +21,7 @@ export interface FilePreviewPayload {
   releaseOrCreateDate: string
   restricted: boolean
   canDownloadFile: boolean
-  categories: string[]
+  categories?: string[]
   tabularTags?: string[]
   variables?: number
   observations?: number

--- a/src/files/infra/repositories/transformers/filePreviewTransformers.ts
+++ b/src/files/infra/repositories/transformers/filePreviewTransformers.ts
@@ -36,6 +36,14 @@ export const transformFilePreviewPayloadToFilePreview = (
     datasetPersistentId: filePreviewPayload.dataset_persistent_id,
     datasetCitation: filePreviewPayload.dataset_citation,
     publicationStatuses: publicationStatuses,
-    releaseOrCreateDate: new Date(filePreviewPayload.releaseOrCreateDate)
+    releaseOrCreateDate: new Date(filePreviewPayload.releaseOrCreateDate),
+    restricted: filePreviewPayload.restricted,
+    canDownloadFile: filePreviewPayload.canDownloadFile,
+    categories: filePreviewPayload.categories,
+    ...(filePreviewPayload.tabularTags && {
+      tabularTags: filePreviewPayload.tabularTags
+    }),
+    ...(filePreviewPayload.variables && { variables: filePreviewPayload.variables }),
+    ...(filePreviewPayload.observations && { observations: filePreviewPayload.observations })
   }
 }

--- a/src/files/infra/repositories/transformers/filePreviewTransformers.ts
+++ b/src/files/infra/repositories/transformers/filePreviewTransformers.ts
@@ -39,7 +39,7 @@ export const transformFilePreviewPayloadToFilePreview = (
     releaseOrCreateDate: new Date(filePreviewPayload.releaseOrCreateDate),
     restricted: filePreviewPayload.restricted,
     canDownloadFile: filePreviewPayload.canDownloadFile,
-    categories: filePreviewPayload.categories,
+    ...(filePreviewPayload.categories && { categories: filePreviewPayload.categories }),
     ...(filePreviewPayload.tabularTags && {
       tabularTags: filePreviewPayload.tabularTags
     }),

--- a/test/integration/collections/CollectionsRepository.test.ts
+++ b/test/integration/collections/CollectionsRepository.test.ts
@@ -399,6 +399,7 @@ describe('CollectionsRepository', () => {
       )
       expect(actualDatasetPreview.parentCollectionName).toBe(expectedCollectionsName)
       expect(actualDatasetPreview.type).toBe(CollectionItemType.DATASET)
+      expect(actualDatasetPreview.imageUrl).toBe('http://dataverse.com')
 
       expect(actualCollectionPreview.name).toBe(expectedCollectionsName)
       expect(actualCollectionPreview.alias).toBe(testSubCollectionAlias)

--- a/test/integration/collections/CollectionsRepository.test.ts
+++ b/test/integration/collections/CollectionsRepository.test.ts
@@ -399,7 +399,6 @@ describe('CollectionsRepository', () => {
       )
       expect(actualDatasetPreview.parentCollectionName).toBe(expectedCollectionsName)
       expect(actualDatasetPreview.type).toBe(CollectionItemType.DATASET)
-      expect(actualDatasetPreview.imageUrl).toBe('http://dataverse.com')
 
       expect(actualCollectionPreview.name).toBe(expectedCollectionsName)
       expect(actualCollectionPreview.alias).toBe(testSubCollectionAlias)

--- a/test/integration/collections/CollectionsRepository.test.ts
+++ b/test/integration/collections/CollectionsRepository.test.ts
@@ -20,8 +20,12 @@ import {
   ROOT_COLLECTION_ALIAS
 } from '../../testHelpers/collections/collectionHelper'
 import { CollectionPayload } from '../../../src/collections/infra/repositories/transformers/CollectionPayload'
-import { uploadFileViaApi } from '../../testHelpers/files/filesHelper'
-import { deleteUnpublishedDatasetViaApi } from '../../testHelpers/datasets/datasetHelper'
+import { updateFileTabularTags, uploadFileViaApi } from '../../testHelpers/files/filesHelper'
+import {
+  deletePublishedDatasetViaApi,
+  deleteUnpublishedDatasetViaApi,
+  publishDatasetViaApi
+} from '../../testHelpers/datasets/datasetHelper'
 import { PublicationStatus } from '../../../src/core/domain/models/PublicationStatus'
 import { CollectionType } from '../../../src/collections/domain/models/CollectionType'
 import {
@@ -33,7 +37,7 @@ describe('CollectionsRepository', () => {
   const testCollectionAlias = 'collectionsRepositoryTestCollection'
   const sut: CollectionsRepository = new CollectionsRepository()
   let testCollectionId: number
-
+  const currentYear = new Date().getFullYear()
   beforeAll(async () => {
     ApiConfig.init(
       TestConstants.TEST_API_URL,
@@ -292,8 +296,7 @@ describe('CollectionsRepository', () => {
       const actualCollectionPreview = actual.items[2] as CollectionPreview
 
       const expectedFileMd5 = '68b22040025784da775f55cfcb6dee2e'
-      const expectedDatasetCitationFragment =
-        'Admin, Dataverse; Owner, Dataverse, 2025, "Dataset created using the createDataset use case'
+      const expectedDatasetCitationFragment = `Admin, Dataverse; Owner, Dataverse, ${currentYear}, "Dataset created using the createDataset use case"`
       const expectedDatasetDescription = 'Dataset created using the createDataset use case'
       const expectedFileName = 'test-file-1.txt'
       const expectedCollectionsName = 'Scientific Research'
@@ -657,6 +660,156 @@ describe('CollectionsRepository', () => {
       await expect(
         sut.getCollectionItems(TestConstants.TEST_DUMMY_COLLECTION_ALIAS)
       ).rejects.toThrow(expectedError)
+    })
+  })
+
+  describe('getCollectionItems for published tabular file', () => {
+    let testDatasetIds: CreatedDatasetIdentifiers
+    const testTextFile4Name = 'test-file-4.tab'
+    const testSubCollectionAlias = 'collectionsRepositoryTestSubCollection'
+
+    beforeAll(async () => {
+      await sut.publishCollection(testCollectionId).catch(() => {
+        throw new Error(`Tests beforeAll(): Error while publishing collection ${testCollectionId}`)
+      })
+
+      const collectionPayload = await createCollectionViaApi(
+        testSubCollectionAlias,
+        testCollectionAlias
+      ).catch(() => {
+        throw new Error(
+          `Tests beforeAll(): Error while creating subcollection ${testSubCollectionAlias}`
+        )
+      })
+
+      await sut.publishCollection(collectionPayload.id).catch(() => {
+        throw new Error(`Tests beforeAll(): Error while publishing collection ${testCollectionId}`)
+      })
+
+      try {
+        testDatasetIds = await createDataset.execute(
+          TestConstants.TEST_NEW_DATASET_DTO,
+          testSubCollectionAlias
+        )
+      } catch (error) {
+        throw new Error('Tests beforeAll(): Error while creating test dataset')
+      }
+      const uploadFileViaApiResult = await uploadFileViaApi(
+        testDatasetIds.numericId,
+        testTextFile4Name,
+        {
+          categories: ['tabular data']
+        }
+      ).catch(() => {
+        throw new Error(`Tests beforeAll(): Error while uploading file ${testTextFile4Name}`)
+      })
+      await new Promise((resolve) => setTimeout(resolve, 5000))
+
+      await updateFileTabularTags(uploadFileViaApiResult.data.data.files[0].dataFile.id, [
+        'Survey',
+        'Genomics'
+      ]).catch(() => {
+        throw new Error(
+          `Tests beforeAll(): Error while updating file tabular tags ${uploadFileViaApiResult.data.data.files[0].dataFile.id}`
+        )
+      })
+
+      await publishDatasetViaApi(testDatasetIds.numericId).catch(() => {
+        throw new Error(
+          `Tests beforeAll(): Error while publishing dataset ${testDatasetIds.numericId}`
+        )
+      })
+    })
+
+    afterAll(async () => {
+      try {
+        await deletePublishedDatasetViaApi(testDatasetIds.persistentId)
+      } catch (error) {
+        throw new Error(
+          `Tests afterAll(): Error while deleting test dataset ${testDatasetIds.persistentId}`
+        )
+      }
+      try {
+        await deleteCollectionViaApi(testSubCollectionAlias)
+      } catch (error) {
+        throw new Error(
+          `Tests afterAll(): Error while deleting subcollection ${testSubCollectionAlias}`
+        )
+      }
+    })
+
+    test('should return collection items given a valid collection alias', async () => {
+      // Give enough time to Solr for indexing
+      await new Promise((resolve) => setTimeout(resolve, 5000))
+
+      const actual = await sut.getCollectionItems(testCollectionAlias)
+      const actualFilePreview = actual.items[1] as FilePreview
+      const actualDatasetPreview = actual.items[0] as DatasetPreview
+      const actualCollectionPreview = actual.items[2] as CollectionPreview
+
+      const expectedFileMd5 = '77c7f03a7d7772907b43f0b322cef723'
+
+      const expectedDatasetCitationFragment = `Admin, Dataverse; Owner, Dataverse, ${currentYear}, "Dataset created using the createDataset use case`
+      const expectedDatasetDescription = 'Dataset created using the createDataset use case'
+      const expectedFileName = 'test-file-4.tab'
+      const expectedCollectionsName = 'Scientific Research'
+
+      expect(actualFilePreview.checksum?.type).toBe('MD5')
+      expect(actualFilePreview.checksum?.value).toBe(expectedFileMd5)
+      expect(actualFilePreview.datasetCitation).toContain(expectedDatasetCitationFragment)
+      expect(actualFilePreview.datasetId).toBe(testDatasetIds.numericId)
+      expect(actualFilePreview.datasetName).toBe(expectedDatasetDescription)
+      expect(actualFilePreview.datasetPersistentId).toBe(testDatasetIds.persistentId)
+      expect(actualFilePreview.description).toBe('')
+      expect(actualFilePreview.fileContentType).toBe('text/tab-separated-values')
+      expect(actualFilePreview.fileId).not.toBeUndefined()
+      expect(actualFilePreview.fileType).toBe('Tab-Delimited')
+      expect(actualFilePreview.md5).toBe(expectedFileMd5)
+      expect(actualFilePreview.name).toBe(expectedFileName)
+      expect(actualFilePreview.publicationStatuses[0]).toBe(PublicationStatus.Published)
+      expect(actualFilePreview.sizeInBytes).toBe(137)
+      expect(actualFilePreview.url).not.toBeUndefined()
+      expect(actualFilePreview.releaseOrCreateDate).not.toBeUndefined()
+      expect(actualFilePreview.type).toBe(CollectionItemType.FILE)
+      expect(actualFilePreview.restricted).toBe(false)
+      expect(actualFilePreview.canDownloadFile).toBe(true)
+      expect(actualFilePreview.categories).toEqual(['tabular data'])
+      expect(actualFilePreview.tabularTags).toEqual(['Genomics', 'Survey'])
+      expect(actualFilePreview.observations).toBe(10)
+      expect(actualFilePreview.variables).toBe(3)
+
+      expect(actualDatasetPreview.title).toBe(expectedDatasetDescription)
+      expect(actualDatasetPreview.citation).toContain(expectedDatasetCitationFragment)
+      expect(actualDatasetPreview.description).toBe('This is the description of the dataset.')
+      expect(actualDatasetPreview.persistentId).not.toBeUndefined()
+      expect(actualDatasetPreview.persistentId).not.toBeUndefined()
+      expect(actualDatasetPreview.publicationStatuses[0]).toBe(PublicationStatus.Published)
+      expect(actualDatasetPreview.versionId).not.toBeUndefined()
+      expect(actualDatasetPreview.versionInfo.createTime).not.toBeUndefined()
+      expect(actualDatasetPreview.versionInfo.lastUpdateTime).not.toBeUndefined()
+      expect(actualDatasetPreview.versionInfo.majorNumber).toBe(1)
+      expect(actualDatasetPreview.versionInfo.minorNumber).toBe(0)
+      expect(actualDatasetPreview.versionInfo.state).toBe('RELEASED')
+      expect(actualDatasetPreview.parentCollectionAlias).toBe(
+        'collectionsRepositoryTestSubCollection'
+      )
+      expect(actualDatasetPreview.parentCollectionName).toBe(expectedCollectionsName)
+      expect(actualDatasetPreview.type).toBe(CollectionItemType.DATASET)
+
+      expect(actualCollectionPreview.name).toBe(expectedCollectionsName)
+      expect(actualCollectionPreview.alias).toBe(testSubCollectionAlias)
+      expect(actualCollectionPreview.description).toBe('We do all the science.')
+      expect(actualCollectionPreview.imageUrl).toBe(undefined)
+      expect(actualCollectionPreview.parentAlias).toBe(testCollectionAlias)
+      expect(actualCollectionPreview.parentName).toBe(expectedCollectionsName)
+      expect(actualCollectionPreview.publicationStatuses[0]).toBe(PublicationStatus.Published)
+      expect(actualCollectionPreview.releaseOrCreateDate).not.toBeUndefined()
+      expect(actualCollectionPreview.affiliation).toBe('Scientific Research University')
+      expect(actualCollectionPreview.parentAlias).toBe('collectionsRepositoryTestCollection')
+      expect(actualCollectionPreview.parentName).toBe(expectedCollectionsName)
+      expect(actualCollectionPreview.type).toBe(CollectionItemType.COLLECTION)
+
+      expect(actual.totalItemCount).toBe(3)
     })
   })
 

--- a/test/integration/collections/CollectionsRepository.test.ts
+++ b/test/integration/collections/CollectionsRepository.test.ts
@@ -293,7 +293,7 @@ describe('CollectionsRepository', () => {
 
       const expectedFileMd5 = '68b22040025784da775f55cfcb6dee2e'
       const expectedDatasetCitationFragment =
-        'Admin, Dataverse; Owner, Dataverse, 2024, "Dataset created using the createDataset use case'
+        'Admin, Dataverse; Owner, Dataverse, 2025, "Dataset created using the createDataset use case'
       const expectedDatasetDescription = 'Dataset created using the createDataset use case'
       const expectedFileName = 'test-file-1.txt'
       const expectedCollectionsName = 'Scientific Research'
@@ -378,6 +378,8 @@ describe('CollectionsRepository', () => {
       expect(actualFilePreview.url).not.toBeUndefined()
       expect(actualFilePreview.releaseOrCreateDate).not.toBeUndefined()
       expect(actualFilePreview.type).toBe(CollectionItemType.FILE)
+      expect(actualFilePreview.restricted).toBe(false)
+      expect(actualFilePreview.canDownloadFile).toBe(true)
 
       expect(actualDatasetPreview.title).toBe(expectedDatasetDescription)
       expect(actualDatasetPreview.citation).toContain(expectedDatasetCitationFragment)

--- a/test/testHelpers/TestConstants.ts
+++ b/test/testHelpers/TestConstants.ts
@@ -89,7 +89,8 @@ export class TestConstants {
               dsDescriptionValue: 'This is the description of the dataset.'
             }
           ],
-          subject: ['Medicine, Health and Life Sciences']
+          subject: ['Medicine, Health and Life Sciences'],
+          imageUrl: 'http://dataverse.com'
         }
       }
     ]

--- a/test/testHelpers/TestConstants.ts
+++ b/test/testHelpers/TestConstants.ts
@@ -89,8 +89,7 @@ export class TestConstants {
               dsDescriptionValue: 'This is the description of the dataset.'
             }
           ],
-          subject: ['Medicine, Health and Life Sciences'],
-          imageUrl: 'http://dataverse.com'
+          subject: ['Medicine, Health and Life Sciences']
         }
       }
     ]

--- a/test/testHelpers/datasets/datasetPreviewHelper.ts
+++ b/test/testHelpers/datasets/datasetPreviewHelper.ts
@@ -29,7 +29,8 @@ export const createDatasetPreviewModel = (): DatasetPreview => {
     description: 'test',
     publicationStatuses: [PublicationStatus.Draft, PublicationStatus.Unpublished],
     parentCollectionAlias: 'parentCollection',
-    parentCollectionName: 'Parent Collection'
+    parentCollectionName: 'Parent Collection',
+    imageUrl: 'http://dataverse.com'
   }
   return datasetPreviewModel
 }
@@ -50,6 +51,7 @@ export const createDatasetPreviewPayload = (): DatasetPreviewPayload => {
     type: 'dataset',
     publicationStatuses: ['Draft', 'Unpublished'],
     identifier_of_dataverse: 'parentCollection',
-    name_of_dataverse: 'Parent Collection'
+    name_of_dataverse: 'Parent Collection',
+    image_url: 'http://dataverse.com'
   }
 }

--- a/test/testHelpers/files/filePreviewHelper.ts
+++ b/test/testHelpers/files/filePreviewHelper.ts
@@ -25,7 +25,10 @@ export const createFilePreviewModel = (): FilePreview => {
     datasetPersistentId: 'test pid1',
     datasetCitation: 'test citation',
     publicationStatuses: [PublicationStatus.Published],
-    releaseOrCreateDate: new Date('2023-05-15T08:21:01Z')
+    releaseOrCreateDate: new Date('2023-05-15T08:21:01Z'),
+    canDownloadFile: true,
+    restricted: false,
+    categories: []
   }
   return filePreviewModel
 }
@@ -53,6 +56,9 @@ export const createFilePreviewPayload = (): FilePreviewPayload => {
     dataset_persistent_id: 'test pid1',
     dataset_citation: 'test citation',
     publicationStatuses: ['Published'],
-    releaseOrCreateDate: '2023-05-15T08:21:01Z'
+    releaseOrCreateDate: '2023-05-15T08:21:01Z',
+    canDownloadFile: true,
+    restricted: false,
+    categories: []
   }
 }

--- a/test/testHelpers/files/filePreviewHelper.ts
+++ b/test/testHelpers/files/filePreviewHelper.ts
@@ -27,8 +27,7 @@ export const createFilePreviewModel = (): FilePreview => {
     publicationStatuses: [PublicationStatus.Published],
     releaseOrCreateDate: new Date('2023-05-15T08:21:01Z'),
     canDownloadFile: true,
-    restricted: false,
-    categories: []
+    restricted: false
   }
   return filePreviewModel
 }
@@ -58,7 +57,6 @@ export const createFilePreviewPayload = (): FilePreviewPayload => {
     publicationStatuses: ['Published'],
     releaseOrCreateDate: '2023-05-15T08:21:01Z',
     canDownloadFile: true,
-    restricted: false,
-    categories: []
+    restricted: false
   }
 }

--- a/test/testHelpers/files/filesHelper.ts
+++ b/test/testHelpers/files/filesHelper.ts
@@ -211,3 +211,19 @@ async function createBlobWithSize(size: number): Promise<Blob> {
   const arrayBuffer = new ArrayBuffer(size)
   return new Blob([arrayBuffer])
 }
+
+export const updateFileTabularTags = async (
+  fileId: number,
+  tabularTags: string[]
+): Promise<AxiosResponse> => {
+  return await axios.post(
+    `${TestConstants.TEST_API_URL}/files/${fileId}/metadata/tabularTags`,
+    { tabularTags },
+    {
+      headers: {
+        'Content-type': 'application/json',
+        'X-Dataverse-Key': process.env.TEST_API_KEY
+      }
+    }
+  )
+}


### PR DESCRIPTION
## What this PR does / why we need it:
In collection page, some missing information is needed for every card item, including the lock icon, tags(categories), and tabular data info, so we need update in FilePreview model.

New fields include:
```
 restricted: boolean
 canDownloadFile: boolean
 categories?: string[]
 tabularTags?: string[]
 variables?: number
 observations?: number

```

In datasetPreview, new field added
` image_url: string`

## Which issue(s) this PR closes:

- Closes #221 
## Related Dataverse PRs:

- Depends on https://github.com/IQSS/dataverse/pull/11097

## Special notes for your reviewer:

## Suggestions on how to test this:
Run all testcases and visually inspect

## Is there a release notes update needed for this change?:

## Additional documentation:
