### PR TITLE
Add Deaccession Reason to DatasetVersionsSummary

### DIFF
--- a/src/datasets/domain/models/DatasetVersionSummaryInfo.ts
+++ b/src/datasets/domain/models/DatasetVersionSummaryInfo.ts
@@ -7,7 +7,17 @@ export interface DatasetVersionSummaryInfo {
 }
 
 export type DatasetVersionSummary = {
-  [key: string]: SummaryUpdates | SummaryUpdatesWithFields | FilesSummaryUpdates | boolean
+  [key: string]:
+    | SummaryUpdates
+    | SummaryUpdatesWithFields
+    | FilesSummaryUpdates
+    | boolean
+    | Deaccessioned
+}
+
+interface Deaccessioned {
+  reason: string
+  url: string
 }
 
 interface SummaryUpdates {
@@ -31,6 +41,5 @@ interface FilesSummaryUpdates {
 export enum DatasetVersionSummaryStringValues {
   firstPublished = 'firstPublished',
   firstDraft = 'firstDraft',
-  versionDeaccessioned = 'versionDeaccessioned',
   previousVersionDeaccessioned = 'previousVersionDeaccessioned'
 }

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -35,7 +35,8 @@ import {
   createCollectionViaApi,
   deleteCollectionViaApi,
   publishCollectionViaApi,
-  ROOT_COLLECTION_ALIAS
+  ROOT_COLLECTION_ALIAS,
+  setStorageDriverViaApi
 } from '../../testHelpers/collections/collectionHelper'
 import {
   calculateBlobChecksum,
@@ -1121,6 +1122,7 @@ describe('DatasetsRepository', () => {
     beforeAll(async () => {
       await createCollectionViaApi(testDatasetVersionsCollectionAlias)
       await publishCollectionViaApi(testDatasetVersionsCollectionAlias)
+      await setStorageDriverViaApi(testDatasetVersionsCollectionAlias, 'LocalStack')
     })
 
     afterAll(async () => {

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -35,8 +35,7 @@ import {
   createCollectionViaApi,
   deleteCollectionViaApi,
   publishCollectionViaApi,
-  ROOT_COLLECTION_ALIAS,
-  setStorageDriverViaApi
+  ROOT_COLLECTION_ALIAS
 } from '../../testHelpers/collections/collectionHelper'
 import {
   calculateBlobChecksum,
@@ -1122,7 +1121,6 @@ describe('DatasetsRepository', () => {
     beforeAll(async () => {
       await createCollectionViaApi(testDatasetVersionsCollectionAlias)
       await publishCollectionViaApi(testDatasetVersionsCollectionAlias)
-      await setStorageDriverViaApi(testDatasetVersionsCollectionAlias, 'LocalStack')
     })
 
     afterAll(async () => {
@@ -1158,6 +1156,29 @@ describe('DatasetsRepository', () => {
       expect(actual.length).toBeGreaterThan(0)
       expect(actual[0].versionNumber).toBe('1.0')
       expect(actual[0].summary).toBe(DatasetVersionSummaryStringValues.firstPublished)
+
+      await deletePublishedDatasetViaApi(testDatasetIds.persistentId)
+    })
+
+    test('should return dataset versions correctly after deaccessioned', async () => {
+      const testDatasetIds = await createDataset.execute(
+        TestConstants.TEST_NEW_DATASET_DTO,
+        testDatasetVersionsCollectionAlias
+      )
+      await publishDataset.execute(testDatasetIds.numericId, VersionUpdateType.MAJOR)
+
+      await waitForNoLocks(testDatasetIds.numericId, 10)
+
+      const deaccessionReason = {
+        deaccessioned: { reason: 'Test reason.' }
+      }
+      await deaccessionDatasetViaApi(testDatasetIds.numericId, '1.0')
+
+      const actual = await sut.getDatasetVersionsSummaries(testDatasetIds.numericId)
+
+      expect(actual.length).toBeGreaterThan(0)
+      expect(actual[0].versionNumber).toBe('1.0')
+      expect(actual[0].summary).toStrictEqual(deaccessionReason)
 
       await deletePublishedDatasetViaApi(testDatasetIds.persistentId)
     })


### PR DESCRIPTION
## What this PR does / why we need it:
the api endpoint added a {deaccession: {reason: string, url: string }} into the version summary, so the model should be changed accordingly to get the deaccession reason

## Which issue(s) this PR closes:

- Closes #288 

## Related Dataverse PRs:

- Depends on #

## Special notes for your reviewer:

## Suggestions on how to test this:

## Is there a release notes update needed for this change?:

## Additional documentation:
