### PR TITLE
Typescript strict config

### DIFF
--- a/src/collections/infra/repositories/CollectionsRepository.ts
+++ b/src/collections/infra/repositories/CollectionsRepository.ts
@@ -33,9 +33,9 @@ export interface NewCollectionContactRequestPayload {
 }
 
 export interface NewCollectionMetadataBlocksRequestPayload {
-  metadataBlockNames: string[]
-  facetIds: string[]
-  inputLevels: NewCollectionInputLevelRequestPayload[]
+  metadataBlockNames?: string[]
+  facetIds?: string[]
+  inputLevels?: NewCollectionInputLevelRequestPayload[]
 }
 
 export interface NewCollectionInputLevelRequestPayload {
@@ -179,7 +179,7 @@ export class CollectionsRepository extends ApiRepository implements ICollections
       })
     )
 
-    const inputLevelsRequestBody: NewCollectionInputLevelRequestPayload[] =
+    const inputLevelsRequestBody: NewCollectionInputLevelRequestPayload[] | undefined =
       collectionDTO.inputLevels?.map((inputLevel) => ({
         datasetFieldTypeName: inputLevel.datasetFieldName,
         include: inputLevel.include,

--- a/src/core/infra/repositories/ApiRepository.ts
+++ b/src/core/infra/repositories/ApiRepository.ts
@@ -47,7 +47,7 @@ export abstract class ApiRepository {
   protected buildApiEndpoint(
     resourceName: string,
     operation: string,
-    resourceId: number | string = undefined
+    resourceId: number | string | undefined = undefined
   ) {
     return typeof resourceId === 'number'
       ? `/${resourceName}/${resourceId}/${operation}`

--- a/src/core/infra/repositories/apiConfigBuilders.ts
+++ b/src/core/infra/repositories/apiConfigBuilders.ts
@@ -8,7 +8,7 @@ export const buildRequestConfig = (
   contentType: string = ApiConstants.CONTENT_TYPE_APPLICATION_JSON,
   abortSignal?: AbortSignal
 ): AxiosRequestConfig => {
-  const requestConfig: AxiosRequestConfig = {
+  const requestConfig: AxiosRequestConfig & { headers: Record<string, unknown> } = {
     params: queryParams,
     headers: {
       'Content-Type': contentType

--- a/src/datasets/domain/models/Dataset.ts
+++ b/src/datasets/domain/models/Dataset.ts
@@ -53,7 +53,7 @@ export type DatasetMetadataFieldValue =
   | DatasetMetadataSubField[]
   | AnonymizedField
 
-export type DatasetMetadataSubField = Record<string, string>
+export type DatasetMetadataSubField = Record<string, string | undefined>
 
 export interface CitationMetadataBlock extends DatasetMetadataBlock {
   name: 'citation'

--- a/src/datasets/domain/useCases/validators/DatasetResourceValidator.ts
+++ b/src/datasets/domain/useCases/validators/DatasetResourceValidator.ts
@@ -17,9 +17,10 @@ export class DatasetResourceValidator implements ResourceValidator {
     metadataBlocks: MetadataBlock[]
   ) {
     const metadataBlockName = metadataBlockValues.name
-    const metadataBlock: MetadataBlock = metadataBlocks.find(
+    const metadataBlock = metadataBlocks.find(
       (metadataBlock) => metadataBlock.name === metadataBlockName
-    )
+    ) as MetadataBlock
+
     for (const metadataFieldKey of Object.keys(metadataBlock.metadataFields)) {
       this.metadataFieldValidator.validate({
         metadataFieldInfo: metadataBlock.metadataFields[metadataFieldKey],

--- a/src/datasets/domain/useCases/validators/SingleMetadataFieldValidator.ts
+++ b/src/datasets/domain/useCases/validators/SingleMetadataFieldValidator.ts
@@ -8,6 +8,7 @@ import { MetadataFieldValidator } from './MetadataFieldValidator'
 import { DatasetMetadataChildFieldValueDTO } from '../../dtos/DatasetDTO'
 import { MultipleMetadataFieldValidator } from './MultipleMetadataFieldValidator'
 import {
+  MetadataFieldInfo,
   MetadataFieldType,
   MetadataFieldWatermark
 } from '../../../../metadataBlocks/domain/models/MetadataBlock'
@@ -62,7 +63,7 @@ export class SingleMetadataFieldValidator extends BaseMetadataFieldValidator {
     datasetMetadataFieldAndValueInfo: DatasetMetadataFieldAndValueInfo
   ) {
     if (
-      !datasetMetadataFieldAndValueInfo.metadataFieldInfo.controlledVocabularyValues.includes(
+      !datasetMetadataFieldAndValueInfo.metadataFieldInfo.controlledVocabularyValues?.includes(
         datasetMetadataFieldAndValueInfo.metadataFieldValue as string
       )
     ) {
@@ -120,13 +121,21 @@ export class SingleMetadataFieldValidator extends BaseMetadataFieldValidator {
     datasetMetadataFieldAndValueInfo: DatasetMetadataFieldAndValueInfo
   ) {
     const metadataFieldInfo = datasetMetadataFieldAndValueInfo.metadataFieldInfo
-    const childMetadataFieldKeys = Object.keys(metadataFieldInfo.childMetadataFields)
+
+    const childMetadataFieldKeys = Object.keys(
+      metadataFieldInfo.childMetadataFields as Record<string, MetadataFieldInfo>
+    )
+
     const metadataFieldValidator = new MetadataFieldValidator(
       this,
       new MultipleMetadataFieldValidator(this)
     )
+
     for (const childMetadataFieldKey of childMetadataFieldKeys) {
-      const childMetadataFieldInfo = metadataFieldInfo.childMetadataFields[childMetadataFieldKey]
+      const childMetadataFieldInfo = (
+        metadataFieldInfo.childMetadataFields as Record<string, MetadataFieldInfo>
+      )[childMetadataFieldKey]
+
       metadataFieldValidator.validate({
         metadataFieldInfo: childMetadataFieldInfo,
         metadataFieldKey: childMetadataFieldKey,

--- a/src/datasets/infra/repositories/transformers/datasetTransformers.ts
+++ b/src/datasets/infra/repositories/transformers/datasetTransformers.ts
@@ -68,9 +68,9 @@ export const transformDatasetModelToUpdateDatasetRequestPayload = (
   datasetMetadataBlocksValues.forEach(function (
     newDatasetMetadataBlockValues: DatasetMetadataBlockValuesDTO
   ) {
-    const metadataBlock: MetadataBlock = metadataBlocks.find(
+    const metadataBlock = metadataBlocks.find(
       (metadataBlock) => metadataBlock.name == newDatasetMetadataBlockValues.name
-    )
+    ) as MetadataBlock
     const metadataBlockFieldsPayload: MetadataFieldRequestPayload[] = []
     const metadataBlockFields = metadataBlock.metadataFields
     const datasetMetadataFields = newDatasetMetadataBlockValues.fields
@@ -119,7 +119,7 @@ export const transformMetadataBlockModelsToRequestPayload = (
   ) {
     const metadataBlock: MetadataBlock = metadataBlocks.find(
       (metadataBlock) => metadataBlock.name == newDatasetMetadataBlockValues.name
-    )
+    ) as MetadataBlock
     metadataBlocksRequestPayload[newDatasetMetadataBlockValues.name] = {
       fields: transformMetadataFieldModelsToRequestPayload(
         newDatasetMetadataBlockValues.fields,
@@ -195,8 +195,9 @@ export const transformMetadataChildFieldValueToRequestPayload = (
 ): Record<string, MetadataFieldRequestPayload> => {
   const metadataChildFieldRequestPayload: Record<string, MetadataFieldRequestPayload> = {}
   for (const metadataChildFieldKey of Object.keys(datasetMetadataChildFieldValue)) {
-    const childMetadataFieldInfo: MetadataFieldInfo =
-      metadataBlockFieldInfo.childMetadataFields[metadataChildFieldKey]
+    const childMetadataFieldInfo: MetadataFieldInfo = (
+      metadataBlockFieldInfo.childMetadataFields as Record<string, MetadataFieldInfo>
+    )[metadataChildFieldKey]
     const value: string = datasetMetadataChildFieldValue[metadataChildFieldKey] as unknown as string
     metadataChildFieldRequestPayload[metadataChildFieldKey] = {
       value: value,
@@ -242,7 +243,9 @@ export const transformVersionPayloadToDataset = (
     })
   }
   if ('license' in versionPayload) {
-    datasetModel.license = transformPayloadToDatasetLicense(versionPayload.license)
+    datasetModel.license = transformPayloadToDatasetLicense(
+      versionPayload.license as LicensePayload
+    )
   }
   if ('alternativePersistentId' in versionPayload) {
     datasetModel.alternativePersistentId = versionPayload.alternativePersistentId

--- a/src/files/infra/clients/DirectUploadClient.ts
+++ b/src/files/infra/clients/DirectUploadClient.ts
@@ -73,7 +73,8 @@ export class DirectUploadClient implements IDirectUploadClient {
       if (axios.isCancel(error)) {
         throw new FileUploadCancelError(file.name, datasetId)
       }
-      throw new FileUploadError(file.name, datasetId, error.message)
+      const errorMessage = error instanceof Error ? error.message : 'Upload singlepart file failed'
+      throw new FileUploadError(file.name, datasetId, errorMessage)
     }
   }
 
@@ -114,7 +115,7 @@ export class DirectUploadClient implements IDirectUploadClient {
         eTags[`${index + 1}`] = eTag
       } catch (error) {
         if (axios.isCancel(error)) {
-          await this.abortMultipartUpload(file.name, datasetId, destination.abortEndpoint)
+          await this.abortMultipartUpload(file.name, datasetId, destination.abortEndpoint as string)
           throw new FileUploadCancelError(file.name, datasetId)
         }
         if (retries < maxRetries) {
@@ -122,8 +123,12 @@ export class DirectUploadClient implements IDirectUploadClient {
           await new Promise((resolve) => setTimeout(resolve, backoffDelay))
           await uploadPart(destinationUrl, index, retries + 1)
         } else {
-          await this.abortMultipartUpload(file.name, datasetId, destination.abortEndpoint)
-          throw new FilePartUploadError(file.name, datasetId, error.message, index + 1)
+          await this.abortMultipartUpload(file.name, datasetId, destination.abortEndpoint as string)
+
+          const errorMessage =
+            error instanceof Error ? error.message : 'Upload part of multipart file failed'
+
+          throw new FilePartUploadError(file.name, datasetId, errorMessage, index + 1)
         }
       }
     }
@@ -165,7 +170,7 @@ export class DirectUploadClient implements IDirectUploadClient {
   ): Promise<void> {
     return await axios
       .put(
-        buildRequestUrl(destination.completeEndpoint),
+        buildRequestUrl(destination.completeEndpoint as string),
         eTags,
         buildRequestConfig(
           true,
@@ -177,7 +182,7 @@ export class DirectUploadClient implements IDirectUploadClient {
       .then(() => undefined)
       .catch(async (error) => {
         if (axios.isCancel(error)) {
-          await this.abortMultipartUpload(fileName, datasetId, destination.abortEndpoint)
+          await this.abortMultipartUpload(fileName, datasetId, destination.abortEndpoint as string)
           throw new FileUploadCancelError(fileName, datasetId)
         }
         throw new MultipartCompletionError(fileName, datasetId, error.message)

--- a/src/metadataBlocks/infra/repositories/transformers/metadataBlockTransformers.ts
+++ b/src/metadataBlocks/infra/repositories/transformers/metadataBlockTransformers.ts
@@ -64,15 +64,19 @@ const transformMetadataBlockPayloadToMetadataBlock = (
 
 const getChildFieldKeys = (metadataBlockFieldsPayload: Record<string, unknown>): Set<string> => {
   const childFieldKeys = new Set<string>()
-  Object.values(metadataBlockFieldsPayload).forEach(
-    (fieldInfo: { childFields?: Record<string, unknown> }) => {
-      if (fieldInfo.childFields) {
-        Object.keys(fieldInfo.childFields).forEach((childKey) => {
-          childFieldKeys.add(childKey)
-        })
-      }
+  Object.values(metadataBlockFieldsPayload).forEach((fieldInfo) => {
+    if (
+      fieldInfo &&
+      typeof fieldInfo === 'object' &&
+      'childFields' in fieldInfo &&
+      typeof fieldInfo.childFields === 'object' &&
+      (fieldInfo?.childFields as Record<string, unknown>)
+    ) {
+      Object.keys(fieldInfo.childFields as Record<string, unknown>).forEach((childKey) => {
+        childFieldKeys.add(childKey)
+      })
     }
-  )
+  })
   return childFieldKeys
 }
 

--- a/test/functional/collections/CreateCollection.test.ts
+++ b/test/functional/collections/CreateCollection.test.ts
@@ -34,7 +34,7 @@ describe('execute', () => {
       await createCollection.execute(testNewCollection, TestConstants.TEST_DUMMY_COLLECTION_ID)
       throw new Error('Use case should throw an error')
     } catch (error) {
-      writeError = error
+      writeError = error as WriteError
     } finally {
       expect(writeError).toBeInstanceOf(WriteError)
       expect(writeError?.message).toEqual(

--- a/test/functional/collections/CreateCollection.test.ts
+++ b/test/functional/collections/CreateCollection.test.ts
@@ -29,7 +29,7 @@ describe('execute', () => {
   test('should throw an error when the parent collection does not exist', async () => {
     const testNewCollection = createCollectionDTO()
     expect.assertions(2)
-    let writeError: WriteError
+    let writeError: WriteError | undefined = undefined
     try {
       await createCollection.execute(testNewCollection, TestConstants.TEST_DUMMY_COLLECTION_ID)
       throw new Error('Use case should throw an error')
@@ -37,7 +37,7 @@ describe('execute', () => {
       writeError = error
     } finally {
       expect(writeError).toBeInstanceOf(WriteError)
-      expect(writeError.message).toEqual(
+      expect(writeError?.message).toEqual(
         `There was an error when writing the resource. Reason was: [404] Can't find dataverse with identifier='${TestConstants.TEST_DUMMY_COLLECTION_ID}'`
       )
     }

--- a/test/functional/collections/GetCollectionFacets.test.ts
+++ b/test/functional/collections/GetCollectionFacets.test.ts
@@ -32,7 +32,7 @@ describe('execute', () => {
       await getCollectionFacets.execute(TestConstants.TEST_DUMMY_COLLECTION_ID)
       throw new Error('Use case should throw an error')
     } catch (error) {
-      readError = error
+      readError = error as ReadError
     } finally {
       expect(readError).toBeInstanceOf(ReadError)
       expect(readError?.message).toEqual(

--- a/test/functional/collections/GetCollectionFacets.test.ts
+++ b/test/functional/collections/GetCollectionFacets.test.ts
@@ -27,7 +27,7 @@ describe('execute', () => {
 
   test('should throw an error when collection does not exist', async () => {
     expect.assertions(2)
-    let readError: ReadError
+    let readError: ReadError | undefined = undefined
     try {
       await getCollectionFacets.execute(TestConstants.TEST_DUMMY_COLLECTION_ID)
       throw new Error('Use case should throw an error')
@@ -35,7 +35,7 @@ describe('execute', () => {
       readError = error
     } finally {
       expect(readError).toBeInstanceOf(ReadError)
-      expect(readError.message).toEqual(
+      expect(readError?.message).toEqual(
         `There was an error when reading the resource. Reason was: [404] Can't find dataverse with identifier='${TestConstants.TEST_DUMMY_COLLECTION_ID}'`
       )
     }

--- a/test/functional/collections/GetCollectionItems.test.ts
+++ b/test/functional/collections/GetCollectionItems.test.ts
@@ -80,7 +80,7 @@ describe('execute', () => {
       await getCollectionItems.execute(TestConstants.TEST_DUMMY_COLLECTION_ALIAS)
       throw new Error('Use case should throw an error')
     } catch (error) {
-      readError = error
+      readError = error as ReadError
     } finally {
       expect(readError).toBeInstanceOf(ReadError)
       expect(readError?.message).toEqual(

--- a/test/functional/collections/GetCollectionItems.test.ts
+++ b/test/functional/collections/GetCollectionItems.test.ts
@@ -15,7 +15,6 @@ import {
 } from '../../testHelpers/collections/collectionHelper'
 import { uploadFileViaApi } from '../../testHelpers/files/filesHelper'
 import { deleteUnpublishedDatasetViaApi } from '../../testHelpers/datasets/datasetHelper'
-import { CollectionItemSubset } from '../../../src/collections/domain/models/CollectionItemSubset'
 
 describe('execute', () => {
   const testCollectionAlias = 'collectionsRepositoryFunctionalTestCollection'
@@ -59,12 +58,9 @@ describe('execute', () => {
     // Give enough time to Solr for indexing
     await new Promise((resolve) => setTimeout(resolve, 5000))
 
-    let actual: CollectionItemSubset
     try {
-      actual = await getCollectionItems.execute(testCollectionAlias)
-    } catch (error) {
-      throw new Error('Item subset should be retrieved')
-    } finally {
+      const actual = await getCollectionItems.execute(testCollectionAlias)
+
       const actualFilePreview = actual.items[0] as FilePreview
       const actualDatasetPreview = actual.items[1] as DatasetPreview
 
@@ -72,12 +68,14 @@ describe('execute', () => {
       expect(actualDatasetPreview.title).toBe('Dataset created using the createDataset use case')
 
       expect(actual.totalItemCount).toBe(2)
+    } catch (error) {
+      throw new Error('Item subset should be retrieved')
     }
   })
 
   test('should throw an error when collection does not exist', async () => {
     expect.assertions(2)
-    let readError: ReadError
+    let readError: ReadError | undefined = undefined
     try {
       await getCollectionItems.execute(TestConstants.TEST_DUMMY_COLLECTION_ALIAS)
       throw new Error('Use case should throw an error')
@@ -85,7 +83,7 @@ describe('execute', () => {
       readError = error
     } finally {
       expect(readError).toBeInstanceOf(ReadError)
-      expect(readError.message).toEqual(
+      expect(readError?.message).toEqual(
         `There was an error when reading the resource. Reason was: [400] Could not find dataverse with alias ${TestConstants.TEST_DUMMY_COLLECTION_ALIAS}`
       )
     }

--- a/test/functional/collections/GetCollectionUserPermissions.test.ts
+++ b/test/functional/collections/GetCollectionUserPermissions.test.ts
@@ -1,9 +1,4 @@
-import {
-  ApiConfig,
-  CollectionUserPermissions,
-  ReadError,
-  getCollectionUserPermissions
-} from '../../../src'
+import { ApiConfig, ReadError, getCollectionUserPermissions } from '../../../src'
 import { TestConstants } from '../../testHelpers/TestConstants'
 import { DataverseApiAuthMechanism } from '../../../src/core/infra/repositories/ApiConfig'
 
@@ -19,41 +14,39 @@ describe('execute', () => {
   })
 
   test('should return user permissions for the default collection', async () => {
-    let actual: CollectionUserPermissions
     try {
-      actual = await getCollectionUserPermissions.execute()
+      const permissions = await getCollectionUserPermissions.execute()
+
+      expect(permissions.canAddDataset).toBe(true)
+      expect(permissions.canAddCollection).toBe(true)
+      expect(permissions.canDeleteCollection).toBe(true)
+      expect(permissions.canEditCollection).toBe(true)
+      expect(permissions.canManageCollectionPermissions).toBe(true)
+      expect(permissions.canPublishCollection).toBe(true)
+      expect(permissions.canViewUnpublishedCollection).toBe(true)
     } catch (error) {
       throw new Error('Permissions should be retrieved')
-    } finally {
-      expect(actual.canAddDataset).toBe(true)
-      expect(actual.canAddCollection).toBe(true)
-      expect(actual.canDeleteCollection).toBe(true)
-      expect(actual.canEditCollection).toBe(true)
-      expect(actual.canManageCollectionPermissions).toBe(true)
-      expect(actual.canPublishCollection).toBe(true)
-      expect(actual.canViewUnpublishedCollection).toBe(true)
     }
   })
   test('should return user permissions when a valid collection alias is provided', async () => {
-    let actual: CollectionUserPermissions
     try {
-      actual = await getCollectionUserPermissions.execute(ROOT_COLLECTION_ALIAS)
+      const permissions = await getCollectionUserPermissions.execute(ROOT_COLLECTION_ALIAS)
+
+      expect(permissions.canAddDataset).toBe(true)
+      expect(permissions.canAddCollection).toBe(true)
+      expect(permissions.canDeleteCollection).toBe(true)
+      expect(permissions.canEditCollection).toBe(true)
+      expect(permissions.canManageCollectionPermissions).toBe(true)
+      expect(permissions.canPublishCollection).toBe(true)
+      expect(permissions.canViewUnpublishedCollection).toBe(true)
     } catch (error) {
       throw new Error('Permissions should be retrieved')
-    } finally {
-      expect(actual.canAddDataset).toBe(true)
-      expect(actual.canAddCollection).toBe(true)
-      expect(actual.canDeleteCollection).toBe(true)
-      expect(actual.canEditCollection).toBe(true)
-      expect(actual.canManageCollectionPermissions).toBe(true)
-      expect(actual.canPublishCollection).toBe(true)
-      expect(actual.canViewUnpublishedCollection).toBe(true)
     }
   })
 
   test('should throw an error when collection does not exist', async () => {
     expect.assertions(2)
-    let readError: ReadError
+    let readError: ReadError | undefined = undefined
     try {
       await getCollectionUserPermissions.execute(TestConstants.TEST_DUMMY_COLLECTION_ID)
       throw new Error('Use case should throw an error')
@@ -61,7 +54,7 @@ describe('execute', () => {
       readError = error
     } finally {
       expect(readError).toBeInstanceOf(ReadError)
-      expect(readError.message).toEqual(
+      expect(readError?.message).toEqual(
         `There was an error when reading the resource. Reason was: [404] Can't find dataverse with identifier='${TestConstants.TEST_DUMMY_COLLECTION_ID}'`
       )
     }

--- a/test/functional/collections/GetCollectionUserPermissions.test.ts
+++ b/test/functional/collections/GetCollectionUserPermissions.test.ts
@@ -51,7 +51,7 @@ describe('execute', () => {
       await getCollectionUserPermissions.execute(TestConstants.TEST_DUMMY_COLLECTION_ID)
       throw new Error('Use case should throw an error')
     } catch (error) {
-      readError = error
+      readError = error as ReadError
     } finally {
       expect(readError).toBeInstanceOf(ReadError)
       expect(readError?.message).toEqual(

--- a/test/functional/collections/UpdateCollection.test.ts
+++ b/test/functional/collections/UpdateCollection.test.ts
@@ -38,7 +38,7 @@ describe('execute', () => {
   test('should throw an error when the parent collection does not exist', async () => {
     const testNewCollection = createCollectionDTO()
     expect.assertions(2)
-    let writeError: WriteError
+    let writeError: WriteError | undefined = undefined
     try {
       await updateCollection.execute(TestConstants.TEST_DUMMY_COLLECTION_ID, testNewCollection)
       throw new Error('Use case should throw an error')
@@ -46,7 +46,7 @@ describe('execute', () => {
       writeError = error
     } finally {
       expect(writeError).toBeInstanceOf(WriteError)
-      expect(writeError.message).toEqual(
+      expect(writeError?.message).toEqual(
         `There was an error when writing the resource. Reason was: [404] Can't find dataverse with identifier='${TestConstants.TEST_DUMMY_COLLECTION_ID}'`
       )
     }

--- a/test/functional/collections/UpdateCollection.test.ts
+++ b/test/functional/collections/UpdateCollection.test.ts
@@ -43,7 +43,7 @@ describe('execute', () => {
       await updateCollection.execute(TestConstants.TEST_DUMMY_COLLECTION_ID, testNewCollection)
       throw new Error('Use case should throw an error')
     } catch (error) {
-      writeError = error
+      writeError = error as WriteError
     } finally {
       expect(writeError).toBeInstanceOf(WriteError)
       expect(writeError?.message).toEqual(

--- a/test/functional/datasets/CreateDataset.test.ts
+++ b/test/functional/datasets/CreateDataset.test.ts
@@ -99,7 +99,7 @@ describe('execute', () => {
       await createDataset.execute(testNewDataset)
       throw new Error('Use case should throw an error')
     } catch (error) {
-      fieldValidationError = error
+      fieldValidationError = error as FieldValidationError
     } finally {
       expect(fieldValidationError).toBeInstanceOf(FieldValidationError)
       expect(fieldValidationError?.citationBlockName).toEqual('citation')
@@ -149,7 +149,7 @@ describe('execute', () => {
       await createDataset.execute(testNewDataset)
       throw new Error('Use case should throw an error')
     } catch (error) {
-      fieldValidationError = error
+      fieldValidationError = error as FieldValidationError
     } finally {
       expect(fieldValidationError).toBeInstanceOf(FieldValidationError)
       expect(fieldValidationError?.citationBlockName).toEqual('citation')
@@ -201,7 +201,7 @@ describe('execute', () => {
       await createDataset.execute(testNewDataset)
       throw new Error('Use case should throw an error')
     } catch (error) {
-      fieldValidationError = error
+      fieldValidationError = error as FieldValidationError
     } finally {
       expect(fieldValidationError).toBeInstanceOf(FieldValidationError)
       expect(fieldValidationError?.citationBlockName).toEqual('citation')

--- a/test/functional/datasets/CreateDataset.test.ts
+++ b/test/functional/datasets/CreateDataset.test.ts
@@ -1,4 +1,4 @@
-import { createDataset, CreatedDatasetIdentifiers } from '../../../src/datasets'
+import { createDataset, DatasetDTO } from '../../../src/datasets'
 import { ApiConfig } from '../../../src'
 import { TestConstants } from '../../testHelpers/TestConstants'
 import { DataverseApiAuthMechanism } from '../../../src/core/infra/repositories/ApiConfig'
@@ -48,16 +48,16 @@ describe('execute', () => {
       ]
     }
     expect.assertions(3)
-    let createdDatasetIdentifiers: CreatedDatasetIdentifiers
+
     try {
-      createdDatasetIdentifiers = await createDataset.execute(testNewDataset)
-    } catch (error) {
-      throw new Error('Dataset should be created')
-    } finally {
+      const createdDatasetIdentifiers = await createDataset.execute(testNewDataset)
+
       expect(createdDatasetIdentifiers).not.toBeNull()
       expect(createdDatasetIdentifiers.numericId).not.toBeNull()
       expect(createdDatasetIdentifiers.persistentId).not.toBeNull()
       await deleteUnpublishedDatasetViaApi(createdDatasetIdentifiers.numericId)
+    } catch (error) {
+      throw new Error('Dataset should be created')
     }
   })
 
@@ -94,7 +94,7 @@ describe('execute', () => {
       ]
     }
     expect.assertions(5)
-    let fieldValidationError: FieldValidationError
+    let fieldValidationError: FieldValidationError | undefined = undefined
     try {
       await createDataset.execute(testNewDataset)
       throw new Error('Use case should throw an error')
@@ -102,17 +102,17 @@ describe('execute', () => {
       fieldValidationError = error
     } finally {
       expect(fieldValidationError).toBeInstanceOf(FieldValidationError)
-      expect(fieldValidationError.citationBlockName).toEqual('citation')
-      expect(fieldValidationError.metadataFieldName).toEqual('title')
-      expect(fieldValidationError.parentMetadataFieldName).toEqual(undefined)
-      expect(fieldValidationError.message).toEqual(
+      expect(fieldValidationError?.citationBlockName).toEqual('citation')
+      expect(fieldValidationError?.metadataFieldName).toEqual('title')
+      expect(fieldValidationError?.parentMetadataFieldName).toEqual(undefined)
+      expect(fieldValidationError?.message).toEqual(
         'There was an error when validating the field title from metadata block citation. Reason was: The field should not be empty.'
       )
     }
   })
 
   test('should throw an error when a second level required field is missing', async () => {
-    const testNewDataset = {
+    const testNewDataset: DatasetDTO = {
       metadataBlockValues: [
         {
           name: 'citation',
@@ -144,7 +144,7 @@ describe('execute', () => {
       ]
     }
     expect.assertions(6)
-    let fieldValidationError: FieldValidationError
+    let fieldValidationError: FieldValidationError | undefined = undefined
     try {
       await createDataset.execute(testNewDataset)
       throw new Error('Use case should throw an error')
@@ -152,11 +152,11 @@ describe('execute', () => {
       fieldValidationError = error
     } finally {
       expect(fieldValidationError).toBeInstanceOf(FieldValidationError)
-      expect(fieldValidationError.citationBlockName).toEqual('citation')
-      expect(fieldValidationError.metadataFieldName).toEqual('authorName')
-      expect(fieldValidationError.parentMetadataFieldName).toEqual('author')
-      expect(fieldValidationError.fieldPosition).toEqual(0)
-      expect(fieldValidationError.message).toEqual(
+      expect(fieldValidationError?.citationBlockName).toEqual('citation')
+      expect(fieldValidationError?.metadataFieldName).toEqual('authorName')
+      expect(fieldValidationError?.parentMetadataFieldName).toEqual('author')
+      expect(fieldValidationError?.fieldPosition).toEqual(0)
+      expect(fieldValidationError?.message).toEqual(
         'There was an error when validating the field authorName from metadata block citation with parent field author in position 0. Reason was: The field should not be empty.'
       )
     }
@@ -196,7 +196,7 @@ describe('execute', () => {
       ]
     }
     expect.assertions(6)
-    let fieldValidationError: FieldValidationError
+    let fieldValidationError: FieldValidationError | undefined = undefined
     try {
       await createDataset.execute(testNewDataset)
       throw new Error('Use case should throw an error')
@@ -204,11 +204,11 @@ describe('execute', () => {
       fieldValidationError = error
     } finally {
       expect(fieldValidationError).toBeInstanceOf(FieldValidationError)
-      expect(fieldValidationError.citationBlockName).toEqual('citation')
-      expect(fieldValidationError.metadataFieldName).toEqual('subject')
-      expect(fieldValidationError.parentMetadataFieldName).toEqual(undefined)
-      expect(fieldValidationError.fieldPosition).toEqual(1)
-      expect(fieldValidationError.message).toEqual(
+      expect(fieldValidationError?.citationBlockName).toEqual('citation')
+      expect(fieldValidationError?.metadataFieldName).toEqual('subject')
+      expect(fieldValidationError?.parentMetadataFieldName).toEqual(undefined)
+      expect(fieldValidationError?.fieldPosition).toEqual(1)
+      expect(fieldValidationError?.message).toEqual(
         'There was an error when validating the field subject from metadata block citation in position 1. Reason was: The field does not have a valid controlled vocabulary value.'
       )
     }

--- a/test/functional/metadataBlocks/GetAllFacetableMetadataFields.test.ts
+++ b/test/functional/metadataBlocks/GetAllFacetableMetadataFields.test.ts
@@ -12,15 +12,15 @@ describe('execute', () => {
   })
 
   test('should return all facetable metadata fields', async () => {
-    let metadataFieldInfos: MetadataFieldInfo[] = null
+    let metadataFieldInfos: MetadataFieldInfo[] | null = null
     try {
       metadataFieldInfos = await getAllFacetableMetadataFields.execute()
     } catch (error) {
       throw new Error('Should not raise an error')
     } finally {
-      expect(metadataFieldInfos.length).toBe(59)
-      expect(metadataFieldInfos[0].name).toBe('authorName')
-      expect(metadataFieldInfos[0].displayName).toBe('Author Name')
+      expect(metadataFieldInfos?.length).toBe(59)
+      expect(metadataFieldInfos?.[0].name).toBe('authorName')
+      expect(metadataFieldInfos?.[0].displayName).toBe('Author Name')
     }
   })
 })

--- a/test/functional/metadataBlocks/GetAllMetadataBlocks.test.ts
+++ b/test/functional/metadataBlocks/GetAllMetadataBlocks.test.ts
@@ -12,15 +12,15 @@ describe('execute', () => {
   })
 
   test('should successfully return metadatablocks', async () => {
-    let metadataBlocks: MetadataBlock[] = null
+    let metadataBlocks: MetadataBlock[] | null = null
     try {
       metadataBlocks = await getAllMetadataBlocks.execute()
     } catch (error) {
       throw new Error('Should not raise an error')
     } finally {
       expect(metadataBlocks).not.toBeNull()
-      expect(metadataBlocks.length).toBe(6)
-      expect(metadataBlocks[0].metadataFields.title.name).toBe('title')
+      expect(metadataBlocks?.length).toBe(6)
+      expect(metadataBlocks?.[0].metadataFields.title.name).toBe('title')
     }
   })
 })

--- a/test/functional/metadataBlocks/GetCollectionMetadataBlocks.test.ts
+++ b/test/functional/metadataBlocks/GetCollectionMetadataBlocks.test.ts
@@ -31,7 +31,7 @@ describe('execute', () => {
       await getCollectionMetadataBlocks.execute('notFoundCollectionAlias')
       throw new Error('Use case should throw an error')
     } catch (error) {
-      readError = error
+      readError = error as ReadError
     } finally {
       expect(readError).toBeInstanceOf(ReadError)
       expect(readError?.message).toEqual(

--- a/test/functional/metadataBlocks/GetCollectionMetadataBlocks.test.ts
+++ b/test/functional/metadataBlocks/GetCollectionMetadataBlocks.test.ts
@@ -12,21 +12,21 @@ describe('execute', () => {
   })
 
   test('should successfully return collection metadatablocks when collection exists', async () => {
-    let collectionMetadataBlocks: MetadataBlock[] = null
+    let collectionMetadataBlocks: MetadataBlock[] | null = null
     try {
       collectionMetadataBlocks = await getCollectionMetadataBlocks.execute('root')
     } catch (error) {
       throw new Error('Should not raise an error')
     } finally {
       expect(collectionMetadataBlocks).not.toBeNull()
-      expect(collectionMetadataBlocks.length).toBe(1)
-      expect(collectionMetadataBlocks[0].metadataFields.title.name).toBe('title')
+      expect(collectionMetadataBlocks?.length).toBe(1)
+      expect(collectionMetadataBlocks?.[0].metadataFields.title.name).toBe('title')
     }
   })
 
   test('should throw an error when a collection is not found', async () => {
     expect.assertions(2)
-    let readError: ReadError
+    let readError: ReadError | undefined = undefined
     try {
       await getCollectionMetadataBlocks.execute('notFoundCollectionAlias')
       throw new Error('Use case should throw an error')
@@ -34,7 +34,7 @@ describe('execute', () => {
       readError = error
     } finally {
       expect(readError).toBeInstanceOf(ReadError)
-      expect(readError.message).toEqual(
+      expect(readError?.message).toEqual(
         `There was an error when reading the resource. Reason was: [404] Can't find dataverse with identifier='notFoundCollectionAlias'`
       )
     }

--- a/test/integration/collections/CollectionsRepository.test.ts
+++ b/test/integration/collections/CollectionsRepository.test.ts
@@ -292,8 +292,7 @@ describe('CollectionsRepository', () => {
       const actualCollectionPreview = actual.items[2] as CollectionPreview
 
       const expectedFileMd5 = '68b22040025784da775f55cfcb6dee2e'
-      const expectedDatasetCitationFragment =
-        'Admin, Dataverse; Owner, Dataverse, 2024, "Dataset created using the createDataset use case'
+      const expectedDatasetCitationFragment = `Admin, Dataverse; Owner, Dataverse, ${new Date().getFullYear()}, "Dataset created using the createDataset use case`
       const expectedDatasetDescription = 'Dataset created using the createDataset use case'
       const expectedFileName = 'test-file-1.txt'
       const expectedCollectionsName = 'Scientific Research'

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -494,8 +494,8 @@ describe('DatasetsRepository', () => {
         '1.0',
         DatasetNotNumberedVersion.DRAFT
       )
-      expect(actual.metadataChanges[0]).not.toBeUndefined()
-      expect(actual.metadataChanges[0].blockName).toEqual('Citation Metadata')
+      expect(actual.metadataChanges?.[0]).not.toBeUndefined()
+      expect(actual.metadataChanges?.[0].blockName).toEqual('Citation Metadata')
     })
 
     test('should return added file diff between two dataset versions', async () => {

--- a/test/unit/auth/AuthRepository.test.ts
+++ b/test/unit/auth/AuthRepository.test.ts
@@ -54,7 +54,7 @@ describe('logout', () => {
   test('should return error result on error response', async () => {
     jest.spyOn(axios, 'post').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
 
-    let error: WriteError = undefined
+    let error: WriteError | undefined = undefined
     await sut.logout().catch((e) => (error = e))
 
     expect(axios.post).toHaveBeenCalledWith(

--- a/test/unit/datasets/DatasetResourceValidator.test.ts
+++ b/test/unit/datasets/DatasetResourceValidator.test.ts
@@ -35,11 +35,13 @@ describe('validate', () => {
       throw new Error('Validation should fail')
     } catch (error) {
       expect(error).toBeInstanceOf(FieldValidationError)
-      expect(error.citationBlockName).toEqual('citation')
-      expect(error.metadataFieldName).toEqual(expectedMetadataFieldName)
-      expect(error.parentMetadataFieldName).toEqual(expectedParentMetadataFieldName)
-      expect(error.fieldPosition).toEqual(expectedPosition)
-      expect(error.message).toEqual(expectedErrorMessage)
+      expect((error as FieldValidationError)?.citationBlockName).toEqual('citation')
+      expect((error as FieldValidationError)?.metadataFieldName).toEqual(expectedMetadataFieldName)
+      expect((error as FieldValidationError)?.parentMetadataFieldName).toEqual(
+        expectedParentMetadataFieldName
+      )
+      expect((error as FieldValidationError)?.fieldPosition).toEqual(expectedPosition)
+      expect((error as FieldValidationError)?.message).toEqual(expectedErrorMessage)
     }
   }
 

--- a/test/unit/files/FilesRepository.test.ts
+++ b/test/unit/files/FilesRepository.test.ts
@@ -261,7 +261,7 @@ describe('FilesRepository', () => {
       offset: testOffset,
       orderCriteria: testFileOrderCriteria,
       contentType: testFileCriteria.contentType,
-      accessStatus: testFileCriteria.accessStatus.toString(),
+      accessStatus: testFileCriteria.accessStatus?.toString(),
       categoryName: testFileCriteria.categoryName,
       tabularTagName: testFileCriteria.tabularTagName
     }
@@ -330,7 +330,7 @@ describe('FilesRepository', () => {
       test('should return error result on error response', async () => {
         jest.spyOn(axios, 'get').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
 
-        let error: ReadError = undefined
+        let error: ReadError | undefined = undefined
         await sut
           .getDatasetFiles(
             testDatasetId,
@@ -402,7 +402,7 @@ describe('FilesRepository', () => {
       test('should return error result on error response', async () => {
         jest.spyOn(axios, 'get').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
 
-        let error: ReadError = undefined
+        let error: ReadError | undefined = undefined
         await sut
           .getDatasetFiles(
             TestConstants.TEST_DUMMY_PERSISTENT_ID,
@@ -440,7 +440,7 @@ describe('FilesRepository', () => {
     const expectedRequestParamsWithOptional = {
       includeDeaccessioned: testIncludeDeaccessioned,
       contentType: testFileCriteria.contentType,
-      accessStatus: testFileCriteria.accessStatus.toString(),
+      accessStatus: testFileCriteria.accessStatus?.toString(),
       categoryName: testFileCriteria.categoryName,
       tabularTagName: testFileCriteria.tabularTagName
     }
@@ -504,7 +504,7 @@ describe('FilesRepository', () => {
       test('should return error result on error response', async () => {
         jest.spyOn(axios, 'get').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
 
-        let error: ReadError = undefined
+        let error: ReadError | undefined = undefined
         await sut
           .getDatasetFileCounts(testDatasetId, testDatasetVersionId, testIncludeDeaccessioned)
           .catch((e) => (error = e))
@@ -549,7 +549,7 @@ describe('FilesRepository', () => {
       test('should return error result on error response', async () => {
         jest.spyOn(axios, 'get').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
 
-        let error: ReadError = undefined
+        let error: ReadError | undefined = undefined
         await sut
           .getDatasetFileCounts(
             TestConstants.TEST_DUMMY_PERSISTENT_ID,
@@ -595,7 +595,7 @@ describe('FilesRepository', () => {
         mode: FileDownloadSizeMode.ARCHIVAL.toString(),
         includeDeaccessioned: testIncludeDeaccessioned,
         contentType: testFileCriteria.contentType,
-        accessStatus: testFileCriteria.accessStatus.toString(),
+        accessStatus: testFileCriteria.accessStatus?.toString(),
         categoryName: testFileCriteria.categoryName,
         tabularTagName: testFileCriteria.tabularTagName
       },
@@ -656,7 +656,7 @@ describe('FilesRepository', () => {
       test('should return error result on error response', async () => {
         jest.spyOn(axios, 'get').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
 
-        let error: ReadError = undefined
+        let error: ReadError | undefined = undefined
         await sut
           .getDatasetFilesTotalDownloadSize(
             testDatasetId,
@@ -708,7 +708,7 @@ describe('FilesRepository', () => {
       test('should return error result on error response', async () => {
         jest.spyOn(axios, 'get').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
 
-        let error: ReadError = undefined
+        let error: ReadError | undefined = undefined
         await sut
           .getDatasetFilesTotalDownloadSize(
             TestConstants.TEST_DUMMY_PERSISTENT_ID,
@@ -765,7 +765,7 @@ describe('FilesRepository', () => {
       test('should return error result on error response', async () => {
         jest.spyOn(axios, 'get').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
 
-        let error: ReadError = undefined
+        let error: ReadError | undefined = undefined
         await sut.getFileDownloadCount(testFile.id).catch((e) => (error = e))
 
         expect(axios.get).toHaveBeenCalledWith(
@@ -806,7 +806,7 @@ describe('FilesRepository', () => {
       test('should return error result on error response', async () => {
         jest.spyOn(axios, 'get').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
 
-        let error: ReadError = undefined
+        let error: ReadError | undefined = undefined
         await sut
           .getFileDownloadCount(TestConstants.TEST_DUMMY_PERSISTENT_ID)
           .catch((e) => (error = e))
@@ -859,7 +859,7 @@ describe('FilesRepository', () => {
       test('should return error result on error response', async () => {
         jest.spyOn(axios, 'get').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
 
-        let error: ReadError = undefined
+        let error: ReadError | undefined = undefined
         await sut.getFileUserPermissions(testFile.id).catch((e) => (error = e))
 
         expect(axios.get).toHaveBeenCalledWith(
@@ -899,7 +899,7 @@ describe('FilesRepository', () => {
       test('should return error result on error response', async () => {
         jest.spyOn(axios, 'get').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
 
-        let error: ReadError = undefined
+        let error: ReadError | undefined = undefined
         await sut
           .getFileUserPermissions(TestConstants.TEST_DUMMY_PERSISTENT_ID)
           .catch((e) => (error = e))
@@ -952,7 +952,7 @@ describe('FilesRepository', () => {
       test('should return error result on error response', async () => {
         jest.spyOn(axios, 'get').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
 
-        let error: ReadError = undefined
+        let error: ReadError | undefined = undefined
         await sut.getFileDataTables(testFile.id).catch((e) => (error = e))
 
         expect(axios.get).toHaveBeenCalledWith(
@@ -993,7 +993,7 @@ describe('FilesRepository', () => {
       test('should return error result on error response', async () => {
         jest.spyOn(axios, 'get').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
 
-        let error: ReadError = undefined
+        let error: ReadError | undefined = undefined
         await sut
           .getFileDataTables(TestConstants.TEST_DUMMY_PERSISTENT_ID)
           .catch((e) => (error = e))

--- a/test/unit/files/GetFileDataTables.test.ts
+++ b/test/unit/files/GetFileDataTables.test.ts
@@ -25,7 +25,7 @@ describe('execute', () => {
     filesRepositoryStub.getFileDataTables = jest.fn().mockRejectedValue(testReadError)
     const sut = new GetFileDataTables(filesRepositoryStub)
 
-    let actualError: ReadError = undefined
+    let actualError: ReadError | undefined = undefined
     await sut.execute(testFileId).catch((e: ReadError) => (actualError = e))
 
     expect(actualError).toBe(testReadError)

--- a/test/unit/info/GetDataverseVersion.test.ts
+++ b/test/unit/info/GetDataverseVersion.test.ts
@@ -22,7 +22,7 @@ describe('execute', () => {
     dataverseInfoRepositoryStub.getDataverseVersion = jest.fn().mockRejectedValue(testReadError)
     const sut = new GetDataverseVersion(dataverseInfoRepositoryStub)
 
-    let actualError: ReadError = undefined
+    let actualError: ReadError | undefined = undefined
     await sut.execute().catch((e) => (actualError = e))
 
     expect(actualError).toBe(testReadError)

--- a/test/unit/info/GetZipDownloadLimit.test.ts
+++ b/test/unit/info/GetZipDownloadLimit.test.ts
@@ -22,7 +22,7 @@ describe('execute', () => {
     dataverseInfoRepositoryStub.getZipDownloadLimit = jest.fn().mockRejectedValue(new ReadError())
     const sut = new GetZipDownloadLimit(dataverseInfoRepositoryStub)
 
-    let actualError: ReadError
+    let actualError: ReadError | undefined = undefined
     await sut.execute().catch((e) => (actualError = e))
 
     expect(actualError).toBeInstanceOf(ReadError)

--- a/test/unit/metadataBlocks/GetMetadataBlockByName.test.ts
+++ b/test/unit/metadataBlocks/GetMetadataBlockByName.test.ts
@@ -29,7 +29,7 @@ describe('execute', () => {
       .mockRejectedValue(new ReadError())
     const sut = new GetMetadataBlockByName(metadataBlocksRepositoryStub)
 
-    let actualError: ReadError
+    let actualError: ReadError | undefined = undefined
     await sut.execute(testMetadataBlockName).catch((e) => (actualError = e))
 
     expect(actualError).toBeInstanceOf(ReadError)

--- a/test/unit/metadataBlocks/MetadataBlocksRepository.test.ts
+++ b/test/unit/metadataBlocks/MetadataBlocksRepository.test.ts
@@ -63,7 +63,7 @@ describe('MetadataBlocksRepository', () => {
       }
       jest.spyOn(axios, 'get').mockRejectedValue(testErrorResponse)
 
-      let error: ReadError = undefined
+      let error: ReadError | undefined = undefined
       await sut
         .getCollectionMetadataBlocks(TestConstants.TEST_DUMMY_COLLECTION_ID, true)
         .catch((e) => (error = e))
@@ -104,7 +104,7 @@ describe('MetadataBlocksRepository', () => {
       }
       jest.spyOn(axios, 'get').mockRejectedValue(testErrorResponse)
 
-      let error: ReadError = undefined
+      let error: ReadError | undefined = undefined
       await sut.getMetadataBlockByName(testMetadataBlockName).catch((e) => (error = e))
 
       expect(axios.get).toHaveBeenCalledWith(

--- a/test/unit/users/UsersRepository.test.ts
+++ b/test/unit/users/UsersRepository.test.ts
@@ -67,7 +67,7 @@ describe('getCurrentAuthenticatedUser', () => {
   test('should return error result on error response', async () => {
     jest.spyOn(axios, 'get').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
 
-    let error: ReadError = undefined
+    let error: ReadError | undefined = undefined
     await sut.getCurrentAuthenticatedUser().catch((e) => (error = e))
 
     expect(axios.get).toHaveBeenCalledWith(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "target": "es2015",
     "outDir": "./dist",
     "esModuleInterop": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "strictNullChecks": true
   },
   "include": ["src/**/*"],
   "exclude": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "outDir": "./dist",
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "strictNullChecks": true
+    "strict": true
   },
   "include": ["src/**/*"],
   "exclude": [


### PR DESCRIPTION
## What this PR does / why we need it:
Applies strict typescript configuration to the project as we do in the spa frontend repo.
Now properties of an interface that are declared as `string | undefined` or `string | null` or `property?: string` for example, are treated as both values, so we can write more safe code now.
This PR also accommodate the code everywhere where after this config change, typescript was complaining because we weren't taking care of possibly undefined or null values, some values are casted with the `as` keyword because there where previous checks and it was safe to cast them.

## Which issue(s) this PR closes:

- Closes #236 

## Suggestions on how to test this:
Visual code inspection and validate that Github Action checks are OK.

