### PR TITLE
Return new file id after file replacement

### DIFF
--- a/docs/useCases.md
+++ b/docs/useCases.md
@@ -1359,7 +1359,9 @@ const uploadedFileDTO: UploadedFileDTO = {
   mimeType: 'text/plain'
 }
 
-replaceFile.execute(fileId, uploadedFileDTO)
+replaceFile.execute(fileId, uploadedFileDTO).then((newFileId: number) => {
+  /* ... */
+})
 
 /* ... */
 ```
@@ -1369,6 +1371,8 @@ _See [use case](../src/files/domain/useCases/ReplaceFile.ts) implementation_.
 The `fileId` parameter can be a string, for persistent identifiers, or a number, for numeric identifiers.
 
 The `uploadedFileDTO` parameter is a [UploadedFileDTO](../src/files/domain/dtos/UploadedFileDTO.ts) and includes properties related to the uploaded files. Some of these properties should be calculated from the uploaded File Blob objects and the resulting storage identifiers from the Upload File use case.
+
+The use case returns a number, which is the identifier of the new file.
 
 #### Restrict or Unrestrict a File
 

--- a/docs/useCases.md
+++ b/docs/useCases.md
@@ -1372,7 +1372,7 @@ The `fileId` parameter can be a string, for persistent identifiers, or a number,
 
 The `uploadedFileDTO` parameter is a [UploadedFileDTO](../src/files/domain/dtos/UploadedFileDTO.ts) and includes properties related to the uploaded files. Some of these properties should be calculated from the uploaded File Blob objects and the resulting storage identifiers from the Upload File use case.
 
-The use case returns a number, which is the identifier of the new file
+The use case returns a number, which is the identifier of the new file.
 
 #### Restrict or Unrestrict a File
 

--- a/docs/useCases.md
+++ b/docs/useCases.md
@@ -1372,7 +1372,7 @@ The `fileId` parameter can be a string, for persistent identifiers, or a number,
 
 The `uploadedFileDTO` parameter is a [UploadedFileDTO](../src/files/domain/dtos/UploadedFileDTO.ts) and includes properties related to the uploaded files. Some of these properties should be calculated from the uploaded File Blob objects and the resulting storage identifiers from the Upload File use case.
 
-The use case returns a number, which is the identifier of the new file.
+The use case returns a number, which is the identifier of the new file
 
 #### Restrict or Unrestrict a File
 

--- a/src/files/domain/repositories/IFilesRepository.ts
+++ b/src/files/domain/repositories/IFilesRepository.ts
@@ -63,7 +63,7 @@ export interface IFilesRepository {
 
   deleteFile(fileId: number | string): Promise<undefined>
 
-  replaceFile(fileId: number | string, uploadedFileDTO: UploadedFileDTO): Promise<undefined>
+  replaceFile(fileId: number | string, uploadedFileDTO: UploadedFileDTO): Promise<number>
 
   restrictFile(fileId: number | string, restrict: boolean): Promise<undefined>
   updateFileMetadata(

--- a/src/files/domain/useCases/ReplaceFile.ts
+++ b/src/files/domain/useCases/ReplaceFile.ts
@@ -2,7 +2,7 @@ import { UseCase } from '../../../core/domain/useCases/UseCase'
 import { UploadedFileDTO } from '../dtos/UploadedFileDTO'
 import { IFilesRepository } from '../repositories/IFilesRepository'
 
-export class ReplaceFile implements UseCase<void> {
+export class ReplaceFile implements UseCase<number> {
   private filesRepository: IFilesRepository
 
   constructor(filesRepository: IFilesRepository) {
@@ -19,10 +19,10 @@ export class ReplaceFile implements UseCase<void> {
    *
    * @param {number | string} [fileId] - The File identifier, which can be a string (for persistent identifiers), or a number (for numeric identifiers).
    * @param {UploadedFileDTO} [uploadedFileDTO] - File DTO associated with the uploaded file.
-   * @returns {Promise<void>} A promise that resolves when the file has been successfully replaced.
+   * @returns {Promise<number>} A promise that resolves when the file has been successfully replaced and returns the new file identifier.
    * @throws {WriteError} - If there are errors while writing data.
    */
-  async execute(fileId: number | string, uploadedFileDTO: UploadedFileDTO): Promise<void> {
-    await this.filesRepository.replaceFile(fileId, uploadedFileDTO)
+  async execute(fileId: number | string, uploadedFileDTO: UploadedFileDTO): Promise<number> {
+    return await this.filesRepository.replaceFile(fileId, uploadedFileDTO)
   }
 }

--- a/src/files/infra/repositories/FilesRepository.ts
+++ b/src/files/infra/repositories/FilesRepository.ts
@@ -20,6 +20,7 @@ import { transformUploadDestinationsResponseToUploadDestination } from './transf
 import { UploadedFileDTO } from '../../domain/dtos/UploadedFileDTO'
 import { UpdateFileMetadataDTO } from '../../domain/dtos/UpdateFileMetadataDTO'
 import { ApiConstants } from '../../../core/infra/repositories/ApiConstants'
+import { AxiosResponse } from 'axios'
 
 export interface GetFilesQueryParams {
   includeDeaccessioned: boolean
@@ -58,6 +59,10 @@ export interface UploadedFileRequestBody {
 export interface ChecksumRequestBody {
   '@value': string
   '@type': string
+}
+
+type ReplaceFileResponseMinimal = {
+  files: { dataFile: { id: number } }[]
 }
 
 export class FilesRepository extends ApiRepository implements IFilesRepository {
@@ -307,7 +312,7 @@ export class FilesRepository extends ApiRepository implements IFilesRepository {
   public async replaceFile(
     fileId: number | string,
     uploadedFileDTO: UploadedFileDTO
-  ): Promise<undefined> {
+  ): Promise<number> {
     const requestBody: UploadedFileRequestBody = {
       fileName: uploadedFileDTO.fileName,
       checksum: {
@@ -332,7 +337,10 @@ export class FilesRepository extends ApiRepository implements IFilesRepository {
       {},
       ApiConstants.CONTENT_TYPE_MULTIPART_FORM_DATA
     )
-      .then(() => undefined)
+      .then((response: AxiosResponse<{ data: ReplaceFileResponseMinimal }>) => {
+        const fileNumber = response.data.data.files[0].dataFile.id
+        return fileNumber
+      })
       .catch((error) => {
         throw error
       })

--- a/src/files/infra/repositories/FilesRepository.ts
+++ b/src/files/infra/repositories/FilesRepository.ts
@@ -1,3 +1,4 @@
+import { AxiosResponse } from 'axios'
 import { ApiRepository } from '../../../core/infra/repositories/ApiRepository'
 import { IFilesRepository } from '../../domain/repositories/IFilesRepository'
 import { FileModel as FileModel } from '../../domain/models/FileModel'
@@ -20,7 +21,6 @@ import { transformUploadDestinationsResponseToUploadDestination } from './transf
 import { UploadedFileDTO } from '../../domain/dtos/UploadedFileDTO'
 import { UpdateFileMetadataDTO } from '../../domain/dtos/UpdateFileMetadataDTO'
 import { ApiConstants } from '../../../core/infra/repositories/ApiConstants'
-import { AxiosResponse } from 'axios'
 
 export interface GetFilesQueryParams {
   includeDeaccessioned: boolean

--- a/src/files/infra/repositories/transformers/FilePayload.ts
+++ b/src/files/infra/repositories/transformers/FilePayload.ts
@@ -10,7 +10,6 @@ export interface FilePayload {
     version: number
     description?: string
     restricted: boolean
-    directoryLabel?: string
     datasetVersionId?: number
     categories?: string[]
     contentType: string
@@ -37,6 +36,7 @@ export interface FilePayload {
   }
   version: number
   restricted: boolean
+  directoryLabel?: string
   label: string
   datasetVersionId: number
 }

--- a/src/files/infra/repositories/transformers/fileTransformers.ts
+++ b/src/files/infra/repositories/transformers/fileTransformers.ts
@@ -44,8 +44,8 @@ const transformFilePayloadToFile = (filePayload: FilePayload): FileModel => {
     ...(filePayload.dataFile.description && { description: filePayload.dataFile.description }),
     restricted: filePayload.restricted,
     latestRestricted: filePayload.dataFile.restricted,
-    ...(filePayload.dataFile.directoryLabel && {
-      directoryLabel: filePayload.dataFile.directoryLabel
+    ...(filePayload.directoryLabel && {
+      directoryLabel: filePayload.directoryLabel
     }),
     ...(filePayload.dataFile.datasetVersionId && {
       datasetVersionId: filePayload.dataFile.datasetVersionId

--- a/test/integration/files/DirectUpload.test.ts
+++ b/test/integration/files/DirectUpload.test.ts
@@ -332,8 +332,6 @@ describe('Direct Upload', () => {
 
     const replaceResponse = await filesRepositorySut.replaceFile(currentFileId, newUploadedFileDTO)
 
-    console.log({ replaceResponse })
-
     // 4 - Verify that the new file is in the dataset and the old file is not
     datasetFiles = await filesRepositorySut.getDatasetFiles(
       testDataset3Ids.numericId,

--- a/test/integration/files/DirectUpload.test.ts
+++ b/test/integration/files/DirectUpload.test.ts
@@ -330,7 +330,9 @@ describe('Direct Upload', () => {
       mimeType: newSinglepartFile.type
     }
 
-    await filesRepositorySut.replaceFile(currentFileId, newUploadedFileDTO)
+    const replaceResponse = await filesRepositorySut.replaceFile(currentFileId, newUploadedFileDTO)
+
+    console.log({ replaceResponse })
 
     // 4 - Verify that the new file is in the dataset and the old file is not
     datasetFiles = await filesRepositorySut.getDatasetFiles(
@@ -341,6 +343,7 @@ describe('Direct Upload', () => {
     )
 
     expect(datasetFiles.totalFilesCount).toBe(1)
+    expect(replaceResponse).toBe(currentFileId + 1)
     expect(datasetFiles.files[0].name).toBe('new-singlepart-file')
     expect(datasetFiles.files[0].sizeBytes).toBe(newSinglepartFile.size)
     expect(datasetFiles.files[0].storageIdentifier).toContain('localstack1://mybucket:')

--- a/test/testHelpers/files/filesHelper.ts
+++ b/test/testHelpers/files/filesHelper.ts
@@ -81,6 +81,7 @@ export const createFilePayload = (): FilePayload => {
     restricted: false,
     version: 1,
     datasetVersionId: 2,
+    directoryLabel: 'directoryLabel',
     dataFile: {
       id: 1,
       version: 1,
@@ -116,7 +117,6 @@ export const createFilePayload = (): FilePayload => {
         isPartOf: { type: DvObjectType.DATAVERSE, identifier: 'root', displayName: 'Root' }
       },
       description: 'description',
-      directoryLabel: 'directoryLabel',
       datasetVersionId: 1,
       originalFormat: 'originalFormat',
       originalSize: 127426,

--- a/test/unit/files/ReplaceFile.test.ts
+++ b/test/unit/files/ReplaceFile.test.ts
@@ -12,15 +12,15 @@ describe('execute', () => {
     mimeType: 'test/type'
   }
 
-  test('should return undefined on client success', async () => {
+  test('should return file id on client success', async () => {
     const filesRepositoryStub: IFilesRepository = {} as IFilesRepository
-    filesRepositoryStub.replaceFile = jest.fn().mockResolvedValue(undefined)
+    filesRepositoryStub.replaceFile = jest.fn().mockResolvedValue(1)
 
     const sut = new ReplaceFile(filesRepositoryStub)
 
     const actual = await sut.execute(1, testUploadedFileDTO)
 
-    expect(actual).toEqual(undefined)
+    expect(actual).toEqual(1)
   })
 
   test('should return error on client error', async () => {


### PR DESCRIPTION
## What this PR does / why we need it:
Returns the new file id number after replacing a file.

## Suggestions on how to test this:
Code review and check that tests are passing.