### PR TITLE
Fix: change the model of DatasetVersionDiff

### DIFF
--- a/src/datasets/domain/models/DatasetVersionDiff.ts
+++ b/src/datasets/domain/models/DatasetVersionDiff.ts
@@ -8,7 +8,9 @@ export interface DatasetVersionDiff {
   filesRemoved?: FileSummary[]
   fileChanges?: FileDiff[]
   filesReplaced?: FileReplacement[]
-  termsOfAccess?: FieldDiff[]
+  termsOfAccess?: {
+    changed: FieldDiff[]
+  }
 }
 
 export interface FileSummary {

--- a/src/datasets/infra/repositories/transformers/DatasetVersionDiffPayload.ts
+++ b/src/datasets/infra/repositories/transformers/DatasetVersionDiffPayload.ts
@@ -6,7 +6,7 @@ export interface DatasetVersionDiffPayload {
   filesRemoved: FileSummaryPayload[]
   fileChanges: FileDiffPayload[]
   filesReplaced: FileReplacementPayload[]
-  TermsOfAccess: FieldDiffPayload[]
+  TermsOfAccess: { changed: FieldDiffPayload[] }
 }
 
 export interface FileSummaryPayload {

--- a/test/testHelpers/datasets/datasetVersionDiffHelper.ts
+++ b/test/testHelpers/datasets/datasetVersionDiffHelper.ts
@@ -74,6 +74,6 @@ export const createDatasetVersionDiff = (): DatasetVersionDiff => {
     filesRemoved: [fileSummary],
     fileChanges: [fileDiff],
     filesReplaced: [fileReplacement],
-    termsOfAccess: [fieldDiff]
+    termsOfAccess: { changed: [fieldDiff] }
   }
 }


### PR DESCRIPTION
## What this PR does / why we need it:
DatasetVersionDiff model, termsOfAccess should be {termsOfAccess?:  changed: FieldDiff[] } from API

Previous PR Merged
197 compare dataset version https://github.com/IQSS/dataverse-client-javascript/pull/220

Related to 
https://github.com/IQSS/dataverse-frontend/pull/623

`curl -H "X-Dataverse-key: $API_TOKEN" -X GET "$SERVER_URL/api/datasets/:persistentId/versions/2.0/compare/:draft?persistentId=$PERSISTENT_IDENTIFIER"`

TermsOfAccess result could be 
```
{
    "status": "OK",
    "data": {
        "oldVersion": {
            "versionNumber": "2.0",
            "versionState": "RELEASED",
            "lastUpdatedDate": "2025-04-02T05:35:36Z"
        },
        "newVersion": {
            "versionNumber": "DRAFT",
            "versionState": "DRAFT",
            "lastUpdatedDate": "2025-04-03T22:03:23Z"
        },
        "TermsOfAccess": {
            "changed": [
                {
                    "fieldName": "Terms of Access for Restricted Files",
                    "oldValue": "ertetre",
                    "newValue": "sgsgr"
                },
                {
                    "fieldName": "Data Access Place",
                    "oldValue": "",
                    "newValue": "qweqe"
                },
                {
                    "fieldName": "Original Archive",
                    "oldValue": "",
                    "newValue": "qwe"
                }
            ]
        }
    }
}
``` 