### PR TITLE
GetCollectionItems use case DatasetPreview publicationDate

### DIFF
--- a/src/datasets/domain/models/DatasetPreview.ts
+++ b/src/datasets/domain/models/DatasetPreview.ts
@@ -11,6 +11,7 @@ export interface DatasetPreview {
   citation: string
   description: string
   publicationStatuses: PublicationStatus[]
+  publicationDate?: string
   parentCollectionName: string
   parentCollectionAlias: string
   imageUrl?: string

--- a/src/datasets/infra/repositories/transformers/datasetPreviewsTransformers.ts
+++ b/src/datasets/infra/repositories/transformers/datasetPreviewsTransformers.ts
@@ -47,6 +47,7 @@ export const transformDatasetPreviewPayloadToDatasetPreview = (
     citation: datasetPreviewPayload.citation,
     description: datasetPreviewPayload.description,
     publicationStatuses: publicationStatuses,
+    publicationDate: datasetPreviewPayload.published_at,
     parentCollectionAlias: datasetPreviewPayload.identifier_of_dataverse,
     parentCollectionName: datasetPreviewPayload.name_of_dataverse,
     ...(datasetPreviewPayload.image_url && {

--- a/test/testHelpers/datasets/datasetPreviewHelper.ts
+++ b/test/testHelpers/datasets/datasetPreviewHelper.ts
@@ -27,6 +27,7 @@ export const createDatasetPreviewModel = (): DatasetPreview => {
     },
     citation: DATASET_CITATION,
     description: 'test',
+    publicationDate: DATASET_RELEASE_TIME_STR,
     publicationStatuses: [PublicationStatus.Draft, PublicationStatus.Unpublished],
     parentCollectionAlias: 'parentCollection',
     parentCollectionName: 'Parent Collection',


### PR DESCRIPTION
Maps and send the publicationDate of a dataset in the GetCollectionItems DatasetPreview information.

To test: is just a new property, code review and check that tests are passing.