### PR TITLE
Fix the integration test for DirectUpload.test.ts 

### DIFF
--- a/test/integration/files/DirectUpload.test.ts
+++ b/test/integration/files/DirectUpload.test.ts
@@ -330,7 +330,7 @@ describe('Direct Upload', () => {
       mimeType: newSinglepartFile.type
     }
 
-    const replaceResponse = await filesRepositorySut.replaceFile(currentFileId, newUploadedFileDTO)
+    await filesRepositorySut.replaceFile(currentFileId, newUploadedFileDTO)
 
     // 4 - Verify that the new file is in the dataset and the old file is not
     datasetFiles = await filesRepositorySut.getDatasetFiles(
@@ -341,7 +341,6 @@ describe('Direct Upload', () => {
     )
 
     expect(datasetFiles.totalFilesCount).toBe(1)
-    expect(replaceResponse).toBe(currentFileId + 1)
     expect(datasetFiles.files[0].name).toBe('new-singlepart-file')
     expect(datasetFiles.files[0].sizeBytes).toBe(newSinglepartFile.size)
     expect(datasetFiles.files[0].storageIdentifier).toContain('localstack1://mybucket:')


### PR DESCRIPTION
## What this PR does / why we need it:
Remove the test of the primary key value, since we can't guarantee the generated value