### PR TITLE
Modify payload sent in Create/Update Collection - JS-Dataverse

### DIFF
--- a/src/collections/domain/dtos/CollectionDTO.ts
+++ b/src/collections/domain/dtos/CollectionDTO.ts
@@ -10,6 +10,8 @@ export interface CollectionDTO {
   metadataBlockNames?: string[]
   facetIds?: string[]
   inputLevels?: CollectionInputLevelDTO[]
+  inheritMetadataBlocksFromParent: boolean
+  inheritFacetsFromParent: boolean
 }
 
 export interface CollectionInputLevelDTO {

--- a/src/collections/infra/repositories/CollectionsRepository.ts
+++ b/src/collections/infra/repositories/CollectionsRepository.ts
@@ -190,18 +190,31 @@ export class CollectionsRepository extends ApiRepository implements ICollections
 
     const metadataBlocksRequestBody: NewCollectionMetadataBlocksRequestPayload = {}
 
-    if (collectionDTO.metadataBlockNames && collectionDTO.inputLevels) {
+    if (collectionDTO.inheritMetadataBlocksFromParent) {
+      metadataBlocksRequestBody['inheritMetadataBlocksFromParent'] = true
+    } else {
       metadataBlocksRequestBody['metadataBlockNames'] = collectionDTO.metadataBlockNames
       metadataBlocksRequestBody['inputLevels'] = inputLevelsRequestBody
-    } else {
-      metadataBlocksRequestBody['inheritMetadataBlocksFromParent'] = true
     }
 
-    if (collectionDTO.facetIds) {
-      metadataBlocksRequestBody['facetIds'] = collectionDTO.facetIds
-    } else {
+    if (collectionDTO.inheritFacetsFromParent) {
       metadataBlocksRequestBody['inheritFacetsFromParent'] = true
+    } else {
+      metadataBlocksRequestBody['facetIds'] = collectionDTO.facetIds
     }
+
+    // if (collectionDTO.metadataBlockNames && collectionDTO.inputLevels) {
+    //   metadataBlocksRequestBody['metadataBlockNames'] = collectionDTO.metadataBlockNames
+    //   metadataBlocksRequestBody['inputLevels'] = inputLevelsRequestBody
+    // } else {
+    //   metadataBlocksRequestBody['inheritMetadataBlocksFromParent'] = true
+    // }
+
+    // if (collectionDTO.facetIds) {
+    //   metadataBlocksRequestBody['facetIds'] = collectionDTO.facetIds
+    // } else {
+    //   metadataBlocksRequestBody['inheritFacetsFromParent'] = true
+    // }
 
     return {
       alias: collectionDTO.alias,
@@ -210,7 +223,13 @@ export class CollectionsRepository extends ApiRepository implements ICollections
       dataverseType: collectionDTO.type,
       ...(collectionDTO.description && { description: collectionDTO.description }),
       ...(collectionDTO.affiliation && { affiliation: collectionDTO.affiliation }),
-      metadataBlocks: metadataBlocksRequestBody
+      metadataBlocks: {
+        metadataBlockNames: collectionDTO.metadataBlockNames,
+        facetIds: collectionDTO.facetIds,
+        inputLevels: inputLevelsRequestBody,
+        inheritFacetsFromParent: metadataBlocksRequestBody.inheritFacetsFromParent,
+        inheritMetadataBlocksFromParent: metadataBlocksRequestBody.inheritMetadataBlocksFromParent
+      }
     }
   }
 

--- a/src/collections/infra/repositories/CollectionsRepository.ts
+++ b/src/collections/infra/repositories/CollectionsRepository.ts
@@ -227,13 +227,7 @@ export class CollectionsRepository extends ApiRepository implements ICollections
       dataverseType: collectionDTO.type,
       ...(collectionDTO.description && { description: collectionDTO.description }),
       ...(collectionDTO.affiliation && { affiliation: collectionDTO.affiliation }),
-      metadataBlocks: {
-        metadataBlockNames: collectionDTO.metadataBlockNames,
-        facetIds: collectionDTO.facetIds,
-        inputLevels: inputLevelsRequestBody,
-        inheritFacetsFromParent: metadataBlocksRequestBody.inheritFacetsFromParent,
-        inheritMetadataBlocksFromParent: metadataBlocksRequestBody.inheritMetadataBlocksFromParent
-      }
+      metadataBlocks: metadataBlocksRequestBody
     }
   }
 

--- a/src/collections/infra/repositories/CollectionsRepository.ts
+++ b/src/collections/infra/repositories/CollectionsRepository.ts
@@ -192,33 +192,17 @@ export class CollectionsRepository extends ApiRepository implements ICollections
         required: inputLevel.required
       }))
 
-    const metadataBlocksRequestBody: NewCollectionMetadataBlocksRequestPayload = {}
-
-    if (collectionDTO.inheritMetadataBlocksFromParent) {
-      metadataBlocksRequestBody['inheritMetadataBlocksFromParent'] = true
-    } else {
-      metadataBlocksRequestBody['metadataBlockNames'] = collectionDTO.metadataBlockNames
-      metadataBlocksRequestBody['inputLevels'] = inputLevelsRequestBody
+    const metadataBlocksRequestBody: NewCollectionMetadataBlocksRequestPayload = {
+      ...(!collectionDTO.inheritMetadataBlocksFromParent && {
+        metadataBlockNames: collectionDTO.metadataBlockNames,
+        inputLevels: inputLevelsRequestBody
+      }),
+      ...(!collectionDTO.inheritFacetsFromParent && {
+        facetIds: collectionDTO.facetIds
+      }),
+      inheritMetadataBlocksFromParent: collectionDTO.inheritMetadataBlocksFromParent,
+      inheritFacetsFromParent: collectionDTO.inheritFacetsFromParent
     }
-
-    if (collectionDTO.inheritFacetsFromParent) {
-      metadataBlocksRequestBody['inheritFacetsFromParent'] = true
-    } else {
-      metadataBlocksRequestBody['facetIds'] = collectionDTO.facetIds
-    }
-
-    // if (collectionDTO.metadataBlockNames && collectionDTO.inputLevels) {
-    //   metadataBlocksRequestBody['metadataBlockNames'] = collectionDTO.metadataBlockNames
-    //   metadataBlocksRequestBody['inputLevels'] = inputLevelsRequestBody
-    // } else {
-    //   metadataBlocksRequestBody['inheritMetadataBlocksFromParent'] = true
-    // }
-
-    // if (collectionDTO.facetIds) {
-    //   metadataBlocksRequestBody['facetIds'] = collectionDTO.facetIds
-    // } else {
-    //   metadataBlocksRequestBody['inheritFacetsFromParent'] = true
-    // }
 
     return {
       alias: collectionDTO.alias,

--- a/src/collections/infra/repositories/CollectionsRepository.ts
+++ b/src/collections/infra/repositories/CollectionsRepository.ts
@@ -36,6 +36,8 @@ export interface NewCollectionMetadataBlocksRequestPayload {
   metadataBlockNames?: string[]
   facetIds?: string[]
   inputLevels?: NewCollectionInputLevelRequestPayload[]
+  inheritMetadataBlocksFromParent?: boolean
+  inheritFacetsFromParent?: boolean
 }
 
 export interface NewCollectionInputLevelRequestPayload {
@@ -186,6 +188,21 @@ export class CollectionsRepository extends ApiRepository implements ICollections
         required: inputLevel.required
       }))
 
+    const metadataBlocksRequestBody: NewCollectionMetadataBlocksRequestPayload = {}
+
+    if (collectionDTO.metadataBlockNames && collectionDTO.inputLevels) {
+      metadataBlocksRequestBody['metadataBlockNames'] = collectionDTO.metadataBlockNames
+      metadataBlocksRequestBody['inputLevels'] = inputLevelsRequestBody
+    } else {
+      metadataBlocksRequestBody['inheritMetadataBlocksFromParent'] = true
+    }
+
+    if (collectionDTO.facetIds) {
+      metadataBlocksRequestBody['facetIds'] = collectionDTO.facetIds
+    } else {
+      metadataBlocksRequestBody['inheritFacetsFromParent'] = true
+    }
+
     return {
       alias: collectionDTO.alias,
       name: collectionDTO.name,
@@ -193,11 +210,7 @@ export class CollectionsRepository extends ApiRepository implements ICollections
       dataverseType: collectionDTO.type,
       ...(collectionDTO.description && { description: collectionDTO.description }),
       ...(collectionDTO.affiliation && { affiliation: collectionDTO.affiliation }),
-      metadataBlocks: {
-        metadataBlockNames: collectionDTO.metadataBlockNames,
-        facetIds: collectionDTO.facetIds,
-        inputLevels: inputLevelsRequestBody
-      }
+      metadataBlocks: metadataBlocksRequestBody
     }
   }
 

--- a/test/integration/collections/CollectionsRepository.test.ts
+++ b/test/integration/collections/CollectionsRepository.test.ts
@@ -1,7 +1,7 @@
 import { CollectionsRepository } from '../../../src/collections/infra/repositories/CollectionsRepository'
 import { TestConstants } from '../../testHelpers/TestConstants'
 import {
-  // CollectionDTO,
+  CollectionDTO,
   CollectionFeaturedItemsDTO,
   CollectionItemType,
   CollectionPreview,
@@ -10,7 +10,7 @@ import {
   DatasetPreview,
   FilePreview,
   ReadError,
-  // WriteError,
+  WriteError,
   createDataset
 } from '../../../src'
 import { ApiConfig } from '../../../src'
@@ -146,140 +146,106 @@ describe('CollectionsRepository', () => {
       expect(createdCollection.name).toBe(newCollectionDTO.name)
     })
   })
-  // describe('createCollection', () => {
-  //   const testCreateCollectionAlias1 = 'createCollection-test-1'
-  //   const testCreateCollectionAlias2 = 'createCollection-test-2'
-  //   const testCreateCollectionAlias3 = 'createCollection-test-3'
+  describe('createCollection', () => {
+    const testCreateCollectionAlias1 = 'createCollection-test-1'
+    const testCreateCollectionAlias2 = 'createCollection-test-2'
+    const testCreateCollectionAlias3 = 'createCollection-test-3'
+    const testCreateCollectionAlias4 = 'createCollection-test-4'
+    const testCreateCollectionAlias5 = 'createCollection-test-5'
 
-  //   afterAll(async () => {
-  //     await deleteCollectionViaApi(testCreateCollectionAlias1)
-  //     await deleteCollectionViaApi(testCreateCollectionAlias2)
-  //     await deleteCollectionViaApi(testCreateCollectionAlias3)
-  //   })
+    afterAll(async () => {
+      await deleteCollectionViaApi(testCreateCollectionAlias1)
+      await deleteCollectionViaApi(testCreateCollectionAlias2)
+      await deleteCollectionViaApi(testCreateCollectionAlias3)
+      await deleteCollectionViaApi(testCreateCollectionAlias4)
+      await deleteCollectionViaApi(testCreateCollectionAlias5)
+    })
 
-  //   test('should create collection in root when no parent collection is set', async () => {
-  //     const newCollectionDTO = createCollectionDTO(testCreateCollectionAlias1)
-  //     const actualId = await sut.createCollection(newCollectionDTO)
-  //     expect(typeof actualId).toBe('number')
+    test('should create collection in root when no parent collection is set', async () => {
+      const newCollectionDTO = createCollectionDTO(testCreateCollectionAlias1)
+      const actualId = await sut.createCollection(newCollectionDTO)
+      expect(typeof actualId).toBe('number')
 
-  //     const createdCollection = await sut.getCollection(actualId)
-  //     expect(createdCollection.id).toBe(actualId)
-  //     expect(createdCollection.alias).toBe(newCollectionDTO.alias)
-  //     expect(createdCollection.name).toBe(newCollectionDTO.name)
-  //     expect(createdCollection.affiliation).toBe(newCollectionDTO.affiliation)
-  //     expect(createdCollection.isPartOf.type).toBe('DATAVERSE')
-  //     expect(createdCollection.isPartOf.displayName).toBe('Root')
-  //     expect(createdCollection.isPartOf.identifier).toBe('root')
-  //     expect(createdCollection.isPartOf.isReleased).toBe(true)
+      const createdCollection = await sut.getCollection(actualId)
+      expect(createdCollection.id).toBe(actualId)
+      expect(createdCollection.alias).toBe(newCollectionDTO.alias)
+      expect(createdCollection.name).toBe(newCollectionDTO.name)
+      expect(createdCollection.affiliation).toBe(newCollectionDTO.affiliation)
+      expect(createdCollection.isPartOf.type).toBe('DATAVERSE')
+      expect(createdCollection.isPartOf.displayName).toBe('Root')
+      expect(createdCollection.isPartOf.identifier).toBe('root')
+      expect(createdCollection.isPartOf.isReleased).toBe(true)
 
-  //     expect(createdCollection.inputLevels?.length).toBe(1)
-  //     const inputLevel = createdCollection.inputLevels?.[0]
-  //     expect(inputLevel?.datasetFieldName).toBe('geographicCoverage')
-  //     expect(inputLevel?.include).toBe(true)
-  //     expect(inputLevel?.required).toBe(true)
-  //   })
+      expect(createdCollection.inputLevels?.length).toBe(1)
+      const inputLevel = createdCollection.inputLevels?.[0]
+      expect(inputLevel?.datasetFieldName).toBe('geographicCoverage')
+      expect(inputLevel?.include).toBe(true)
+      expect(inputLevel?.required).toBe(true)
+    })
 
-  //   test('should create collection in parent collection when parent collection is set', async () => {
-  //     const actualId = await sut.createCollection(
-  //       createCollectionDTO(testCreateCollectionAlias2),
-  //       testCollectionId
-  //     )
-  //     expect(typeof actualId).toBe('number')
+    test('should create collection in parent collection when parent collection is set', async () => {
+      const actualId = await sut.createCollection(
+        createCollectionDTO(testCreateCollectionAlias2),
+        testCollectionId
+      )
+      expect(typeof actualId).toBe('number')
 
-  //     const collectionCreated = await sut.getCollection(actualId)
+      const collectionCreated = await sut.getCollection(actualId)
 
-  //     expect(collectionCreated.isMetadataBlockRoot).toBe(true)
-  //     expect(collectionCreated.isFacetRoot).toBe(true)
-  //   })
+      expect(collectionCreated.isMetadataBlockRoot).toBe(true)
+      expect(collectionCreated.isFacetRoot).toBe(true)
+    })
 
-  //   test('should create collection without input levels', async () => {
-  //     const newCollectionDTO = createCollectionDTO(testCreateCollectionAlias3)
-  //     newCollectionDTO.inputLevels = undefined
-  //     const actualId = await sut.createCollection(newCollectionDTO, testCollectionId)
-  //     expect(typeof actualId).toBe('number')
+    test('should create a collection to inherit metadata blocks from parent collection', async () => {
+      const childCollectionDTO = createCollectionDTO(testCreateCollectionAlias3)
+      childCollectionDTO.inheritMetadataBlocksFromParent = true
 
-  //     const collectionCreated = await sut.getCollection(actualId)
+      const childCollectionId = await sut.createCollection(childCollectionDTO)
 
-  //     expect(collectionCreated.isMetadataBlockRoot).toBe(false)
-  //     expect(collectionCreated.isFacetRoot).toBe(true)
-  //   })
+      const childCollection = await sut.getCollection(childCollectionId)
 
-  //   test('should create a collection to inherit metadata blocks from parent collection', async () => {
-  //     const parentCollectionAlias = 'inherit-metablocks-parent'
-  //     const parentCollectionDTO = createCollectionDTO(parentCollectionAlias)
-  //     const parentCollectionId = await sut.createCollection(parentCollectionDTO)
+      expect(childCollection.isMetadataBlockRoot).toBe(false)
+      expect(childCollection.isFacetRoot).toBe(true)
+    })
 
-  //     const childCollectionAlias = 'inherit-metablocks-child'
-  //     const childCollectionDTO = createCollectionDTO(childCollectionAlias)
-  //     childCollectionDTO.metadataBlockNames = undefined
-  //     childCollectionDTO.inputLevels = undefined
+    test('should create a collection to inherit facets from parent collection', async () => {
+      const childCollectionDTO = createCollectionDTO(testCreateCollectionAlias4)
+      childCollectionDTO.inheritFacetsFromParent = true
 
-  //     const childCollectionId = await sut.createCollection(childCollectionDTO, parentCollectionId)
+      const childCollectionId = await sut.createCollection(childCollectionDTO)
 
-  //     const childCollection = await sut.getCollection(childCollectionId)
+      const childCollection = await sut.getCollection(childCollectionId)
 
-  //     expect(childCollection.isMetadataBlockRoot).toBe(false)
-  //     expect(childCollection.isFacetRoot).toBe(true)
+      expect(childCollection.isMetadataBlockRoot).toBe(true)
+      expect(childCollection.isFacetRoot).toBe(false)
+    })
 
-  //     await deleteCollectionViaApi(childCollectionAlias)
-  //     await deleteCollectionViaApi(parentCollectionAlias)
-  //   })
+    test('should create a collection to inherit metadata blocks and facets from parent collection', async () => {
+      const childCollectionDTO = createCollectionDTO(testCreateCollectionAlias5)
+      childCollectionDTO.inheritMetadataBlocksFromParent = true
+      childCollectionDTO.inheritFacetsFromParent = true
 
-  //   test('should create a collection to inherit facets from parent collection', async () => {
-  //     const parentCollectionAlias = 'inherit-facets-parent'
-  //     const parentCollectionDTO = createCollectionDTO(parentCollectionAlias)
-  //     const parentCollectionId = await sut.createCollection(parentCollectionDTO)
+      const childCollectionId = await sut.createCollection(childCollectionDTO)
 
-  //     const childCollectionAlias = 'inherit-facets-child'
-  //     const childCollectionDTO = createCollectionDTO(childCollectionAlias)
-  //     childCollectionDTO.facetIds = undefined
+      const childCollection = await sut.getCollection(childCollectionId)
 
-  //     const childCollectionId = await sut.createCollection(childCollectionDTO, parentCollectionId)
+      expect(childCollection.isMetadataBlockRoot).toBe(false)
+      expect(childCollection.isFacetRoot).toBe(false)
+    })
 
-  //     const childCollection = await sut.getCollection(childCollectionId)
-
-  //     expect(childCollection.isMetadataBlockRoot).toBe(true)
-  //     expect(childCollection.isFacetRoot).toBe(false)
-
-  //     await deleteCollectionViaApi(childCollectionAlias)
-  //     await deleteCollectionViaApi(parentCollectionAlias)
-  //   })
-
-  //   test('should create a collection to inherit metadata blocks and facets from parent collection', async () => {
-  //     const parentCollectionAlias = 'inherit-metablocks-facets-parent'
-  //     const parentCollectionDTO = createCollectionDTO(parentCollectionAlias)
-  //     const parentCollectionId = await sut.createCollection(parentCollectionDTO)
-
-  //     const childCollectionAlias = 'inherit-metablocks-facets-child'
-  //     const childCollectionDTO = createCollectionDTO(childCollectionAlias)
-  //     childCollectionDTO.metadataBlockNames = undefined
-  //     childCollectionDTO.inputLevels = undefined
-  //     childCollectionDTO.facetIds = undefined
-
-  //     const childCollectionId = await sut.createCollection(childCollectionDTO, parentCollectionId)
-
-  //     const childCollection = await sut.getCollection(childCollectionId)
-
-  //     expect(childCollection.isMetadataBlockRoot).toBe(false)
-  //     expect(childCollection.isFacetRoot).toBe(false)
-
-  //     await deleteCollectionViaApi(childCollectionAlias)
-  //     await deleteCollectionViaApi(parentCollectionAlias)
-  //   })
-
-  //   test('should return error when parent collection does not exist', async () => {
-  //     const expectedError = new WriteError(
-  //       `[404] Can't find dataverse with identifier='${TestConstants.TEST_DUMMY_COLLECTION_ID}'`
-  //     )
-  //     const testCreateCollectionAlias3 = 'createCollection-test-3'
-  //     await expect(
-  //       sut.createCollection(
-  //         createCollectionDTO(testCreateCollectionAlias3),
-  //         TestConstants.TEST_DUMMY_COLLECTION_ID
-  //       )
-  //     ).rejects.toThrow(expectedError)
-  //   })
-  // })
+    test('should return error when parent collection does not exist', async () => {
+      const expectedError = new WriteError(
+        `[404] Can't find dataverse with identifier='${TestConstants.TEST_DUMMY_COLLECTION_ID}'`
+      )
+      const testCreateCollectionAlias3 = 'createCollection-test-3'
+      await expect(
+        sut.createCollection(
+          createCollectionDTO(testCreateCollectionAlias3),
+          TestConstants.TEST_DUMMY_COLLECTION_ID
+        )
+      ).rejects.toThrow(expectedError)
+    })
+  })
 
   describe('getCollectionFacets', () => {
     test('should return collection facets given a valid collection alias', async () => {
@@ -895,234 +861,188 @@ describe('CollectionsRepository', () => {
     })
   })
 
-  // describe('updateCollection', () => {
-  //   const testUpdatedCollectionAlias = 'updateCollection-test-updatedAlias'
+  describe('updateCollection', () => {
+    const testUpdatedCollectionAlias = 'updateCollection-test-updatedAlias'
 
-  //   afterAll(async () => {
-  //     await deleteCollectionViaApi(testUpdatedCollectionAlias)
-  //   })
+    afterAll(async () => {
+      await deleteCollectionViaApi(testUpdatedCollectionAlias)
+    })
 
-  //   test('should update the collection', async () => {
-  //     // First we create a test collection using a CollectionDTO and createCollection method
-  //     const collectionDTO = createCollectionDTO('updatedCollection-test-originalAlias')
-  //     const testUpdateCollectionId = await sut.createCollection(collectionDTO)
-  //     const createdCollection = await sut.getCollection(testUpdateCollectionId)
-  //     expect(createdCollection.id).toBe(testUpdateCollectionId)
-  //     expect(createdCollection.alias).toBe(collectionDTO.alias)
-  //     expect(createdCollection.name).toBe(collectionDTO.name)
-  //     expect(createdCollection.affiliation).toBe(collectionDTO.affiliation)
-  //     expect(createdCollection.inputLevels?.length).toBe(1)
-  //     const inputLevel = createdCollection.inputLevels?.[0]
-  //     expect(inputLevel?.datasetFieldName).toBe('geographicCoverage')
-  //     expect(inputLevel?.include).toBe(true)
-  //     expect(inputLevel?.required).toBe(true)
+    test('should update the collection', async () => {
+      // First we create a test collection using a CollectionDTO and createCollection method
+      const collectionDTO = createCollectionDTO('updatedCollection-test-originalAlias')
+      const testUpdateCollectionId = await sut.createCollection(collectionDTO)
+      const createdCollection = await sut.getCollection(testUpdateCollectionId)
+      expect(createdCollection.id).toBe(testUpdateCollectionId)
+      expect(createdCollection.alias).toBe(collectionDTO.alias)
+      expect(createdCollection.name).toBe(collectionDTO.name)
+      expect(createdCollection.affiliation).toBe(collectionDTO.affiliation)
+      expect(createdCollection.inputLevels?.length).toBe(1)
+      const inputLevel = createdCollection.inputLevels?.[0]
+      expect(inputLevel?.datasetFieldName).toBe('geographicCoverage')
+      expect(inputLevel?.include).toBe(true)
+      expect(inputLevel?.required).toBe(true)
 
-  //     // Now we update CollectionDTO and verify updates are correctly persisted after calling updateCollection method
-  //     collectionDTO.alias = testUpdatedCollectionAlias
-  //     const updatedCollectionName = 'updatedCollectionName'
-  //     collectionDTO.name = updatedCollectionName
-  //     const updatedCollectionAffiliation = 'updatedCollectionAffiliation'
-  //     collectionDTO.affiliation = updatedCollectionAffiliation
-  //     const updatedInputLevels = [
-  //       {
-  //         datasetFieldName: 'country',
-  //         required: false,
-  //         include: true
-  //       }
-  //     ]
-  //     collectionDTO.inputLevels = updatedInputLevels
-  //     await sut.updateCollection(testUpdateCollectionId, collectionDTO)
-  //     const updatedCollection = await sut.getCollection(testUpdateCollectionId)
-  //     expect(updatedCollection.id).toBe(testUpdateCollectionId)
-  //     expect(updatedCollection.alias).toBe(testUpdatedCollectionAlias)
-  //     expect(updatedCollection.name).toBe(updatedCollectionName)
-  //     expect(updatedCollection.affiliation).toBe(updatedCollectionAffiliation)
-  //     expect(updatedCollection.inputLevels?.length).toBe(1)
-  //     const updatedInputLevel = updatedCollection.inputLevels?.[0]
-  //     expect(updatedInputLevel?.datasetFieldName).toBe('country')
-  //     expect(updatedInputLevel?.include).toBe(true)
-  //     expect(updatedInputLevel?.required).toBe(false)
-  //   })
+      // Now we update CollectionDTO and verify updates are correctly persisted after calling updateCollection method
+      collectionDTO.alias = testUpdatedCollectionAlias
+      const updatedCollectionName = 'updatedCollectionName'
+      collectionDTO.name = updatedCollectionName
+      const updatedCollectionAffiliation = 'updatedCollectionAffiliation'
+      collectionDTO.affiliation = updatedCollectionAffiliation
+      const updatedInputLevels = [
+        {
+          datasetFieldName: 'country',
+          required: false,
+          include: true
+        }
+      ]
+      collectionDTO.inputLevels = updatedInputLevels
+      await sut.updateCollection(testUpdateCollectionId, collectionDTO)
+      const updatedCollection = await sut.getCollection(testUpdateCollectionId)
+      expect(updatedCollection.id).toBe(testUpdateCollectionId)
+      expect(updatedCollection.alias).toBe(testUpdatedCollectionAlias)
+      expect(updatedCollection.name).toBe(updatedCollectionName)
+      expect(updatedCollection.affiliation).toBe(updatedCollectionAffiliation)
+      expect(updatedCollection.inputLevels?.length).toBe(1)
+      const updatedInputLevel = updatedCollection.inputLevels?.[0]
+      expect(updatedInputLevel?.datasetFieldName).toBe('country')
+      expect(updatedInputLevel?.include).toBe(true)
+      expect(updatedInputLevel?.required).toBe(false)
+    })
 
-  //   test('should update the collection to inherit metadata blocks from parent collection', async () => {
-  //     const parentCollectionAlias = 'inherit-metablocks-parent-update'
-  //     const parentCollectionDTO = createCollectionDTO(parentCollectionAlias)
-  //     const parentCollectionId = await sut.createCollection(parentCollectionDTO)
+    test('should update the collection to inherit metadata blocks from parent collection', async () => {
+      const parentCollectionAlias = 'inherit-metablocks-parent-update'
+      const parentCollectionDTO = createCollectionDTO(parentCollectionAlias)
+      const parentCollectionId = await sut.createCollection(parentCollectionDTO)
 
-  //     const childCollectionAlias = 'inherit-metablocks-child-update'
-  //     const childCollectionDTO = createCollectionDTO(childCollectionAlias)
+      const childCollectionAlias = 'inherit-metablocks-child-update'
+      const childCollectionDTO = createCollectionDTO(childCollectionAlias)
 
-  //     const childCollectionId = await sut.createCollection(childCollectionDTO, parentCollectionId)
+      const childCollectionId = await sut.createCollection(childCollectionDTO, parentCollectionId)
 
-  //     const childCollection = await sut.getCollection(childCollectionId)
+      const childCollection = await sut.getCollection(childCollectionId)
 
-  //     expect(childCollection.isMetadataBlockRoot).toBe(true)
-  //     expect(childCollection.isFacetRoot).toBe(true)
+      expect(childCollection.isMetadataBlockRoot).toBe(true)
+      expect(childCollection.isFacetRoot).toBe(true)
 
-  //     const updatedChildCollectionDTO = createCollectionDTO(childCollectionAlias)
-  //     updatedChildCollectionDTO.metadataBlockNames = undefined
-  //     updatedChildCollectionDTO.inputLevels = undefined
+      const updatedChildCollectionDTO = createCollectionDTO(childCollectionAlias)
+      updatedChildCollectionDTO.inheritMetadataBlocksFromParent = true
 
-  //     await sut.updateCollection(childCollectionId, updatedChildCollectionDTO)
+      await sut.updateCollection(childCollectionId, updatedChildCollectionDTO)
 
-  //     const childCollectionAfterUpdate = await sut.getCollection(childCollectionId)
+      const childCollectionAfterUpdate = await sut.getCollection(childCollectionId)
 
-  //     expect(childCollectionAfterUpdate.isMetadataBlockRoot).toBe(false)
-  //     expect(childCollectionAfterUpdate.isFacetRoot).toBe(true)
+      expect(childCollectionAfterUpdate.isMetadataBlockRoot).toBe(false)
+      expect(childCollectionAfterUpdate.isFacetRoot).toBe(true)
 
-  //     await deleteCollectionViaApi(childCollectionAlias)
-  //     await deleteCollectionViaApi(parentCollectionAlias)
-  //   })
+      await deleteCollectionViaApi(childCollectionAlias)
+      await deleteCollectionViaApi(parentCollectionAlias)
+    })
 
-  //   test('should update the collection to inherit facets from parent collection', async () => {
-  //     const parentCollectionAlias = 'inherit-facets-parent-update'
-  //     const parentCollectionDTO = createCollectionDTO(parentCollectionAlias)
-  //     const parentCollectionId = await sut.createCollection(parentCollectionDTO)
+    test('should update the collection to inherit facets from parent collection', async () => {
+      const parentCollectionAlias = 'inherit-facets-parent-update'
+      const parentCollectionDTO = createCollectionDTO(parentCollectionAlias)
+      const parentCollectionId = await sut.createCollection(parentCollectionDTO)
 
-  //     const childCollectionAlias = 'inherit-facets-child-update'
-  //     const childCollectionDTO = createCollectionDTO(childCollectionAlias)
+      const childCollectionAlias = 'inherit-facets-child-update'
+      const childCollectionDTO = createCollectionDTO(childCollectionAlias)
 
-  //     const childCollectionId = await sut.createCollection(childCollectionDTO, parentCollectionId)
+      const childCollectionId = await sut.createCollection(childCollectionDTO, parentCollectionId)
 
-  //     const childCollection = await sut.getCollection(childCollectionId)
+      const childCollection = await sut.getCollection(childCollectionId)
 
-  //     expect(childCollection.isMetadataBlockRoot).toBe(true)
-  //     expect(childCollection.isFacetRoot).toBe(true)
+      expect(childCollection.isMetadataBlockRoot).toBe(true)
+      expect(childCollection.isFacetRoot).toBe(true)
 
-  //     const updatedChildCollectionDTO = createCollectionDTO(childCollectionAlias)
-  //     updatedChildCollectionDTO.facetIds = undefined
+      const updatedChildCollectionDTO = createCollectionDTO(childCollectionAlias)
+      updatedChildCollectionDTO.inheritFacetsFromParent = true
 
-  //     await sut.updateCollection(childCollectionId, updatedChildCollectionDTO)
+      await sut.updateCollection(childCollectionId, updatedChildCollectionDTO)
 
-  //     const childCollectionAfterUpdate = await sut.getCollection(childCollectionId)
+      const childCollectionAfterUpdate = await sut.getCollection(childCollectionId)
 
-  //     expect(childCollectionAfterUpdate.isMetadataBlockRoot).toBe(true)
-  //     expect(childCollectionAfterUpdate.isFacetRoot).toBe(false)
+      expect(childCollectionAfterUpdate.isMetadataBlockRoot).toBe(true)
+      expect(childCollectionAfterUpdate.isFacetRoot).toBe(false)
 
-  //     await deleteCollectionViaApi(childCollectionAlias)
-  //     await deleteCollectionViaApi(parentCollectionAlias)
-  //   })
+      await deleteCollectionViaApi(childCollectionAlias)
+      await deleteCollectionViaApi(parentCollectionAlias)
+    })
 
-  //   test('should update the collection to inherit metadata blocks and facets from parent collection', async () => {
-  //     const parentCollectionAlias = 'inherit-metablocks-facets-parent-update'
-  //     const parentCollectionDTO = createCollectionDTO(parentCollectionAlias)
-  //     const parentCollectionId = await sut.createCollection(parentCollectionDTO)
+    test('should update the collection to inherit metadata blocks and facets from parent collection', async () => {
+      const parentCollectionAlias = 'inherit-metablocks-facets-parent-update'
+      const parentCollectionDTO = createCollectionDTO(parentCollectionAlias)
+      const parentCollectionId = await sut.createCollection(parentCollectionDTO)
 
-  //     const childCollectionAlias = 'inherit-metablocks-facets-child-update'
-  //     const childCollectionDTO = createCollectionDTO(childCollectionAlias)
+      const childCollectionAlias = 'inherit-metablocks-facets-child-update'
+      const childCollectionDTO = createCollectionDTO(childCollectionAlias)
 
-  //     const childCollectionId = await sut.createCollection(childCollectionDTO, parentCollectionId)
+      const childCollectionId = await sut.createCollection(childCollectionDTO, parentCollectionId)
 
-  //     const childCollection = await sut.getCollection(childCollectionId)
+      const childCollection = await sut.getCollection(childCollectionId)
 
-  //     expect(childCollection.isMetadataBlockRoot).toBe(true)
-  //     expect(childCollection.isFacetRoot).toBe(true)
+      expect(childCollection.isMetadataBlockRoot).toBe(true)
+      expect(childCollection.isFacetRoot).toBe(true)
 
-  //     const updatedChildCollectionDTO = createCollectionDTO(childCollectionAlias)
-  //     updatedChildCollectionDTO.metadataBlockNames = undefined
-  //     updatedChildCollectionDTO.inputLevels = undefined
-  //     updatedChildCollectionDTO.facetIds = undefined
+      const updatedChildCollectionDTO = createCollectionDTO(childCollectionAlias)
+      updatedChildCollectionDTO.inheritFacetsFromParent = true
+      updatedChildCollectionDTO.inheritMetadataBlocksFromParent = true
 
-  //     await sut.updateCollection(childCollectionId, updatedChildCollectionDTO)
+      await sut.updateCollection(childCollectionId, updatedChildCollectionDTO)
 
-  //     const childCollectionAfterUpdate = await sut.getCollection(childCollectionId)
+      const childCollectionAfterUpdate = await sut.getCollection(childCollectionId)
 
-  //     expect(childCollectionAfterUpdate.isMetadataBlockRoot).toBe(false)
-  //     expect(childCollectionAfterUpdate.isFacetRoot).toBe(false)
+      expect(childCollectionAfterUpdate.isMetadataBlockRoot).toBe(false)
+      expect(childCollectionAfterUpdate.isFacetRoot).toBe(false)
 
-  //     await deleteCollectionViaApi(childCollectionAlias)
-  //     await deleteCollectionViaApi(parentCollectionAlias)
-  //   })
+      await deleteCollectionViaApi(childCollectionAlias)
+      await deleteCollectionViaApi(parentCollectionAlias)
+    })
 
-  //   // TODO:ME - Cuidado, lo que pasa al enviar inheritFromFacets en root collection
-  //   // Quizas conviene aceptar estas dos flags desde el use case y en el front enviar siempre los facets ids, meta block names en input levels si se esta editando la coleccion root
-  //   /*
-  //     console.log
-  //   {
-  //     rootCollection: '{"id":1,"alias":"root","name":"Root","isReleased":true,"type":"UNCATEGORIZED","isMetadataBlockRoot":true,"isFacetRoot":true,"description":"The root dataverse.","contacts":[{"email":"root@mailinator.com","displayOrder":0}]}'
-  //   }
+    test('should not update root collection facets and keep isMetadataBlockRoot and isFacetRoot in true if facet ids are sent as undefined', async () => {
+      const rootCollection = await sut.getCollection()
 
-  //     at test/integration/collections/CollectionsRepository.test.ts:1032:15
+      const rootCollectionFacets = await sut.getCollectionFacets(rootCollection.alias)
 
-  // console.log
-  //   {
-  //     collectionFacets: '[{"id":2,"name":"authorName","displayName":"Author Name"},{"id":1,"name":"subject","displayName":"Subject"},{"id":4,"name":"keywordValue","displayName":"Keyword Term"},{"id":3,"name":"dateOfDeposit","displayName":"Deposit Date"}]'
-  //   }
+      const updatedRootCollectionDTO: CollectionDTO = {
+        alias: rootCollection.alias,
+        name: rootCollection.name,
+        contacts: [rootCollection.contacts?.[0].email as string],
+        type: rootCollection.type,
+        description: rootCollection.description,
+        affiliation: rootCollection.affiliation,
+        metadataBlockNames: undefined,
+        facetIds: undefined,
+        inputLevels: undefined,
+        inheritFacetsFromParent: false,
+        inheritMetadataBlocksFromParent: false
+      }
 
-  //     at test/integration/collections/CollectionsRepository.test.ts:1036:15
+      await sut.updateCollection(rootCollection.id, updatedRootCollectionDTO)
 
-  // console.log
-  //   {
-  //     rootCollectionAfterUpdate: '{"id":1,"alias":"root","name":"Root","isReleased":true,"type":"UNCATEGORIZED","isMetadataBlockRoot":false,"isFacetRoot":false,"description":"The root dataverse.","contacts":[{"email":"root@mailinator.com","displayOrder":0}]}'
-  //   }
+      const rootCollectionAfterUpdate = await sut.getCollection()
 
-  //     at test/integration/collections/CollectionsRepository.test.ts:1054:15
+      const rootCollectionFacetsAfterUpdate = await sut.getCollectionFacets(rootCollection.alias)
 
-  // console.log
-  //   { collectionFacetsAfterUpdate: '[]' }
-  //   */
+      expect(rootCollectionFacets).toStrictEqual(rootCollectionFacetsAfterUpdate)
+      expect(rootCollection.isMetadataBlockRoot).toBe(true)
+      expect(rootCollection.isFacetRoot).toBe(true)
+      expect(rootCollectionAfterUpdate.isMetadataBlockRoot).toBe(true)
+      expect(rootCollectionAfterUpdate.isFacetRoot).toBe(true)
+    })
 
-  //   test('should not update root collection metadata blocks/input levels and/or facets and keep isMetadataBlockRoot and isFacetRoot in true', async () => {
-  //     const rootCollection = await sut.getCollection()
-
-  //     console.log({ rootCollection: JSON.stringify(rootCollection) })
-
-  //     const collectionFacets = await sut.getCollectionFacets(rootCollection.alias)
-
-  //     console.log({ collectionFacets: JSON.stringify(collectionFacets) })
-
-  //     const updatedRootCollectionDTO: CollectionDTO = {
-  //       alias: rootCollection.alias,
-  //       name: rootCollection.name,
-  //       contacts: [rootCollection.contacts?.[0].email as string],
-  //       type: rootCollection.type,
-  //       description: rootCollection.description,
-  //       affiliation: rootCollection.affiliation,
-  //       metadataBlockNames: undefined,
-  //       facetIds: undefined,
-  //       inputLevels: undefined
-  //     }
-
-  //     await sut.updateCollection(rootCollection.id, updatedRootCollectionDTO)
-
-  //     const rootCollectionAfterUpdate = await sut.getCollection()
-
-  //     console.log({ rootCollectionAfterUpdate: JSON.stringify(rootCollectionAfterUpdate) })
-
-  //     const collectionFacetsAfterUpdate = await sut.getCollectionFacets(rootCollection.alias)
-
-  //     console.log({ collectionFacetsAfterUpdate: JSON.stringify(collectionFacetsAfterUpdate) })
-
-  //     expect(rootCollection.isMetadataBlockRoot).toBe(true)
-  //     expect(rootCollection.isFacetRoot).toBe(true)
-  //   })
-
-  //   test('should return error when collection does not exist', async () => {
-  //     const expectedError = new WriteError(
-  //       `[404] Can't find dataverse with identifier='${TestConstants.TEST_DUMMY_COLLECTION_ID}'`
-  //     )
-  //     const testCollectionAlias = 'updateCollection-not-found-test'
-  //     await expect(
-  //       sut.updateCollection(
-  //         TestConstants.TEST_DUMMY_COLLECTION_ID,
-  //         createCollectionDTO(testCollectionAlias)
-  //       )
-  //     ).rejects.toThrow(expectedError)
-  //   })
-  // })
-  //   test('should return error when collection does not exist', async () => {
-  //     const expectedError = new WriteError(
-  //       `[404] Can't find dataverse with identifier='${TestConstants.TEST_DUMMY_COLLECTION_ID}'`
-  //     )
-  //     const testCollectionAlias = 'updateCollection-not-found-test'
-  //     await expect(
-  //       sut.updateCollection(
-  //         TestConstants.TEST_DUMMY_COLLECTION_ID,
-  //         createCollectionDTO(testCollectionAlias)
-  //       )
-  //     ).rejects.toThrow(expectedError)
-  //   })
-  // })
+    test('should return error when collection does not exist', async () => {
+      const expectedError = new WriteError(
+        `[404] Can't find dataverse with identifier='${TestConstants.TEST_DUMMY_COLLECTION_ID}'`
+      )
+      const testCollectionAlias = 'updateCollection-not-found-test'
+      await expect(
+        sut.updateCollection(
+          TestConstants.TEST_DUMMY_COLLECTION_ID,
+          createCollectionDTO(testCollectionAlias)
+        )
+      ).rejects.toThrow(expectedError)
+    })
+  })
 
   describe('getCollectionFeaturedItems', () => {
     let testFeaturedItemId: number

--- a/test/integration/collections/CollectionsRepository.test.ts
+++ b/test/integration/collections/CollectionsRepository.test.ts
@@ -1,6 +1,7 @@
 import { CollectionsRepository } from '../../../src/collections/infra/repositories/CollectionsRepository'
 import { TestConstants } from '../../testHelpers/TestConstants'
 import {
+  // CollectionDTO,
   CollectionItemType,
   CollectionPreview,
   CollectionSearchCriteria,
@@ -8,7 +9,7 @@ import {
   DatasetPreview,
   FilePreview,
   ReadError,
-  WriteError,
+  // WriteError,
   createDataset
 } from '../../../src'
 import { ApiConfig } from '../../../src'
@@ -137,67 +138,140 @@ describe('CollectionsRepository', () => {
       expect(createdCollection.name).toBe(newCollectionDTO.name)
     })
   })
-  describe('createCollection', () => {
-    const testCreateCollectionAlias1 = 'createCollection-test-1'
-    const testCreateCollectionAlias2 = 'createCollection-test-2'
-    const testCreateCollectionAlias3 = 'createCollection-test-3'
+  // describe('createCollection', () => {
+  //   const testCreateCollectionAlias1 = 'createCollection-test-1'
+  //   const testCreateCollectionAlias2 = 'createCollection-test-2'
+  //   const testCreateCollectionAlias3 = 'createCollection-test-3'
 
-    afterAll(async () => {
-      await deleteCollectionViaApi(testCreateCollectionAlias1)
-      await deleteCollectionViaApi(testCreateCollectionAlias2)
-      await deleteCollectionViaApi(testCreateCollectionAlias3)
-    })
+  //   afterAll(async () => {
+  //     await deleteCollectionViaApi(testCreateCollectionAlias1)
+  //     await deleteCollectionViaApi(testCreateCollectionAlias2)
+  //     await deleteCollectionViaApi(testCreateCollectionAlias3)
+  //   })
 
-    test('should create collection in root when no parent collection is set', async () => {
-      const newCollectionDTO = createCollectionDTO(testCreateCollectionAlias1)
-      const actualId = await sut.createCollection(newCollectionDTO)
-      expect(typeof actualId).toBe('number')
+  //   test('should create collection in root when no parent collection is set', async () => {
+  //     const newCollectionDTO = createCollectionDTO(testCreateCollectionAlias1)
+  //     const actualId = await sut.createCollection(newCollectionDTO)
+  //     expect(typeof actualId).toBe('number')
 
-      const createdCollection = await sut.getCollection(actualId)
-      expect(createdCollection.id).toBe(actualId)
-      expect(createdCollection.alias).toBe(newCollectionDTO.alias)
-      expect(createdCollection.name).toBe(newCollectionDTO.name)
-      expect(createdCollection.affiliation).toBe(newCollectionDTO.affiliation)
-      expect(createdCollection.isPartOf.type).toBe('DATAVERSE')
-      expect(createdCollection.isPartOf.displayName).toBe('Root')
-      expect(createdCollection.isPartOf.identifier).toBe('root')
-      expect(createdCollection.isPartOf.isReleased).toBe(true)
+  //     const createdCollection = await sut.getCollection(actualId)
+  //     expect(createdCollection.id).toBe(actualId)
+  //     expect(createdCollection.alias).toBe(newCollectionDTO.alias)
+  //     expect(createdCollection.name).toBe(newCollectionDTO.name)
+  //     expect(createdCollection.affiliation).toBe(newCollectionDTO.affiliation)
+  //     expect(createdCollection.isPartOf.type).toBe('DATAVERSE')
+  //     expect(createdCollection.isPartOf.displayName).toBe('Root')
+  //     expect(createdCollection.isPartOf.identifier).toBe('root')
+  //     expect(createdCollection.isPartOf.isReleased).toBe(true)
 
-      expect(createdCollection.inputLevels?.length).toBe(1)
-      const inputLevel = createdCollection.inputLevels?.[0]
-      expect(inputLevel?.datasetFieldName).toBe('geographicCoverage')
-      expect(inputLevel?.include).toBe(true)
-      expect(inputLevel?.required).toBe(true)
-    })
+  //     expect(createdCollection.inputLevels?.length).toBe(1)
+  //     const inputLevel = createdCollection.inputLevels?.[0]
+  //     expect(inputLevel?.datasetFieldName).toBe('geographicCoverage')
+  //     expect(inputLevel?.include).toBe(true)
+  //     expect(inputLevel?.required).toBe(true)
+  //   })
 
-    test('should create collection in parent collection when parent collection is set', async () => {
-      const actualId = await sut.createCollection(
-        createCollectionDTO(testCreateCollectionAlias2),
-        testCollectionId
-      )
-      expect(typeof actualId).toBe('number')
-    })
+  //   test('should create collection in parent collection when parent collection is set', async () => {
+  //     const actualId = await sut.createCollection(
+  //       createCollectionDTO(testCreateCollectionAlias2),
+  //       testCollectionId
+  //     )
+  //     expect(typeof actualId).toBe('number')
 
-    test('should create collection without input levels', async () => {
-      const newCollectionDTO = createCollectionDTO(testCreateCollectionAlias3)
-      newCollectionDTO.inputLevels = undefined
-      const actualId = await sut.createCollection(newCollectionDTO, testCollectionId)
-      expect(typeof actualId).toBe('number')
-    })
+  //     const collectionCreated = await sut.getCollection(actualId)
 
-    test('should return error when parent collection does not exist', async () => {
-      const expectedError = new WriteError(
-        `[404] Can't find dataverse with identifier='${TestConstants.TEST_DUMMY_COLLECTION_ID}'`
-      )
-      const testCreateCollectionAlias3 = 'createCollection-test-3'
-      await expect(
-        sut.createCollection(
-          createCollectionDTO(testCreateCollectionAlias3),
-          TestConstants.TEST_DUMMY_COLLECTION_ID
-        )
-      ).rejects.toThrow(expectedError)
-    })
-  })
+  //     expect(collectionCreated.isMetadataBlockRoot).toBe(true)
+  //     expect(collectionCreated.isFacetRoot).toBe(true)
+  //   })
+
+  //   test('should create collection without input levels', async () => {
+  //     const newCollectionDTO = createCollectionDTO(testCreateCollectionAlias3)
+  //     newCollectionDTO.inputLevels = undefined
+  //     const actualId = await sut.createCollection(newCollectionDTO, testCollectionId)
+  //     expect(typeof actualId).toBe('number')
+
+  //     const collectionCreated = await sut.getCollection(actualId)
+
+  //     expect(collectionCreated.isMetadataBlockRoot).toBe(false)
+  //     expect(collectionCreated.isFacetRoot).toBe(true)
+  //   })
+
+  //   test('should create a collection to inherit metadata blocks from parent collection', async () => {
+  //     const parentCollectionAlias = 'inherit-metablocks-parent'
+  //     const parentCollectionDTO = createCollectionDTO(parentCollectionAlias)
+  //     const parentCollectionId = await sut.createCollection(parentCollectionDTO)
+
+  //     const childCollectionAlias = 'inherit-metablocks-child'
+  //     const childCollectionDTO = createCollectionDTO(childCollectionAlias)
+  //     childCollectionDTO.metadataBlockNames = undefined
+  //     childCollectionDTO.inputLevels = undefined
+
+  //     const childCollectionId = await sut.createCollection(childCollectionDTO, parentCollectionId)
+
+  //     const childCollection = await sut.getCollection(childCollectionId)
+
+  //     expect(childCollection.isMetadataBlockRoot).toBe(false)
+  //     expect(childCollection.isFacetRoot).toBe(true)
+
+  //     await deleteCollectionViaApi(childCollectionAlias)
+  //     await deleteCollectionViaApi(parentCollectionAlias)
+  //   })
+
+  //   test('should create a collection to inherit facets from parent collection', async () => {
+  //     const parentCollectionAlias = 'inherit-facets-parent'
+  //     const parentCollectionDTO = createCollectionDTO(parentCollectionAlias)
+  //     const parentCollectionId = await sut.createCollection(parentCollectionDTO)
+
+  //     const childCollectionAlias = 'inherit-facets-child'
+  //     const childCollectionDTO = createCollectionDTO(childCollectionAlias)
+  //     childCollectionDTO.facetIds = undefined
+
+  //     const childCollectionId = await sut.createCollection(childCollectionDTO, parentCollectionId)
+
+  //     const childCollection = await sut.getCollection(childCollectionId)
+
+  //     expect(childCollection.isMetadataBlockRoot).toBe(true)
+  //     expect(childCollection.isFacetRoot).toBe(false)
+
+  //     await deleteCollectionViaApi(childCollectionAlias)
+  //     await deleteCollectionViaApi(parentCollectionAlias)
+  //   })
+
+  //   test('should create a collection to inherit metadata blocks and facets from parent collection', async () => {
+  //     const parentCollectionAlias = 'inherit-metablocks-facets-parent'
+  //     const parentCollectionDTO = createCollectionDTO(parentCollectionAlias)
+  //     const parentCollectionId = await sut.createCollection(parentCollectionDTO)
+
+  //     const childCollectionAlias = 'inherit-metablocks-facets-child'
+  //     const childCollectionDTO = createCollectionDTO(childCollectionAlias)
+  //     childCollectionDTO.metadataBlockNames = undefined
+  //     childCollectionDTO.inputLevels = undefined
+  //     childCollectionDTO.facetIds = undefined
+
+  //     const childCollectionId = await sut.createCollection(childCollectionDTO, parentCollectionId)
+
+  //     const childCollection = await sut.getCollection(childCollectionId)
+
+  //     expect(childCollection.isMetadataBlockRoot).toBe(false)
+  //     expect(childCollection.isFacetRoot).toBe(false)
+
+  //     await deleteCollectionViaApi(childCollectionAlias)
+  //     await deleteCollectionViaApi(parentCollectionAlias)
+  //   })
+
+  //   test('should return error when parent collection does not exist', async () => {
+  //     const expectedError = new WriteError(
+  //       `[404] Can't find dataverse with identifier='${TestConstants.TEST_DUMMY_COLLECTION_ID}'`
+  //     )
+  //     const testCreateCollectionAlias3 = 'createCollection-test-3'
+  //     await expect(
+  //       sut.createCollection(
+  //         createCollectionDTO(testCreateCollectionAlias3),
+  //         TestConstants.TEST_DUMMY_COLLECTION_ID
+  //       )
+  //     ).rejects.toThrow(expectedError)
+  //   })
+  // })
 
   describe('getCollectionFacets', () => {
     test('should return collection facets given a valid collection alias', async () => {
@@ -813,66 +887,219 @@ describe('CollectionsRepository', () => {
     })
   })
 
-  describe('updateCollection', () => {
-    const testUpdatedCollectionAlias = 'updateCollection-test-updatedAlias'
+  // describe('updateCollection', () => {
+  //   const testUpdatedCollectionAlias = 'updateCollection-test-updatedAlias'
 
-    afterAll(async () => {
-      await deleteCollectionViaApi(testUpdatedCollectionAlias)
-    })
+  //   afterAll(async () => {
+  //     await deleteCollectionViaApi(testUpdatedCollectionAlias)
+  //   })
 
-    test('should update the collection', async () => {
-      // First we create a test collection using a CollectionDTO and createCollection method
-      const collectionDTO = createCollectionDTO('updatedCollection-test-originalAlias')
-      const testUpdateCollectionId = await sut.createCollection(collectionDTO)
-      const createdCollection = await sut.getCollection(testUpdateCollectionId)
-      expect(createdCollection.id).toBe(testUpdateCollectionId)
-      expect(createdCollection.alias).toBe(collectionDTO.alias)
-      expect(createdCollection.name).toBe(collectionDTO.name)
-      expect(createdCollection.affiliation).toBe(collectionDTO.affiliation)
-      expect(createdCollection.inputLevels?.length).toBe(1)
-      const inputLevel = createdCollection.inputLevels?.[0]
-      expect(inputLevel?.datasetFieldName).toBe('geographicCoverage')
-      expect(inputLevel?.include).toBe(true)
-      expect(inputLevel?.required).toBe(true)
+  //   test('should update the collection', async () => {
+  //     // First we create a test collection using a CollectionDTO and createCollection method
+  //     const collectionDTO = createCollectionDTO('updatedCollection-test-originalAlias')
+  //     const testUpdateCollectionId = await sut.createCollection(collectionDTO)
+  //     const createdCollection = await sut.getCollection(testUpdateCollectionId)
+  //     expect(createdCollection.id).toBe(testUpdateCollectionId)
+  //     expect(createdCollection.alias).toBe(collectionDTO.alias)
+  //     expect(createdCollection.name).toBe(collectionDTO.name)
+  //     expect(createdCollection.affiliation).toBe(collectionDTO.affiliation)
+  //     expect(createdCollection.inputLevels?.length).toBe(1)
+  //     const inputLevel = createdCollection.inputLevels?.[0]
+  //     expect(inputLevel?.datasetFieldName).toBe('geographicCoverage')
+  //     expect(inputLevel?.include).toBe(true)
+  //     expect(inputLevel?.required).toBe(true)
 
-      // Now we update CollectionDTO and verify updates are correctly persisted after calling updateCollection method
-      collectionDTO.alias = testUpdatedCollectionAlias
-      const updatedCollectionName = 'updatedCollectionName'
-      collectionDTO.name = updatedCollectionName
-      const updatedCollectionAffiliation = 'updatedCollectionAffiliation'
-      collectionDTO.affiliation = updatedCollectionAffiliation
-      const updatedInputLevels = [
-        {
-          datasetFieldName: 'country',
-          required: false,
-          include: true
-        }
-      ]
-      collectionDTO.inputLevels = updatedInputLevels
-      await sut.updateCollection(testUpdateCollectionId, collectionDTO)
-      const updatedCollection = await sut.getCollection(testUpdateCollectionId)
-      expect(updatedCollection.id).toBe(testUpdateCollectionId)
-      expect(updatedCollection.alias).toBe(testUpdatedCollectionAlias)
-      expect(updatedCollection.name).toBe(updatedCollectionName)
-      expect(updatedCollection.affiliation).toBe(updatedCollectionAffiliation)
-      expect(updatedCollection.inputLevels?.length).toBe(1)
-      const updatedInputLevel = updatedCollection.inputLevels?.[0]
-      expect(updatedInputLevel?.datasetFieldName).toBe('country')
-      expect(updatedInputLevel?.include).toBe(true)
-      expect(updatedInputLevel?.required).toBe(false)
-    })
+  //     // Now we update CollectionDTO and verify updates are correctly persisted after calling updateCollection method
+  //     collectionDTO.alias = testUpdatedCollectionAlias
+  //     const updatedCollectionName = 'updatedCollectionName'
+  //     collectionDTO.name = updatedCollectionName
+  //     const updatedCollectionAffiliation = 'updatedCollectionAffiliation'
+  //     collectionDTO.affiliation = updatedCollectionAffiliation
+  //     const updatedInputLevels = [
+  //       {
+  //         datasetFieldName: 'country',
+  //         required: false,
+  //         include: true
+  //       }
+  //     ]
+  //     collectionDTO.inputLevels = updatedInputLevels
+  //     await sut.updateCollection(testUpdateCollectionId, collectionDTO)
+  //     const updatedCollection = await sut.getCollection(testUpdateCollectionId)
+  //     expect(updatedCollection.id).toBe(testUpdateCollectionId)
+  //     expect(updatedCollection.alias).toBe(testUpdatedCollectionAlias)
+  //     expect(updatedCollection.name).toBe(updatedCollectionName)
+  //     expect(updatedCollection.affiliation).toBe(updatedCollectionAffiliation)
+  //     expect(updatedCollection.inputLevels?.length).toBe(1)
+  //     const updatedInputLevel = updatedCollection.inputLevels?.[0]
+  //     expect(updatedInputLevel?.datasetFieldName).toBe('country')
+  //     expect(updatedInputLevel?.include).toBe(true)
+  //     expect(updatedInputLevel?.required).toBe(false)
+  //   })
 
-    test('should return error when collection does not exist', async () => {
-      const expectedError = new WriteError(
-        `[404] Can't find dataverse with identifier='${TestConstants.TEST_DUMMY_COLLECTION_ID}'`
-      )
-      const testCollectionAlias = 'updateCollection-not-found-test'
-      await expect(
-        sut.updateCollection(
-          TestConstants.TEST_DUMMY_COLLECTION_ID,
-          createCollectionDTO(testCollectionAlias)
-        )
-      ).rejects.toThrow(expectedError)
-    })
-  })
+  //   test('should update the collection to inherit metadata blocks from parent collection', async () => {
+  //     const parentCollectionAlias = 'inherit-metablocks-parent-update'
+  //     const parentCollectionDTO = createCollectionDTO(parentCollectionAlias)
+  //     const parentCollectionId = await sut.createCollection(parentCollectionDTO)
+
+  //     const childCollectionAlias = 'inherit-metablocks-child-update'
+  //     const childCollectionDTO = createCollectionDTO(childCollectionAlias)
+
+  //     const childCollectionId = await sut.createCollection(childCollectionDTO, parentCollectionId)
+
+  //     const childCollection = await sut.getCollection(childCollectionId)
+
+  //     expect(childCollection.isMetadataBlockRoot).toBe(true)
+  //     expect(childCollection.isFacetRoot).toBe(true)
+
+  //     const updatedChildCollectionDTO = createCollectionDTO(childCollectionAlias)
+  //     updatedChildCollectionDTO.metadataBlockNames = undefined
+  //     updatedChildCollectionDTO.inputLevels = undefined
+
+  //     await sut.updateCollection(childCollectionId, updatedChildCollectionDTO)
+
+  //     const childCollectionAfterUpdate = await sut.getCollection(childCollectionId)
+
+  //     expect(childCollectionAfterUpdate.isMetadataBlockRoot).toBe(false)
+  //     expect(childCollectionAfterUpdate.isFacetRoot).toBe(true)
+
+  //     await deleteCollectionViaApi(childCollectionAlias)
+  //     await deleteCollectionViaApi(parentCollectionAlias)
+  //   })
+
+  //   test('should update the collection to inherit facets from parent collection', async () => {
+  //     const parentCollectionAlias = 'inherit-facets-parent-update'
+  //     const parentCollectionDTO = createCollectionDTO(parentCollectionAlias)
+  //     const parentCollectionId = await sut.createCollection(parentCollectionDTO)
+
+  //     const childCollectionAlias = 'inherit-facets-child-update'
+  //     const childCollectionDTO = createCollectionDTO(childCollectionAlias)
+
+  //     const childCollectionId = await sut.createCollection(childCollectionDTO, parentCollectionId)
+
+  //     const childCollection = await sut.getCollection(childCollectionId)
+
+  //     expect(childCollection.isMetadataBlockRoot).toBe(true)
+  //     expect(childCollection.isFacetRoot).toBe(true)
+
+  //     const updatedChildCollectionDTO = createCollectionDTO(childCollectionAlias)
+  //     updatedChildCollectionDTO.facetIds = undefined
+
+  //     await sut.updateCollection(childCollectionId, updatedChildCollectionDTO)
+
+  //     const childCollectionAfterUpdate = await sut.getCollection(childCollectionId)
+
+  //     expect(childCollectionAfterUpdate.isMetadataBlockRoot).toBe(true)
+  //     expect(childCollectionAfterUpdate.isFacetRoot).toBe(false)
+
+  //     await deleteCollectionViaApi(childCollectionAlias)
+  //     await deleteCollectionViaApi(parentCollectionAlias)
+  //   })
+
+  //   test('should update the collection to inherit metadata blocks and facets from parent collection', async () => {
+  //     const parentCollectionAlias = 'inherit-metablocks-facets-parent-update'
+  //     const parentCollectionDTO = createCollectionDTO(parentCollectionAlias)
+  //     const parentCollectionId = await sut.createCollection(parentCollectionDTO)
+
+  //     const childCollectionAlias = 'inherit-metablocks-facets-child-update'
+  //     const childCollectionDTO = createCollectionDTO(childCollectionAlias)
+
+  //     const childCollectionId = await sut.createCollection(childCollectionDTO, parentCollectionId)
+
+  //     const childCollection = await sut.getCollection(childCollectionId)
+
+  //     expect(childCollection.isMetadataBlockRoot).toBe(true)
+  //     expect(childCollection.isFacetRoot).toBe(true)
+
+  //     const updatedChildCollectionDTO = createCollectionDTO(childCollectionAlias)
+  //     updatedChildCollectionDTO.metadataBlockNames = undefined
+  //     updatedChildCollectionDTO.inputLevels = undefined
+  //     updatedChildCollectionDTO.facetIds = undefined
+
+  //     await sut.updateCollection(childCollectionId, updatedChildCollectionDTO)
+
+  //     const childCollectionAfterUpdate = await sut.getCollection(childCollectionId)
+
+  //     expect(childCollectionAfterUpdate.isMetadataBlockRoot).toBe(false)
+  //     expect(childCollectionAfterUpdate.isFacetRoot).toBe(false)
+
+  //     await deleteCollectionViaApi(childCollectionAlias)
+  //     await deleteCollectionViaApi(parentCollectionAlias)
+  //   })
+
+  //   // TODO:ME - Cuidado, lo que pasa al enviar inheritFromFacets en root collection
+  //   // Quizas conviene aceptar estas dos flags desde el use case y en el front enviar siempre los facets ids, meta block names en input levels si se esta editando la coleccion root
+  //   /*
+  //     console.log
+  //   {
+  //     rootCollection: '{"id":1,"alias":"root","name":"Root","isReleased":true,"type":"UNCATEGORIZED","isMetadataBlockRoot":true,"isFacetRoot":true,"description":"The root dataverse.","contacts":[{"email":"root@mailinator.com","displayOrder":0}]}'
+  //   }
+
+  //     at test/integration/collections/CollectionsRepository.test.ts:1032:15
+
+  // console.log
+  //   {
+  //     collectionFacets: '[{"id":2,"name":"authorName","displayName":"Author Name"},{"id":1,"name":"subject","displayName":"Subject"},{"id":4,"name":"keywordValue","displayName":"Keyword Term"},{"id":3,"name":"dateOfDeposit","displayName":"Deposit Date"}]'
+  //   }
+
+  //     at test/integration/collections/CollectionsRepository.test.ts:1036:15
+
+  // console.log
+  //   {
+  //     rootCollectionAfterUpdate: '{"id":1,"alias":"root","name":"Root","isReleased":true,"type":"UNCATEGORIZED","isMetadataBlockRoot":false,"isFacetRoot":false,"description":"The root dataverse.","contacts":[{"email":"root@mailinator.com","displayOrder":0}]}'
+  //   }
+
+  //     at test/integration/collections/CollectionsRepository.test.ts:1054:15
+
+  // console.log
+  //   { collectionFacetsAfterUpdate: '[]' }
+  //   */
+
+  //   test('should not update root collection metadata blocks/input levels and/or facets and keep isMetadataBlockRoot and isFacetRoot in true', async () => {
+  //     const rootCollection = await sut.getCollection()
+
+  //     console.log({ rootCollection: JSON.stringify(rootCollection) })
+
+  //     const collectionFacets = await sut.getCollectionFacets(rootCollection.alias)
+
+  //     console.log({ collectionFacets: JSON.stringify(collectionFacets) })
+
+  //     const updatedRootCollectionDTO: CollectionDTO = {
+  //       alias: rootCollection.alias,
+  //       name: rootCollection.name,
+  //       contacts: [rootCollection.contacts?.[0].email as string],
+  //       type: rootCollection.type,
+  //       description: rootCollection.description,
+  //       affiliation: rootCollection.affiliation,
+  //       metadataBlockNames: undefined,
+  //       facetIds: undefined,
+  //       inputLevels: undefined
+  //     }
+
+  //     await sut.updateCollection(rootCollection.id, updatedRootCollectionDTO)
+
+  //     const rootCollectionAfterUpdate = await sut.getCollection()
+
+  //     console.log({ rootCollectionAfterUpdate: JSON.stringify(rootCollectionAfterUpdate) })
+
+  //     const collectionFacetsAfterUpdate = await sut.getCollectionFacets(rootCollection.alias)
+
+  //     console.log({ collectionFacetsAfterUpdate: JSON.stringify(collectionFacetsAfterUpdate) })
+
+  //     expect(rootCollection.isMetadataBlockRoot).toBe(true)
+  //     expect(rootCollection.isFacetRoot).toBe(true)
+  //   })
+
+  //   test('should return error when collection does not exist', async () => {
+  //     const expectedError = new WriteError(
+  //       `[404] Can't find dataverse with identifier='${TestConstants.TEST_DUMMY_COLLECTION_ID}'`
+  //     )
+  //     const testCollectionAlias = 'updateCollection-not-found-test'
+  //     await expect(
+  //       sut.updateCollection(
+  //         TestConstants.TEST_DUMMY_COLLECTION_ID,
+  //         createCollectionDTO(testCollectionAlias)
+  //       )
+  //     ).rejects.toThrow(expectedError)
+  //   })
+  // })
 })

--- a/test/testHelpers/collections/collectionHelper.ts
+++ b/test/testHelpers/collections/collectionHelper.ts
@@ -160,7 +160,9 @@ export const createCollectionDTO = (alias = 'test-collection'): CollectionDTO =>
         required: true,
         include: true
       }
-    ]
+    ],
+    inheritFacetsFromParent: false,
+    inheritMetadataBlocksFromParent: false
   }
 }
 

--- a/test/testHelpers/collections/collectionHelper.ts
+++ b/test/testHelpers/collections/collectionHelper.ts
@@ -182,14 +182,16 @@ export const createNewCollectionRequestPayload = (): NewCollectionRequestPayload
     affiliation: 'test affiliation',
     metadataBlocks: {
       metadataBlockNames: ['citation', 'geospatial'],
-      facetIds: ['authorName', 'authorAffiliation'],
       inputLevels: [
         {
           datasetFieldTypeName: 'geographicCoverage',
           include: true,
           required: true
         }
-      ]
+      ],
+      facetIds: ['authorName', 'authorAffiliation'],
+      inheritMetadataBlocksFromParent: false,
+      inheritFacetsFromParent: false
     }
   }
 }

--- a/test/unit/collections/CollectionsRepository.test.ts
+++ b/test/unit/collections/CollectionsRepository.test.ts
@@ -8,17 +8,14 @@ import {
   DataverseApiAuthMechanism
 } from '../../../src/core/infra/repositories/ApiConfig'
 import {
-  // createCollectionDTO,
+  createCollectionDTO,
   createCollectionFacetRequestPayload,
   createCollectionModel,
-  createCollectionPayload
-  // createNewCollectionRequestPayload
+  createCollectionPayload,
+  createNewCollectionRequestPayload
 } from '../../testHelpers/collections/collectionHelper'
 import { TestConstants } from '../../testHelpers/TestConstants'
-import {
-  ReadError
-  // WriteError
-} from '../../../src'
+import { ReadError, WriteError } from '../../../src'
 import { ROOT_COLLECTION_ID } from '../../../src/collections/domain/models/Collection'
 import {
   createCollectionUserPermissionsModel,
@@ -146,122 +143,122 @@ describe('CollectionsRepository', () => {
     })
   })
 
-  // describe('createCollection', () => {
-  //   const testNewCollection = createCollectionDTO()
+  describe('createCollection', () => {
+    const testNewCollection = createCollectionDTO()
 
-  //   const testCreatedCollectionId = 1
-  //   const testCreateCollectionResponse = {
-  //     data: {
-  //       status: 'OK',
-  //       data: {
-  //         id: testCreatedCollectionId
-  //       }
-  //     }
-  //   }
+    const testCreatedCollectionId = 1
+    const testCreateCollectionResponse = {
+      data: {
+        status: 'OK',
+        data: {
+          id: testCreatedCollectionId
+        }
+      }
+    }
 
-  //   const expectedNewCollectionRequestPayloadJson = JSON.stringify(
-  //     createNewCollectionRequestPayload()
-  //   )
-  //   const expectedApiEndpoint = `${TestConstants.TEST_API_URL}/dataverses/:root`
+    const expectedNewCollectionRequestPayloadJson = JSON.stringify(
+      createNewCollectionRequestPayload()
+    )
+    const expectedApiEndpoint = `${TestConstants.TEST_API_URL}/dataverses/:root`
 
-  //   test('should call the API with a correct request payload', async () => {
-  //     jest.spyOn(axios, 'post').mockResolvedValue(testCreateCollectionResponse)
+    test('should call the API with a correct request payload', async () => {
+      jest.spyOn(axios, 'post').mockResolvedValue(testCreateCollectionResponse)
 
-  //     // API Key auth
-  //     let actual = await sut.createCollection(testNewCollection)
+      // API Key auth
+      let actual = await sut.createCollection(testNewCollection)
 
-  //     expect(axios.post).toHaveBeenCalledWith(
-  //       expectedApiEndpoint,
-  //       expectedNewCollectionRequestPayloadJson,
-  //       TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY
-  //     )
-  //     expect(actual).toStrictEqual(testCreatedCollectionId)
+      expect(axios.post).toHaveBeenCalledWith(
+        expectedApiEndpoint,
+        expectedNewCollectionRequestPayloadJson,
+        TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY
+      )
+      expect(actual).toStrictEqual(testCreatedCollectionId)
 
-  //     // Session cookie auth
-  //     ApiConfig.init(TestConstants.TEST_API_URL, DataverseApiAuthMechanism.SESSION_COOKIE)
+      // Session cookie auth
+      ApiConfig.init(TestConstants.TEST_API_URL, DataverseApiAuthMechanism.SESSION_COOKIE)
 
-  //     actual = await sut.createCollection(testNewCollection)
+      actual = await sut.createCollection(testNewCollection)
 
-  //     expect(axios.post).toHaveBeenCalledWith(
-  //       expectedApiEndpoint,
-  //       expectedNewCollectionRequestPayloadJson,
-  //       TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE
-  //     )
-  //     expect(actual).toStrictEqual(testCreatedCollectionId)
-  //   })
+      expect(axios.post).toHaveBeenCalledWith(
+        expectedApiEndpoint,
+        expectedNewCollectionRequestPayloadJson,
+        TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE
+      )
+      expect(actual).toStrictEqual(testCreatedCollectionId)
+    })
 
-  //   test('should return error result on error response', async () => {
-  //     jest.spyOn(axios, 'post').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
+    test('should return error result on error response', async () => {
+      jest.spyOn(axios, 'post').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
 
-  //     let error = undefined as unknown as WriteError
-  //     await sut.createCollection(testNewCollection).catch((e) => (error = e))
+      let error = undefined as unknown as WriteError
+      await sut.createCollection(testNewCollection).catch((e) => (error = e))
 
-  //     expect(axios.post).toHaveBeenCalledWith(
-  //       expectedApiEndpoint,
-  //       expectedNewCollectionRequestPayloadJson,
-  //       TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY
-  //     )
-  //     expect(error).toBeInstanceOf(Error)
-  //   })
-  // })
+      expect(axios.post).toHaveBeenCalledWith(
+        expectedApiEndpoint,
+        expectedNewCollectionRequestPayloadJson,
+        TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY
+      )
+      expect(error).toBeInstanceOf(Error)
+    })
+  })
 
-  // describe('updateCollection', () => {
-  //   const testUpdatedCollection = createCollectionDTO()
-  //   const testAlias = 'testCollectionAlias'
+  describe('updateCollection', () => {
+    const testUpdatedCollection = createCollectionDTO()
+    const testAlias = 'testCollectionAlias'
 
-  //   const testCreatedCollectionId = 1
-  //   const testCreateCollectionResponse = {
-  //     data: {
-  //       status: 'OK',
-  //       data: {
-  //         id: testCreatedCollectionId
-  //       }
-  //     }
-  //   }
+    const testCreatedCollectionId = 1
+    const testCreateCollectionResponse = {
+      data: {
+        status: 'OK',
+        data: {
+          id: testCreatedCollectionId
+        }
+      }
+    }
 
-  //   const expectedUpdatedCollectionRequestPayloadJson = JSON.stringify(
-  //     createNewCollectionRequestPayload()
-  //   )
-  //   const expectedApiEndpoint = `${TestConstants.TEST_API_URL}/dataverses/${testAlias}`
+    const expectedUpdatedCollectionRequestPayloadJson = JSON.stringify(
+      createNewCollectionRequestPayload()
+    )
+    const expectedApiEndpoint = `${TestConstants.TEST_API_URL}/dataverses/${testAlias}`
 
-  //   test('should call the API with a correct request payload', async () => {
-  //     jest.spyOn(axios, 'put').mockResolvedValue(testCreateCollectionResponse)
+    test('should call the API with a correct request payload', async () => {
+      jest.spyOn(axios, 'put').mockResolvedValue(testCreateCollectionResponse)
 
-  //     // API Key auth
-  //     await sut.updateCollection(testAlias, testUpdatedCollection)
+      // API Key auth
+      await sut.updateCollection(testAlias, testUpdatedCollection)
 
-  //     expect(axios.put).toHaveBeenCalledWith(
-  //       expectedApiEndpoint,
-  //       expectedUpdatedCollectionRequestPayloadJson,
-  //       TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY
-  //     )
+      expect(axios.put).toHaveBeenCalledWith(
+        expectedApiEndpoint,
+        expectedUpdatedCollectionRequestPayloadJson,
+        TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY
+      )
 
-  //     // Session cookie auth
-  //     ApiConfig.init(TestConstants.TEST_API_URL, DataverseApiAuthMechanism.SESSION_COOKIE)
+      // Session cookie auth
+      ApiConfig.init(TestConstants.TEST_API_URL, DataverseApiAuthMechanism.SESSION_COOKIE)
 
-  //     await sut.updateCollection(testAlias, testUpdatedCollection)
+      await sut.updateCollection(testAlias, testUpdatedCollection)
 
-  //     expect(axios.put).toHaveBeenCalledWith(
-  //       expectedApiEndpoint,
-  //       expectedUpdatedCollectionRequestPayloadJson,
-  //       TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE
-  //     )
-  //   })
+      expect(axios.put).toHaveBeenCalledWith(
+        expectedApiEndpoint,
+        expectedUpdatedCollectionRequestPayloadJson,
+        TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE
+      )
+    })
 
-  //   test('should return error result on error response', async () => {
-  //     jest.spyOn(axios, 'put').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
+    test('should return error result on error response', async () => {
+      jest.spyOn(axios, 'put').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
 
-  //     let error = undefined as unknown as WriteError
-  //     await sut.updateCollection(testAlias, testUpdatedCollection).catch((e) => (error = e))
+      let error = undefined as unknown as WriteError
+      await sut.updateCollection(testAlias, testUpdatedCollection).catch((e) => (error = e))
 
-  //     expect(axios.put).toHaveBeenCalledWith(
-  //       expectedApiEndpoint,
-  //       expectedUpdatedCollectionRequestPayloadJson,
-  //       TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY
-  //     )
-  //     expect(error).toBeInstanceOf(Error)
-  //   })
-  // })
+      expect(axios.put).toHaveBeenCalledWith(
+        expectedApiEndpoint,
+        expectedUpdatedCollectionRequestPayloadJson,
+        TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY
+      )
+      expect(error).toBeInstanceOf(Error)
+    })
+  })
 
   describe('getCollectionFacets', () => {
     const testFacetsSuccessfulResponse = {

--- a/test/unit/collections/CollectionsRepository.test.ts
+++ b/test/unit/collections/CollectionsRepository.test.ts
@@ -8,14 +8,17 @@ import {
   DataverseApiAuthMechanism
 } from '../../../src/core/infra/repositories/ApiConfig'
 import {
-  createCollectionDTO,
+  // createCollectionDTO,
   createCollectionFacetRequestPayload,
   createCollectionModel,
-  createCollectionPayload,
-  createNewCollectionRequestPayload
+  createCollectionPayload
+  // createNewCollectionRequestPayload
 } from '../../testHelpers/collections/collectionHelper'
 import { TestConstants } from '../../testHelpers/TestConstants'
-import { ReadError, WriteError } from '../../../src'
+import {
+  ReadError
+  // WriteError
+} from '../../../src'
 import { ROOT_COLLECTION_ID } from '../../../src/collections/domain/models/Collection'
 import {
   createCollectionUserPermissionsModel,
@@ -143,122 +146,122 @@ describe('CollectionsRepository', () => {
     })
   })
 
-  describe('createCollection', () => {
-    const testNewCollection = createCollectionDTO()
+  // describe('createCollection', () => {
+  //   const testNewCollection = createCollectionDTO()
 
-    const testCreatedCollectionId = 1
-    const testCreateCollectionResponse = {
-      data: {
-        status: 'OK',
-        data: {
-          id: testCreatedCollectionId
-        }
-      }
-    }
+  //   const testCreatedCollectionId = 1
+  //   const testCreateCollectionResponse = {
+  //     data: {
+  //       status: 'OK',
+  //       data: {
+  //         id: testCreatedCollectionId
+  //       }
+  //     }
+  //   }
 
-    const expectedNewCollectionRequestPayloadJson = JSON.stringify(
-      createNewCollectionRequestPayload()
-    )
-    const expectedApiEndpoint = `${TestConstants.TEST_API_URL}/dataverses/:root`
+  //   const expectedNewCollectionRequestPayloadJson = JSON.stringify(
+  //     createNewCollectionRequestPayload()
+  //   )
+  //   const expectedApiEndpoint = `${TestConstants.TEST_API_URL}/dataverses/:root`
 
-    test('should call the API with a correct request payload', async () => {
-      jest.spyOn(axios, 'post').mockResolvedValue(testCreateCollectionResponse)
+  //   test('should call the API with a correct request payload', async () => {
+  //     jest.spyOn(axios, 'post').mockResolvedValue(testCreateCollectionResponse)
 
-      // API Key auth
-      let actual = await sut.createCollection(testNewCollection)
+  //     // API Key auth
+  //     let actual = await sut.createCollection(testNewCollection)
 
-      expect(axios.post).toHaveBeenCalledWith(
-        expectedApiEndpoint,
-        expectedNewCollectionRequestPayloadJson,
-        TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY
-      )
-      expect(actual).toStrictEqual(testCreatedCollectionId)
+  //     expect(axios.post).toHaveBeenCalledWith(
+  //       expectedApiEndpoint,
+  //       expectedNewCollectionRequestPayloadJson,
+  //       TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY
+  //     )
+  //     expect(actual).toStrictEqual(testCreatedCollectionId)
 
-      // Session cookie auth
-      ApiConfig.init(TestConstants.TEST_API_URL, DataverseApiAuthMechanism.SESSION_COOKIE)
+  //     // Session cookie auth
+  //     ApiConfig.init(TestConstants.TEST_API_URL, DataverseApiAuthMechanism.SESSION_COOKIE)
 
-      actual = await sut.createCollection(testNewCollection)
+  //     actual = await sut.createCollection(testNewCollection)
 
-      expect(axios.post).toHaveBeenCalledWith(
-        expectedApiEndpoint,
-        expectedNewCollectionRequestPayloadJson,
-        TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE
-      )
-      expect(actual).toStrictEqual(testCreatedCollectionId)
-    })
+  //     expect(axios.post).toHaveBeenCalledWith(
+  //       expectedApiEndpoint,
+  //       expectedNewCollectionRequestPayloadJson,
+  //       TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE
+  //     )
+  //     expect(actual).toStrictEqual(testCreatedCollectionId)
+  //   })
 
-    test('should return error result on error response', async () => {
-      jest.spyOn(axios, 'post').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
+  //   test('should return error result on error response', async () => {
+  //     jest.spyOn(axios, 'post').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
 
-      let error = undefined as unknown as WriteError
-      await sut.createCollection(testNewCollection).catch((e) => (error = e))
+  //     let error = undefined as unknown as WriteError
+  //     await sut.createCollection(testNewCollection).catch((e) => (error = e))
 
-      expect(axios.post).toHaveBeenCalledWith(
-        expectedApiEndpoint,
-        expectedNewCollectionRequestPayloadJson,
-        TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY
-      )
-      expect(error).toBeInstanceOf(Error)
-    })
-  })
+  //     expect(axios.post).toHaveBeenCalledWith(
+  //       expectedApiEndpoint,
+  //       expectedNewCollectionRequestPayloadJson,
+  //       TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY
+  //     )
+  //     expect(error).toBeInstanceOf(Error)
+  //   })
+  // })
 
-  describe('updateCollection', () => {
-    const testUpdatedCollection = createCollectionDTO()
-    const testAlias = 'testCollectionAlias'
+  // describe('updateCollection', () => {
+  //   const testUpdatedCollection = createCollectionDTO()
+  //   const testAlias = 'testCollectionAlias'
 
-    const testCreatedCollectionId = 1
-    const testCreateCollectionResponse = {
-      data: {
-        status: 'OK',
-        data: {
-          id: testCreatedCollectionId
-        }
-      }
-    }
+  //   const testCreatedCollectionId = 1
+  //   const testCreateCollectionResponse = {
+  //     data: {
+  //       status: 'OK',
+  //       data: {
+  //         id: testCreatedCollectionId
+  //       }
+  //     }
+  //   }
 
-    const expectedUpdatedCollectionRequestPayloadJson = JSON.stringify(
-      createNewCollectionRequestPayload()
-    )
-    const expectedApiEndpoint = `${TestConstants.TEST_API_URL}/dataverses/${testAlias}`
+  //   const expectedUpdatedCollectionRequestPayloadJson = JSON.stringify(
+  //     createNewCollectionRequestPayload()
+  //   )
+  //   const expectedApiEndpoint = `${TestConstants.TEST_API_URL}/dataverses/${testAlias}`
 
-    test('should call the API with a correct request payload', async () => {
-      jest.spyOn(axios, 'put').mockResolvedValue(testCreateCollectionResponse)
+  //   test('should call the API with a correct request payload', async () => {
+  //     jest.spyOn(axios, 'put').mockResolvedValue(testCreateCollectionResponse)
 
-      // API Key auth
-      await sut.updateCollection(testAlias, testUpdatedCollection)
+  //     // API Key auth
+  //     await sut.updateCollection(testAlias, testUpdatedCollection)
 
-      expect(axios.put).toHaveBeenCalledWith(
-        expectedApiEndpoint,
-        expectedUpdatedCollectionRequestPayloadJson,
-        TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY
-      )
+  //     expect(axios.put).toHaveBeenCalledWith(
+  //       expectedApiEndpoint,
+  //       expectedUpdatedCollectionRequestPayloadJson,
+  //       TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY
+  //     )
 
-      // Session cookie auth
-      ApiConfig.init(TestConstants.TEST_API_URL, DataverseApiAuthMechanism.SESSION_COOKIE)
+  //     // Session cookie auth
+  //     ApiConfig.init(TestConstants.TEST_API_URL, DataverseApiAuthMechanism.SESSION_COOKIE)
 
-      await sut.updateCollection(testAlias, testUpdatedCollection)
+  //     await sut.updateCollection(testAlias, testUpdatedCollection)
 
-      expect(axios.put).toHaveBeenCalledWith(
-        expectedApiEndpoint,
-        expectedUpdatedCollectionRequestPayloadJson,
-        TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE
-      )
-    })
+  //     expect(axios.put).toHaveBeenCalledWith(
+  //       expectedApiEndpoint,
+  //       expectedUpdatedCollectionRequestPayloadJson,
+  //       TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE
+  //     )
+  //   })
 
-    test('should return error result on error response', async () => {
-      jest.spyOn(axios, 'put').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
+  //   test('should return error result on error response', async () => {
+  //     jest.spyOn(axios, 'put').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
 
-      let error = undefined as unknown as WriteError
-      await sut.updateCollection(testAlias, testUpdatedCollection).catch((e) => (error = e))
+  //     let error = undefined as unknown as WriteError
+  //     await sut.updateCollection(testAlias, testUpdatedCollection).catch((e) => (error = e))
 
-      expect(axios.put).toHaveBeenCalledWith(
-        expectedApiEndpoint,
-        expectedUpdatedCollectionRequestPayloadJson,
-        TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY
-      )
-      expect(error).toBeInstanceOf(Error)
-    })
-  })
+  //     expect(axios.put).toHaveBeenCalledWith(
+  //       expectedApiEndpoint,
+  //       expectedUpdatedCollectionRequestPayloadJson,
+  //       TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY
+  //     )
+  //     expect(error).toBeInstanceOf(Error)
+  //   })
+  // })
 
   describe('getCollectionFacets', () => {
     const testFacetsSuccessfulResponse = {

--- a/test/unit/collections/CollectionsRepository.test.ts
+++ b/test/unit/collections/CollectionsRepository.test.ts
@@ -148,7 +148,6 @@ describe('CollectionsRepository', () => {
 
   // describe('createCollection', () => {
   //   const testNewCollection = createCollectionDTO()
-  //TODO:Remove
 
   //   const testCreatedCollectionId = 1
   //   const testCreateCollectionResponse = {

--- a/test/unit/collections/CollectionsRepository.test.ts
+++ b/test/unit/collections/CollectionsRepository.test.ts
@@ -148,6 +148,7 @@ describe('CollectionsRepository', () => {
 
   // describe('createCollection', () => {
   //   const testNewCollection = createCollectionDTO()
+  //TODO:Remove
 
   //   const testCreatedCollectionId = 1
   //   const testCreateCollectionResponse = {


### PR DESCRIPTION
## What this PR does / why we need it:
Modifies how we are sending the payload to the API while creating or updating a collection

## Which issue(s) this PR closes:

- Closes #237 

## Suggestions on how to test this:
Visual inspection of code and test actions passing.
