### PR TITLE
Add deaccession reason to version summary

### DIFF
--- a/src/datasets/domain/models/DatasetVersionSummaryInfo.ts
+++ b/src/datasets/domain/models/DatasetVersionSummaryInfo.ts
@@ -7,7 +7,17 @@ export interface DatasetVersionSummaryInfo {
 }
 
 export type DatasetVersionSummary = {
-  [key: string]: SummaryUpdates | SummaryUpdatesWithFields | FilesSummaryUpdates | boolean
+  [key: string]:
+    | SummaryUpdates
+    | SummaryUpdatesWithFields
+    | FilesSummaryUpdates
+    | boolean
+    | Deaccessioned
+}
+
+interface Deaccessioned {
+  reason: string
+  url: string
 }
 
 interface SummaryUpdates {

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -1162,6 +1162,29 @@ describe('DatasetsRepository', () => {
       await deletePublishedDatasetViaApi(testDatasetIds.persistentId)
     })
 
+    test('should return dataset versions correctly after deaccessioned', async () => {
+      const testDatasetIds = await createDataset.execute(
+        TestConstants.TEST_NEW_DATASET_DTO,
+        testDatasetVersionsCollectionAlias
+      )
+      await publishDataset.execute(testDatasetIds.numericId, VersionUpdateType.MAJOR)
+
+      await waitForNoLocks(testDatasetIds.numericId, 10)
+
+      const deaccessionReason = {
+        deaccessioned: { reason: 'Test reason.' }
+      }
+      await deaccessionDatasetViaApi(testDatasetIds.numericId, '1.0')
+
+      const actual = await sut.getDatasetVersionsSummaries(testDatasetIds.numericId)
+
+      expect(actual.length).toBeGreaterThan(0)
+      expect(actual[0].versionNumber).toBe('1.0')
+      expect(actual[0].summary).toStrictEqual(deaccessionReason)
+
+      await deletePublishedDatasetViaApi(testDatasetIds.persistentId)
+    })
+
     test('should return dataset versions correctly after 1st publish and metadata fields update', async () => {
       const testDatasetIds = await createDataset.execute(
         TestConstants.TEST_NEW_DATASET_DTO,


### PR DESCRIPTION
## What this PR does / why we need it:

the api endpoint added a {deaccession: {reason: string, url: string }} into the version summary, so the model should be changed accordingly to get the deaccession reason

## Which issue(s) this PR closes:

- Closes #288 

## Special notes for your reviewer:

