### PR TITLE
Get Dataset Extension: add Terms of Use

### DIFF
--- a/src/datasets/domain/models/Dataset.ts
+++ b/src/datasets/domain/models/Dataset.ts
@@ -6,6 +6,7 @@ export interface Dataset {
   versionId: number
   versionInfo: DatasetVersionInfo
   license?: DatasetLicense
+  termsOfUse: TermsOfUse
   alternativePersistentId?: string
   publicationDate?: string
   citationDate?: string
@@ -33,6 +34,17 @@ export interface DatasetLicense {
   name: string
   uri: string
   iconUri?: string
+}
+
+export interface TermsOfUse {
+  fileAccessRequest: boolean
+  termsOfAccess?: string
+  dataAccessPlace?: string
+  originalArchive?: string
+  availabilityStatus?: string
+  contactForAccess?: string
+  sizeOfCollection?: string
+  studyCompletion?: string
 }
 
 export type DatasetMetadataBlocks = [CitationMetadataBlock, ...DatasetMetadataBlock[]]

--- a/src/datasets/infra/repositories/transformers/DatasetPayload.ts
+++ b/src/datasets/infra/repositories/transformers/DatasetPayload.ts
@@ -16,6 +16,14 @@ export interface DatasetPayload {
   alternativePersistentId?: string
   publicationDate?: string
   citationDate?: string
+  fileAccessRequest: boolean
+  termsOfAccess?: string
+  dataAccessPlace?: string
+  originalArchive?: string
+  availabilityStatus?: string
+  contactForAccess?: string
+  sizeOfCollection?: string
+  studyCompletion?: string
   files: FilePayload[]
   isPartOf: OwnerNodePayload
 }

--- a/src/datasets/infra/repositories/transformers/datasetTransformers.ts
+++ b/src/datasets/infra/repositories/transformers/datasetTransformers.ts
@@ -233,6 +233,16 @@ export const transformVersionPayloadToDataset = (
       lastUpdateTime: new Date(versionPayload.lastUpdateTime),
       releaseTime: new Date(versionPayload.releaseTime)
     },
+    termsOfUse: {
+      fileAccessRequest: versionPayload.fileAccessRequest,
+      termsOfAccess: versionPayload.termsOfAccess,
+      dataAccessPlace: versionPayload.dataAccessPlace,
+      originalArchive: versionPayload.originalArchive,
+      availabilityStatus: versionPayload.availabilityStatus,
+      contactForAccess: versionPayload.contactForAccess,
+      sizeOfCollection: versionPayload.sizeOfCollection,
+      studyCompletion: versionPayload.studyCompletion
+    },
     metadataBlocks: transformPayloadToDatasetMetadataBlocks(
       versionPayload.metadataBlocks,
       keepRawFields

--- a/test/testHelpers/datasets/datasetHelper.ts
+++ b/test/testHelpers/datasets/datasetHelper.ts
@@ -52,6 +52,16 @@ export const createDatasetModel = (
       lastUpdateTime: new Date(DATASET_UPDATE_TIME_STR),
       releaseTime: new Date(DATASET_RELEASE_TIME_STR)
     },
+    termsOfUse: {
+      fileAccessRequest: true,
+      termsOfAccess: 'Terms of access',
+      dataAccessPlace: 'Data access place',
+      originalArchive: 'Original archive',
+      availabilityStatus: 'Availability status',
+      contactForAccess: 'Contact for access',
+      sizeOfCollection: 'Size of collection',
+      studyCompletion: 'Study completion'
+    },
     publicationDate: DATASET_PUBLICATION_DATE_STR,
     metadataBlocks: [
       {
@@ -111,6 +121,14 @@ export const createDatasetVersionPayload = (
     releaseTime: DATASET_RELEASE_TIME_STR,
     createTime: DATASET_CREATE_TIME_STR,
     publicationDate: DATASET_PUBLICATION_DATE_STR,
+    fileAccessRequest: true,
+    termsOfAccess: 'Terms of access',
+    dataAccessPlace: 'Data access place',
+    originalArchive: 'Original archive',
+    availabilityStatus: 'Availability status',
+    contactForAccess: 'Contact for access',
+    sizeOfCollection: 'Size of collection',
+    studyCompletion: 'Study completion',
     metadataBlocks: {
       citation: {
         name: 'citation',


### PR DESCRIPTION
## What this PR does / why we need it:
For the Dataset Page: Terms of Use tab, we need all the Terms of Use fields associated with the Datset

## Which issue(s) this PR closes:

- Closes #239 

## Related Dataverse PRs:

- Depends on #

## Suggestions on how to test this:

Visual code inspection and validate new tests
