### PR TITLE
Get Dataset: refactor terms of use

### DIFF
--- a/src/datasets/domain/models/Dataset.ts
+++ b/src/datasets/domain/models/Dataset.ts
@@ -36,9 +36,19 @@ export interface DatasetLicense {
   iconUri?: string
 }
 
-export interface TermsOfUse {
+export interface CustomTerms {
+  termsOfUse: string
+  confidentialityDeclaration?: string
+  specialPermissions?: string
+  restrictions?: string
+  citationRequirements?: string
+  depositorRequirements?: string
+  conditions?: string
+  disclaimer?: string
+}
+export interface TermsOfAccess {
   fileAccessRequest: boolean
-  termsOfAccess?: string
+  termsOfAccessForRestrictedFiles?: string
   dataAccessPlace?: string
   originalArchive?: string
   availabilityStatus?: string
@@ -47,6 +57,10 @@ export interface TermsOfUse {
   studyCompletion?: string
 }
 
+export interface TermsOfUse {
+  termsOfAccess: TermsOfAccess
+  customTerms?: CustomTerms
+}
 export type DatasetMetadataBlocks = [CitationMetadataBlock, ...DatasetMetadataBlock[]]
 
 export interface DatasetMetadataBlock {

--- a/src/datasets/index.ts
+++ b/src/datasets/index.ts
@@ -73,7 +73,8 @@ export {
   DatasetMetadataBlocks,
   DatasetMetadataFields,
   DatasetMetadataSubField,
-  DatasetMetadataFieldValue
+  DatasetMetadataFieldValue,
+  TermsOfUse
 } from './domain/models/Dataset'
 export { DatasetPreview } from './domain/models/DatasetPreview'
 export { DatasetVersionDiff } from './domain/models/DatasetVersionDiff'

--- a/src/datasets/infra/repositories/transformers/datasetTransformers.ts
+++ b/src/datasets/infra/repositories/transformers/datasetTransformers.ts
@@ -294,7 +294,13 @@ export const transformVersionPayloadToDataset = (
   return datasetModel
 }
 
-const transformPayloadToDatasetLicense = (licensePayload: LicensePayload): DatasetLicense => {
+const transformPayloadToDatasetLicense = (
+  licensePayload: LicensePayload
+): DatasetLicense | undefined => {
+  if (!licensePayload) {
+    return undefined
+  }
+
   const datasetLicense: DatasetLicense = {
     name: licensePayload.name,
     uri: licensePayload.uri
@@ -303,6 +309,7 @@ const transformPayloadToDatasetLicense = (licensePayload: LicensePayload): Datas
   if ('iconUri' in licensePayload) {
     datasetLicense.iconUri = licensePayload.iconUri
   }
+
   return datasetLicense
 }
 

--- a/src/datasets/infra/repositories/transformers/datasetTransformers.ts
+++ b/src/datasets/infra/repositories/transformers/datasetTransformers.ts
@@ -235,14 +235,19 @@ export const transformVersionPayloadToDataset = (
       releaseTime: new Date(versionPayload.releaseTime)
     },
     termsOfUse: {
-      fileAccessRequest: versionPayload.fileAccessRequest,
-      termsOfAccess: versionPayload.termsOfAccess,
-      dataAccessPlace: versionPayload.dataAccessPlace,
-      originalArchive: versionPayload.originalArchive,
-      availabilityStatus: versionPayload.availabilityStatus,
-      contactForAccess: versionPayload.contactForAccess,
-      sizeOfCollection: versionPayload.sizeOfCollection,
-      studyCompletion: versionPayload.studyCompletion
+      termsOfAccess: {
+        fileAccessRequest: versionPayload.fileAccessRequest,
+        termsOfAccessForRestrictedFiles: transformPayloadText(
+          keepRawFields,
+          versionPayload.termsOfAccess
+        ),
+        dataAccessPlace: transformPayloadText(keepRawFields, versionPayload.dataAccessPlace),
+        originalArchive: transformPayloadText(keepRawFields, versionPayload.originalArchive),
+        availabilityStatus: transformPayloadText(keepRawFields, versionPayload.availabilityStatus),
+        contactForAccess: transformPayloadText(keepRawFields, versionPayload.contactForAccess),
+        sizeOfCollection: transformPayloadText(keepRawFields, versionPayload.sizeOfCollection),
+        studyCompletion: transformPayloadText(keepRawFields, versionPayload.studyCompletion)
+      }
     },
     metadataBlocks: transformPayloadToDatasetMetadataBlocks(
       versionPayload.metadataBlocks,
@@ -256,6 +261,26 @@ export const transformVersionPayloadToDataset = (
     datasetModel.license = transformPayloadToDatasetLicense(
       versionPayload.license as LicensePayload
     )
+  } else {
+    datasetModel.termsOfUse.customTerms = {
+      termsOfUse: transformPayloadText(keepRawFields, versionPayload.termsOfUse) as string,
+      confidentialityDeclaration: transformPayloadText(
+        keepRawFields,
+        versionPayload.confidentialityDeclaration
+      ),
+      specialPermissions: transformPayloadText(keepRawFields, versionPayload.specialPermissions),
+      restrictions: transformPayloadText(keepRawFields, versionPayload.restrictions),
+      citationRequirements: transformPayloadText(
+        keepRawFields,
+        versionPayload.citationRequirements
+      ),
+      depositorRequirements: transformPayloadText(
+        keepRawFields,
+        versionPayload.depositorRequirements
+      ),
+      conditions: transformPayloadText(keepRawFields, versionPayload.conditions),
+      disclaimer: transformPayloadText(keepRawFields, versionPayload.disclaimer)
+    }
   }
   if ('alternativePersistentId' in versionPayload) {
     datasetModel.alternativePersistentId = versionPayload.alternativePersistentId
@@ -279,6 +304,16 @@ const transformPayloadToDatasetLicense = (licensePayload: LicensePayload): Datas
     datasetLicense.iconUri = licensePayload.iconUri
   }
   return datasetLicense
+}
+
+const transformPayloadText = (
+  keepRawFields: boolean,
+  text: string | undefined
+): string | undefined => {
+  if (!text) {
+    return undefined
+  }
+  return keepRawFields ? text : transformHtmlToMarkdown(text)
 }
 
 const transformPayloadToDatasetMetadataBlocks = (

--- a/test/functional/datasets/GetDataset.test.ts
+++ b/test/functional/datasets/GetDataset.test.ts
@@ -76,7 +76,17 @@ describe('execute', () => {
 
     await expect(getDataset.execute(nonExistentTestDatasetId)).rejects.toThrow(expectedError)
   })
-
+  test('should not return custom terms if license is set', async () => {
+    const versionPayload = createDatasetVersionPayload()
+    versionPayload.license = {
+      name: 'CC0',
+      uri: 'https://creativecommons.org/publicdomain/zero/1.0/',
+      iconUri: 'https://creativecommons.org/publicdomain/zero/1.0/'
+    }
+    const dataset = transformVersionPayloadToDataset(versionPayload, false)
+    expect(dataset.termsOfUse.termsOfAccess.termsOfAccessForRestrictedFiles).toBe('Terms of access')
+    expect(dataset.termsOfUse.customTerms).toBe(undefined)
+  })
   test('should return metadata fields in markdown format when keepRawFields is false', async () => {
     const createdDatasetIdentifiers = await createDataset.execute(testNewDataset)
 
@@ -98,13 +108,15 @@ describe('execute', () => {
     const versionPayload = createDatasetVersionPayload()
     versionPayload.termsOfAccess = 'Hello <b>world</b>'
     const dataset = transformVersionPayloadToDataset(versionPayload, false)
-    expect(dataset.termsOfUse.termsOfAccess).toBe('Hello **world**')
+    expect(dataset.termsOfUse.termsOfAccess.termsOfAccessForRestrictedFiles).toBe('Hello **world**')
   })
 
   test('should return terms of use fields in html format when keepRawFields is true', async () => {
     const versionPayload = createDatasetVersionPayload()
     const dataset = transformVersionPayloadToDataset(versionPayload, true)
-    expect(dataset.termsOfUse.termsOfAccess).toBe(versionPayload.termsOfAccess)
+    expect(dataset.termsOfUse.termsOfAccess.termsOfAccessForRestrictedFiles).toBe(
+      versionPayload.termsOfAccess
+    )
   })
 
   test('should not return metadata fields in markdown format when keepRawFields is true', async () => {

--- a/test/functional/datasets/GetDataset.test.ts
+++ b/test/functional/datasets/GetDataset.test.ts
@@ -90,6 +90,19 @@ describe('execute', () => {
     await deleteUnpublishedDatasetViaApi(createdDatasetIdentifiers.numericId)
   })
 
+  test('should return terms of use fields in markdown format when keepRawFields is false', async () => {
+    const versionPayload = createDatasetVersionPayload()
+    versionPayload.termsOfAccess = 'Hello <b>world</b>'
+    const dataset = transformVersionPayloadToDataset(versionPayload, false)
+    expect(dataset.termsOfUse.termsOfAccess.termsOfAccessForRestrictedFiles).toBe('Hello **world**')
+  })
+
+  test('should return terms of use fields in html format when keepRawFields is true', async () => {
+    const versionPayload = createDatasetVersionPayload()
+    const dataset = transformVersionPayloadToDataset(versionPayload, true)
+    expect(dataset.termsOfUse.termsOfAccess.contactForAccess).toBe(versionPayload.contactForAccess)
+  })
+
   test('should not return metadata fields in markdown format when keepRawFields is true', async () => {
     const createdDatasetIdentifiers = await createDataset.execute(testNewDataset)
 

--- a/test/functional/datasets/GetDataset.test.ts
+++ b/test/functional/datasets/GetDataset.test.ts
@@ -87,6 +87,12 @@ describe('execute', () => {
     expect(dataset.termsOfUse.termsOfAccess.termsOfAccessForRestrictedFiles).toBe('Terms of access')
     expect(dataset.termsOfUse.customTerms).toBe(undefined)
   })
+  test('should  return custom terms if license is undefined', async () => {
+    const versionPayload = createDatasetVersionPayload()
+    const dataset = transformVersionPayloadToDataset(versionPayload, false)
+    expect(dataset.termsOfUse.termsOfAccess.termsOfAccessForRestrictedFiles).toBe('Terms of access')
+    expect(dataset.termsOfUse.customTerms?.termsOfUse).toBe('Terms of use')
+  })
   test('should return metadata fields in markdown format when keepRawFields is false', async () => {
     const createdDatasetIdentifiers = await createDataset.execute(testNewDataset)
 

--- a/test/testHelpers/datasets/datasetHelper.ts
+++ b/test/testHelpers/datasets/datasetHelper.ts
@@ -142,14 +142,6 @@ export const createDatasetVersionPayload = (
     contactForAccess: 'Contact for access',
     sizeOfCollection: 'Size of collection',
     studyCompletion: 'Study completion',
-    termsOfUse: 'Terms of use',
-    confidentialityDeclaration: 'Confidentiality declaration',
-    specialPermissions: 'Special permissions',
-    restrictions: 'Restrictions',
-    citationRequirements: 'Citation requirements',
-    depositorRequirements: 'Depositor requirements',
-    conditions: 'Conditions',
-    disclaimer: 'Disclaimer',
     metadataBlocks: {
       citation: {
         name: 'citation',
@@ -245,6 +237,15 @@ export const createDatasetVersionPayload = (
   }
   if (license !== undefined) {
     datasetPayload.license = license
+  } else {
+    datasetPayload.termsOfUse = 'Terms of use'
+    datasetPayload.confidentialityDeclaration = 'Confidentiality declaration'
+    datasetPayload.specialPermissions = 'Special permissions'
+    datasetPayload.restrictions = 'Restrictions'
+    datasetPayload.citationRequirements = 'Citation requirements'
+    datasetPayload.depositorRequirements = 'Depositor requirements'
+    datasetPayload.conditions = 'Conditions'
+    datasetPayload.disclaimer = 'Disclaimer'
   }
   if (addOptionalProperties) {
     datasetPayload.alternativePersistentId = 'doi:10.5072/FK2/HC6KTB'

--- a/test/testHelpers/datasets/datasetHelper.ts
+++ b/test/testHelpers/datasets/datasetHelper.ts
@@ -53,14 +53,16 @@ export const createDatasetModel = (
       releaseTime: new Date(DATASET_RELEASE_TIME_STR)
     },
     termsOfUse: {
-      fileAccessRequest: true,
-      termsOfAccess: 'Terms of access',
-      dataAccessPlace: 'Data access place',
-      originalArchive: 'Original archive',
-      availabilityStatus: 'Availability status',
-      contactForAccess: 'Contact for access',
-      sizeOfCollection: 'Size of collection',
-      studyCompletion: 'Study completion'
+      termsOfAccess: {
+        fileAccessRequest: true,
+        termsOfAccessForRestrictedFiles: 'Terms of access',
+        dataAccessPlace: 'Data access place',
+        originalArchive: 'Original archive',
+        availabilityStatus: 'Availability status',
+        contactForAccess: 'Contact for access',
+        sizeOfCollection: 'Size of collection',
+        studyCompletion: 'Study completion'
+      }
     },
     publicationDate: DATASET_PUBLICATION_DATE_STR,
     metadataBlocks: [
@@ -97,6 +99,17 @@ export const createDatasetModel = (
   }
   if (license !== undefined) {
     datasetModel.license = license
+  } else {
+    datasetModel.termsOfUse.customTerms = {
+      termsOfUse: 'Terms of use',
+      confidentialityDeclaration: 'Confidentiality declaration',
+      specialPermissions: 'Special permissions',
+      restrictions: 'Restrictions',
+      citationRequirements: 'Citation requirements',
+      depositorRequirements: 'Depositor requirements',
+      conditions: 'Conditions',
+      disclaimer: 'Disclaimer'
+    }
   }
   if (addOptionalParameters) {
     datasetModel.alternativePersistentId = 'doi:10.5072/FK2/HC6KTB'
@@ -129,6 +142,14 @@ export const createDatasetVersionPayload = (
     contactForAccess: 'Contact for access',
     sizeOfCollection: 'Size of collection',
     studyCompletion: 'Study completion',
+    termsOfUse: 'Terms of use',
+    confidentialityDeclaration: 'Confidentiality declaration',
+    specialPermissions: 'Special permissions',
+    restrictions: 'Restrictions',
+    citationRequirements: 'Citation requirements',
+    depositorRequirements: 'Depositor requirements',
+    conditions: 'Conditions',
+    disclaimer: 'Disclaimer',
     metadataBlocks: {
       citation: {
         name: 'citation',

--- a/test/testHelpers/datasets/datasetHelper.ts
+++ b/test/testHelpers/datasets/datasetHelper.ts
@@ -99,6 +99,17 @@ export const createDatasetModel = (
   }
   if (license !== undefined) {
     datasetModel.license = license
+  } else {
+    datasetModel.termsOfUse.customTerms = {
+      termsOfUse: 'Terms of use',
+      confidentialityDeclaration: 'Confidentiality declaration',
+      specialPermissions: 'Special permissions',
+      restrictions: 'Restrictions',
+      citationRequirements: 'Citation requirements',
+      depositorRequirements: 'Depositor requirements',
+      conditions: 'Conditions',
+      disclaimer: 'Disclaimer'
+    }
   }
   if (addOptionalParameters) {
     datasetModel.alternativePersistentId = 'doi:10.5072/FK2/HC6KTB'

--- a/test/unit/datasets/DatasetsRepository.test.ts
+++ b/test/unit/datasets/DatasetsRepository.test.ts
@@ -115,127 +115,7 @@ describe('DatasetsRepository', () => {
         TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE.withCredentials,
       headers: TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE.headers
     }
-    describe('with custom terms of use', () => {
-      test('should return Dataset with customTerms when license is undefined', async () => {
-        jest.spyOn(axios, 'get').mockResolvedValue(testDatasetVersionSuccessfulResponse)
-        const expectedApiEndpoint = `${TestConstants.TEST_API_URL}/datasets/${testDatasetModel.id}/versions/${testVersionId}`
 
-        // API Key auth
-        let actual = await sut.getDataset(
-          testDatasetModel.id,
-          testVersionId,
-          testIncludeDeaccessioned,
-          false
-        )
-
-        expect(axios.get).toHaveBeenCalledWith(expectedApiEndpoint, expectedRequestConfigApiKey)
-        expect(actual).toStrictEqual(testDatasetModel)
-
-        // Session cookie auth
-        ApiConfig.init(TestConstants.TEST_API_URL, DataverseApiAuthMechanism.SESSION_COOKIE)
-        actual = await sut.getDataset(
-          testDatasetModel.id,
-          testVersionId,
-          testIncludeDeaccessioned,
-          false
-        )
-        expect(axios.get).toHaveBeenCalledWith(
-          expectedApiEndpoint,
-          expectedRequestConfigSessionCookie
-        )
-        expect(actual).toStrictEqual(testDatasetModel)
-      })
-
-      test('should return Dataset when providing id, version id, and response with license is successful', async () => {
-        const testDatasetLicense = createDatasetLicenseModel()
-        const testDatasetVersionWithLicenseSuccessfulResponse = {
-          data: {
-            status: 'OK',
-            data: createDatasetVersionPayload(testDatasetLicense)
-          }
-        }
-        jest.spyOn(axios, 'get').mockResolvedValue(testDatasetVersionWithLicenseSuccessfulResponse)
-
-        const actual = await sut.getDataset(
-          testDatasetModel.id,
-          testVersionId,
-          testIncludeDeaccessioned,
-          false
-        )
-
-        expect(axios.get).toHaveBeenCalledWith(
-          `${TestConstants.TEST_API_URL}/datasets/${testDatasetModel.id}/versions/${testVersionId}`,
-          expectedRequestConfigApiKey
-        )
-        expect(actual).toStrictEqual(createDatasetModel(testDatasetLicense))
-      })
-
-      test('should return Dataset when providing id, version id, and response with license without icon URI is successful', async () => {
-        const testDatasetLicenseWithoutIconUri = createDatasetLicenseModel(false)
-        const testDatasetVersionWithLicenseSuccessfulResponse = {
-          data: {
-            status: 'OK',
-            data: createDatasetVersionPayload(testDatasetLicenseWithoutIconUri)
-          }
-        }
-        jest.spyOn(axios, 'get').mockResolvedValue(testDatasetVersionWithLicenseSuccessfulResponse)
-
-        const actual = await sut.getDataset(
-          testDatasetModel.id,
-          testVersionId,
-          testIncludeDeaccessioned,
-          false
-        )
-
-        expect(axios.get).toHaveBeenCalledWith(
-          `${TestConstants.TEST_API_URL}/datasets/${testDatasetModel.id}/versions/${testVersionId}`,
-          expectedRequestConfigApiKey
-        )
-        expect(actual).toStrictEqual(createDatasetModel(testDatasetLicenseWithoutIconUri))
-      })
-
-      test('should return dataset with alternative persistent id, publication date and citation date when they are present in the response', async () => {
-        const testDatasetVersionWithAlternativePersistentIdAndDatesSuccessfulResponse = {
-          data: {
-            status: 'OK',
-            data: createDatasetVersionPayload(undefined, true)
-          }
-        }
-        jest
-          .spyOn(axios, 'get')
-          .mockResolvedValue(
-            testDatasetVersionWithAlternativePersistentIdAndDatesSuccessfulResponse
-          )
-
-        const actual = await sut.getDataset(
-          testDatasetModel.id,
-          testVersionId,
-          testIncludeDeaccessioned,
-          false
-        )
-
-        expect(axios.get).toHaveBeenCalledWith(
-          `${TestConstants.TEST_API_URL}/datasets/${testDatasetModel.id}/versions/${testVersionId}`,
-          expectedRequestConfigApiKey
-        )
-        expect(actual).toStrictEqual(createDatasetModel(undefined, true))
-      })
-
-      test('should return error on repository read error', async () => {
-        jest.spyOn(axios, 'get').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
-
-        let error = undefined as unknown as ReadError
-        await sut
-          .getDataset(testDatasetModel.id, testVersionId, testIncludeDeaccessioned, false)
-          .catch((e) => (error = e))
-
-        expect(axios.get).toHaveBeenCalledWith(
-          `${TestConstants.TEST_API_URL}/datasets/${testDatasetModel.id}/versions/${testVersionId}`,
-          expectedRequestConfigApiKey
-        )
-        expect(error).toBeInstanceOf(Error)
-      })
-    })
     describe('by numeric id', () => {
       test('should return Dataset when providing id, version id, and response is successful', async () => {
         jest.spyOn(axios, 'get').mockResolvedValue(testDatasetVersionSuccessfulResponse)
@@ -340,6 +220,64 @@ describe('DatasetsRepository', () => {
           expectedRequestConfigApiKey
         )
         expect(actual).toStrictEqual(createDatasetModel(undefined, true))
+      })
+      test('should return Dataset with customTerms when license is undefined', async () => {
+        jest.spyOn(axios, 'get').mockResolvedValue(testDatasetVersionSuccessfulResponse)
+        const expectedApiEndpoint = `${TestConstants.TEST_API_URL}/datasets/${testDatasetModel.id}/versions/${testVersionId}`
+
+        // API Key auth
+        let actual = await sut.getDataset(
+          testDatasetModel.id,
+          testVersionId,
+          testIncludeDeaccessioned,
+          false
+        )
+
+        expect(axios.get).toHaveBeenCalledWith(expectedApiEndpoint, expectedRequestConfigApiKey)
+        expect(actual).toStrictEqual(testDatasetModel)
+
+        // Session cookie auth
+        ApiConfig.init(TestConstants.TEST_API_URL, DataverseApiAuthMechanism.SESSION_COOKIE)
+        actual = await sut.getDataset(
+          testDatasetModel.id,
+          testVersionId,
+          testIncludeDeaccessioned,
+          false
+        )
+        expect(axios.get).toHaveBeenCalledWith(
+          expectedApiEndpoint,
+          expectedRequestConfigSessionCookie
+        )
+        expect(actual).toStrictEqual(testDatasetModel)
+      })
+      test('should return Dataset without customTerms when license is defined', async () => {
+        jest.spyOn(axios, 'get').mockResolvedValue(testDatasetVersionSuccessfulResponse)
+        const expectedApiEndpoint = `${TestConstants.TEST_API_URL}/datasets/${testDatasetModel.id}/versions/${testVersionId}`
+
+        // API Key auth
+        let actual = await sut.getDataset(
+          testDatasetModel.id,
+          testVersionId,
+          testIncludeDeaccessioned,
+          false
+        )
+
+        expect(axios.get).toHaveBeenCalledWith(expectedApiEndpoint, expectedRequestConfigApiKey)
+        expect(actual).toStrictEqual(testDatasetModel)
+
+        // Session cookie auth
+        ApiConfig.init(TestConstants.TEST_API_URL, DataverseApiAuthMechanism.SESSION_COOKIE)
+        actual = await sut.getDataset(
+          testDatasetModel.id,
+          testVersionId,
+          testIncludeDeaccessioned,
+          false
+        )
+        expect(axios.get).toHaveBeenCalledWith(
+          expectedApiEndpoint,
+          expectedRequestConfigSessionCookie
+        )
+        expect(actual).toStrictEqual(testDatasetModel)
       })
 
       test('should return error on repository read error', async () => {

--- a/test/unit/datasets/DatasetsRepository.test.ts
+++ b/test/unit/datasets/DatasetsRepository.test.ts
@@ -115,7 +115,127 @@ describe('DatasetsRepository', () => {
         TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE.withCredentials,
       headers: TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE.headers
     }
+    describe('with custom terms of use', () => {
+      test('should return Dataset with customTerms when license is undefined', async () => {
+        jest.spyOn(axios, 'get').mockResolvedValue(testDatasetVersionSuccessfulResponse)
+        const expectedApiEndpoint = `${TestConstants.TEST_API_URL}/datasets/${testDatasetModel.id}/versions/${testVersionId}`
 
+        // API Key auth
+        let actual = await sut.getDataset(
+          testDatasetModel.id,
+          testVersionId,
+          testIncludeDeaccessioned,
+          false
+        )
+
+        expect(axios.get).toHaveBeenCalledWith(expectedApiEndpoint, expectedRequestConfigApiKey)
+        expect(actual).toStrictEqual(testDatasetModel)
+
+        // Session cookie auth
+        ApiConfig.init(TestConstants.TEST_API_URL, DataverseApiAuthMechanism.SESSION_COOKIE)
+        actual = await sut.getDataset(
+          testDatasetModel.id,
+          testVersionId,
+          testIncludeDeaccessioned,
+          false
+        )
+        expect(axios.get).toHaveBeenCalledWith(
+          expectedApiEndpoint,
+          expectedRequestConfigSessionCookie
+        )
+        expect(actual).toStrictEqual(testDatasetModel)
+      })
+
+      test('should return Dataset when providing id, version id, and response with license is successful', async () => {
+        const testDatasetLicense = createDatasetLicenseModel()
+        const testDatasetVersionWithLicenseSuccessfulResponse = {
+          data: {
+            status: 'OK',
+            data: createDatasetVersionPayload(testDatasetLicense)
+          }
+        }
+        jest.spyOn(axios, 'get').mockResolvedValue(testDatasetVersionWithLicenseSuccessfulResponse)
+
+        const actual = await sut.getDataset(
+          testDatasetModel.id,
+          testVersionId,
+          testIncludeDeaccessioned,
+          false
+        )
+
+        expect(axios.get).toHaveBeenCalledWith(
+          `${TestConstants.TEST_API_URL}/datasets/${testDatasetModel.id}/versions/${testVersionId}`,
+          expectedRequestConfigApiKey
+        )
+        expect(actual).toStrictEqual(createDatasetModel(testDatasetLicense))
+      })
+
+      test('should return Dataset when providing id, version id, and response with license without icon URI is successful', async () => {
+        const testDatasetLicenseWithoutIconUri = createDatasetLicenseModel(false)
+        const testDatasetVersionWithLicenseSuccessfulResponse = {
+          data: {
+            status: 'OK',
+            data: createDatasetVersionPayload(testDatasetLicenseWithoutIconUri)
+          }
+        }
+        jest.spyOn(axios, 'get').mockResolvedValue(testDatasetVersionWithLicenseSuccessfulResponse)
+
+        const actual = await sut.getDataset(
+          testDatasetModel.id,
+          testVersionId,
+          testIncludeDeaccessioned,
+          false
+        )
+
+        expect(axios.get).toHaveBeenCalledWith(
+          `${TestConstants.TEST_API_URL}/datasets/${testDatasetModel.id}/versions/${testVersionId}`,
+          expectedRequestConfigApiKey
+        )
+        expect(actual).toStrictEqual(createDatasetModel(testDatasetLicenseWithoutIconUri))
+      })
+
+      test('should return dataset with alternative persistent id, publication date and citation date when they are present in the response', async () => {
+        const testDatasetVersionWithAlternativePersistentIdAndDatesSuccessfulResponse = {
+          data: {
+            status: 'OK',
+            data: createDatasetVersionPayload(undefined, true)
+          }
+        }
+        jest
+          .spyOn(axios, 'get')
+          .mockResolvedValue(
+            testDatasetVersionWithAlternativePersistentIdAndDatesSuccessfulResponse
+          )
+
+        const actual = await sut.getDataset(
+          testDatasetModel.id,
+          testVersionId,
+          testIncludeDeaccessioned,
+          false
+        )
+
+        expect(axios.get).toHaveBeenCalledWith(
+          `${TestConstants.TEST_API_URL}/datasets/${testDatasetModel.id}/versions/${testVersionId}`,
+          expectedRequestConfigApiKey
+        )
+        expect(actual).toStrictEqual(createDatasetModel(undefined, true))
+      })
+
+      test('should return error on repository read error', async () => {
+        jest.spyOn(axios, 'get').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
+
+        let error = undefined as unknown as ReadError
+        await sut
+          .getDataset(testDatasetModel.id, testVersionId, testIncludeDeaccessioned, false)
+          .catch((e) => (error = e))
+
+        expect(axios.get).toHaveBeenCalledWith(
+          `${TestConstants.TEST_API_URL}/datasets/${testDatasetModel.id}/versions/${testVersionId}`,
+          expectedRequestConfigApiKey
+        )
+        expect(error).toBeInstanceOf(Error)
+      })
+    })
     describe('by numeric id', () => {
       test('should return Dataset when providing id, version id, and response is successful', async () => {
         jest.spyOn(axios, 'get').mockResolvedValue(testDatasetVersionSuccessfulResponse)


### PR DESCRIPTION
## What this PR does / why we need it:

Reorganize TermsOfUse model in the Dataset so it groups custom terms and terms of access into separate objects

## Which issue(s) this PR closes:

- Closes #251 

## Suggestions on how to test this:
Review code and tests

## Is there a release notes update needed for this change?:

## Additional documentation:
