### PR TITLE
Remove transform to markdown from Get Collection use case

### DIFF
--- a/src/collections/infra/repositories/transformers/collectionTransformers.ts
+++ b/src/collections/infra/repositories/transformers/collectionTransformers.ts
@@ -6,7 +6,6 @@ import {
   CollectionPayload
 } from './CollectionPayload'
 import { transformPayloadToOwnerNode } from '../../../../core/infra/repositories/transformers/dvObjectOwnerNodeTransformer'
-import { transformHtmlToMarkdown } from '../../../../datasets/infra/repositories/transformers/datasetTransformers'
 import { CollectionFacet } from '../../../domain/models/CollectionFacet'
 import { CollectionFacetPayload } from './CollectionFacetPayload'
 import {
@@ -53,9 +52,7 @@ const transformPayloadToCollection = (collectionPayload: CollectionPayload): Col
     type: collectionPayload.dataverseType as CollectionType,
     isMetadataBlockRoot: collectionPayload.isMetadataBlockRoot,
     isFacetRoot: collectionPayload.isFacetRoot,
-    ...(collectionPayload.description && {
-      description: transformHtmlToMarkdown(collectionPayload.description)
-    }),
+    description: collectionPayload.description,
     ...(collectionPayload.isPartOf && {
       isPartOf: transformPayloadToOwnerNode(collectionPayload.isPartOf)
     }),

--- a/test/functional/collections/GetCollectionItems.test.ts
+++ b/test/functional/collections/GetCollectionItems.test.ts
@@ -61,8 +61,8 @@ describe('execute', () => {
     try {
       const actual = await getCollectionItems.execute(testCollectionAlias)
 
-      const actualFilePreview = actual.items[0] as FilePreview
-      const actualDatasetPreview = actual.items[1] as DatasetPreview
+      const actualFilePreview = actual.items[1] as FilePreview
+      const actualDatasetPreview = actual.items[0] as DatasetPreview
 
       expect(actualFilePreview.name).toBe('test-file-1.txt')
       expect(actualDatasetPreview.title).toBe('Dataset created using the createDataset use case')

--- a/test/integration/collections/CollectionsRepository.test.ts
+++ b/test/integration/collections/CollectionsRepository.test.ts
@@ -339,8 +339,8 @@ describe('CollectionsRepository', () => {
       await new Promise((resolve) => setTimeout(resolve, 5000))
 
       let actual = await sut.getCollectionItems(testCollectionAlias)
-      const actualFilePreview = actual.items[0] as FilePreview
-      const actualDatasetPreview = actual.items[1] as DatasetPreview
+      const actualFilePreview = actual.items[1] as FilePreview
+      const actualDatasetPreview = actual.items[0] as DatasetPreview
       const actualCollectionPreview = actual.items[2] as CollectionPreview
 
       const expectedFileMd5 = '68b22040025784da775f55cfcb6dee2e'
@@ -473,7 +473,7 @@ describe('CollectionsRepository', () => {
 
       // Test limit and offset
       actual = await sut.getCollectionItems(testCollectionAlias, 1, 1)
-      expect((actual.items[0] as DatasetPreview).persistentId).toBe(testDatasetIds.persistentId)
+      expect((actual.items[0] as FilePreview).name).toBe(expectedFileName)
       expect(actual.items.length).toBe(1)
       expect(actual.totalItemCount).toBe(3)
 
@@ -683,8 +683,8 @@ describe('CollectionsRepository', () => {
       )
       expect(actual.items.length).toBe(3)
       expect(actual.totalItemCount).toBe(3)
-      expect((actual.items[0] as FilePreview).type).toBe(CollectionItemType.FILE)
-      expect((actual.items[1] as DatasetPreview).type).toBe(CollectionItemType.DATASET)
+      expect((actual.items[0] as DatasetPreview).type).toBe(CollectionItemType.DATASET)
+      expect((actual.items[1] as FilePreview).type).toBe(CollectionItemType.FILE)
       expect((actual.items[2] as CollectionPreview).type).toBe(CollectionItemType.COLLECTION)
       expect(actual.countPerObjectType.dataverses).toBe(1)
       expect(actual.countPerObjectType.datasets).toBe(1)

--- a/test/testHelpers/collections/collectionHelper.ts
+++ b/test/testHelpers/collections/collectionHelper.ts
@@ -16,8 +16,7 @@ const COLLECTION_ALIAS_STR = 'secondCollection'
 const COLLECTION_NAME_STR = 'Laboratory Research'
 const COLLECTION_AFFILIATION_STR = 'Laboratory Research Corporation'
 
-const COLLECTION_DESCRIPTION_HTML = 'This is an <b>example</b> collection used for testing.'
-const COLLECTION_DESCRIPTION_MARKDOWN = 'This is an **example** collection used for testing.'
+const COLLECTION_DESCRIPTION = 'This is an <b>example</b> collection used for testing.'
 
 const DATAVERSE_API_REQUEST_HEADERS = {
   headers: { 'Content-Type': 'application/json', 'X-Dataverse-Key': process.env.TEST_API_KEY }
@@ -30,7 +29,7 @@ export const createCollectionModel = (): Collection => {
     name: COLLECTION_NAME_STR,
     isReleased: COLLECTION_IS_RELEASED,
     affiliation: COLLECTION_AFFILIATION_STR,
-    description: COLLECTION_DESCRIPTION_MARKDOWN,
+    description: COLLECTION_DESCRIPTION,
     isPartOf: { type: DvObjectType.DATAVERSE, identifier: 'root', displayName: 'Root' },
     inputLevels: [
       {
@@ -59,7 +58,7 @@ export const createCollectionPayload = (): CollectionPayload => {
     name: COLLECTION_NAME_STR,
     isReleased: COLLECTION_IS_RELEASED,
     affiliation: COLLECTION_AFFILIATION_STR,
-    description: COLLECTION_DESCRIPTION_HTML,
+    description: COLLECTION_DESCRIPTION,
     isPartOf: { type: DvObjectType.DATAVERSE, identifier: 'root', displayName: 'Root' },
     inputLevels: [
       {


### PR DESCRIPTION
## What this PR does / why we need it:
To simplify the logic for managing HTML in strings, we are moving the conversion from HTML to markdown from the library to the frontend. 

## Which issue(s) this PR closes:

- Closes #264 

## Related Dataverse PRs:

- Depends on #

## Special notes for your reviewer:

## Suggestions on how to test this:

Review the code and tests

## Is there a release notes update needed for this change?:

## Additional documentation:
