### PR TITLE
fix: underscore escape while html transforming

### DIFF
--- a/src/datasets/infra/repositories/transformers/datasetTransformers.ts
+++ b/src/datasets/infra/repositories/transformers/datasetTransformers.ts
@@ -312,7 +312,6 @@ const transformPayloadToDatasetMetadataFieldValue = (
   if (typeClass === 'anonymized') {
     return ANONYMIZED_FIELD_VALUE
   }
-
   if (typeof metadataFieldValuePayload === 'string') {
     if (keepRawFields) {
       return metadataFieldValuePayload
@@ -350,5 +349,8 @@ const transformPayloadToDatasetMetadataSubfieldValue = (
 }
 
 export const transformHtmlToMarkdown = (source: string): string => {
+  turndownService.escape = (text) => {
+    return text.replace(/\\_/g, '_')
+  }
   return turndownService.turndown(source)
 }


### PR DESCRIPTION
## What this PR does / why we need it:
Fix the bug that the underscore are escaped with backslashes and accumulate.
After investigating, the function `transformHtmlToMarkdown` leads the underscore format problem, for example, input: "test_" would be transformed to "test\\_". This error isn't followed with other symbols, only underscore.

After I give an underscore to the title, the test information looks like this
<img width="1020" alt="Screenshot 2025-01-19 at 10 48 36 PM" src="https://github.com/user-attachments/assets/1217e506-052b-48c0-b993-fb02fa4af9d8" />

## Which issue(s) this PR closes:

- Closes #241 

## Special notes for your reviewer:

## Suggestions on how to test this:
Even though this is a js-dataverse repo PR, the test has to be done on front end SPA page.
Environment Setting: in package.json, change to `"@iqss/dataverse-client-javascript": "v2.0.0-pr242.cbb959e"`, run` npm i `, and run` npm run build`, may need restart docker as well.

1. create a dataset, give a title, subtitle or email(any text area) with underscore `_`, such as `dataverse_11@mailinator.com`
2. edit the dataset metadata randomly, but keep the underscore
3. check the information display in the dataset page, underscore should be there without any strangely backslash. 

![image](https://github.com/user-attachments/assets/c17ab492-6c30-4f49-9998-facd79abe555)

