### PR TITLE
Avoid double encoding of search term

### DIFF
--- a/src/collections/infra/repositories/CollectionsRepository.ts
+++ b/src/collections/infra/repositories/CollectionsRepository.ts
@@ -221,10 +221,7 @@ export class CollectionsRepository extends ApiRepository implements ICollections
     }
 
     if (searchText) {
-      queryParams.set(
-        GetMyDataCollectionItemsQueryParams.SEARCH_TEXT,
-        encodeURIComponent(searchText)
-      )
+      queryParams.set(GetMyDataCollectionItemsQueryParams.SEARCH_TEXT, searchText)
     }
 
     roleIds.forEach((roleId) => {
@@ -315,10 +312,7 @@ export class CollectionsRepository extends ApiRepository implements ICollections
     collectionSearchCriteria: CollectionSearchCriteria
   ) {
     if (collectionSearchCriteria.searchText) {
-      queryParams.set(
-        GetCollectionItemsQueryParams.QUERY,
-        encodeURIComponent(collectionSearchCriteria.searchText)
-      )
+      queryParams.set(GetCollectionItemsQueryParams.QUERY, collectionSearchCriteria.searchText)
     }
 
     if (collectionSearchCriteria?.itemTypes) {

--- a/test/integration/collections/CollectionsRepository.test.ts
+++ b/test/integration/collections/CollectionsRepository.test.ts
@@ -487,8 +487,8 @@ describe('CollectionsRepository', () => {
       expect(actualFilePreview.fileType).toBe('Plain Text')
       expect(actualFilePreview.md5).toBe(expectedFileMd5)
       expect(actualFilePreview.name).toBe(expectedFileName)
-      expect(actualFilePreview.publicationStatuses[0]).toBe(PublicationStatus.Unpublished)
-      expect(actualFilePreview.publicationStatuses[1]).toBe(PublicationStatus.Draft)
+      expect(actualFilePreview.publicationStatuses).toContain(PublicationStatus.Unpublished)
+      expect(actualFilePreview.publicationStatuses).toContain(PublicationStatus.Draft)
       expect(actualFilePreview.sizeInBytes).toBe(12)
       expect(actualFilePreview.url).not.toBeUndefined()
       expect(actualFilePreview.releaseOrCreateDate).not.toBeUndefined()
@@ -501,8 +501,8 @@ describe('CollectionsRepository', () => {
       expect(actualDatasetPreview.description).toBe('This is the description of the dataset.')
       expect(actualDatasetPreview.persistentId).not.toBeUndefined()
       expect(actualDatasetPreview.persistentId).not.toBeUndefined()
-      expect(actualDatasetPreview.publicationStatuses[0]).toBe(PublicationStatus.Unpublished)
-      expect(actualDatasetPreview.publicationStatuses[1]).toBe(PublicationStatus.Draft)
+      expect(actualDatasetPreview.publicationStatuses).toContain(PublicationStatus.Unpublished)
+      expect(actualFilePreview.publicationStatuses).toContain(PublicationStatus.Draft)
       expect(actualDatasetPreview.versionId).not.toBeUndefined()
       expect(actualDatasetPreview.versionInfo.createTime).not.toBeUndefined()
       expect(actualDatasetPreview.versionInfo.lastUpdateTime).not.toBeUndefined()
@@ -521,7 +521,7 @@ describe('CollectionsRepository', () => {
       expect(actualCollectionPreview.imageUrl).toBe(undefined)
       expect(actualCollectionPreview.parentAlias).toBe(testCollectionAlias)
       expect(actualCollectionPreview.parentName).toBe(expectedCollectionsName)
-      expect(actualCollectionPreview.publicationStatuses[0]).toBe(PublicationStatus.Unpublished)
+      expect(actualCollectionPreview.publicationStatuses).toContain(PublicationStatus.Unpublished)
       expect(actualCollectionPreview.releaseOrCreateDate).not.toBeUndefined()
       expect(actualCollectionPreview.affiliation).toBe('Scientific Research University')
       expect(actualCollectionPreview.parentAlias).toBe('collectionsRepositoryTestCollection')
@@ -558,7 +558,7 @@ describe('CollectionsRepository', () => {
       expect(actual.countPerObjectType.files).toBe(1)
 
       const collectionSearchCriteriaForDataset = new CollectionSearchCriteria().withSearchText(
-        'This is the description'
+        'Dataset created using'
       )
       actual = await sut.getCollectionItems(
         testCollectionAlias,
@@ -566,6 +566,7 @@ describe('CollectionsRepository', () => {
         undefined,
         collectionSearchCriteriaForDataset
       )
+
       expect(actual.totalItemCount).toBe(1)
       expect((actual.items[0] as DatasetPreview).title).toBe(expectedDatasetDescription)
       expect(actual.countPerObjectType.collections).toBe(0)
@@ -926,7 +927,7 @@ describe('CollectionsRepository', () => {
       expect(actualFilePreview.fileType).toBe('Tab-Delimited')
       expect(actualFilePreview.md5).toBe(expectedFileMd5)
       expect(actualFilePreview.name).toBe(expectedFileName)
-      expect(actualFilePreview.publicationStatuses[0]).toBe(PublicationStatus.Published)
+      expect(actualFilePreview.publicationStatuses).toContain(PublicationStatus.Published)
       expect(actualFilePreview.sizeInBytes).toBe(137)
       expect(actualFilePreview.url).not.toBeUndefined()
       expect(actualFilePreview.releaseOrCreateDate).not.toBeUndefined()
@@ -943,7 +944,7 @@ describe('CollectionsRepository', () => {
       expect(actualDatasetPreview.description).toBe('This is the description of the dataset.')
       expect(actualDatasetPreview.persistentId).not.toBeUndefined()
       expect(actualDatasetPreview.persistentId).not.toBeUndefined()
-      expect(actualDatasetPreview.publicationStatuses[0]).toBe(PublicationStatus.Published)
+      expect(actualDatasetPreview.publicationStatuses).toContain(PublicationStatus.Published)
       expect(actualDatasetPreview.versionId).not.toBeUndefined()
       expect(actualDatasetPreview.versionInfo.createTime).not.toBeUndefined()
       expect(actualDatasetPreview.versionInfo.lastUpdateTime).not.toBeUndefined()
@@ -962,7 +963,7 @@ describe('CollectionsRepository', () => {
       expect(actualCollectionPreview.imageUrl).toBe(undefined)
       expect(actualCollectionPreview.parentAlias).toBe(testCollectionAlias)
       expect(actualCollectionPreview.parentName).toBe(expectedCollectionsName)
-      expect(actualCollectionPreview.publicationStatuses[0]).toBe(PublicationStatus.Published)
+      expect(actualCollectionPreview.publicationStatuses).toContain(PublicationStatus.Published)
       expect(actualCollectionPreview.releaseOrCreateDate).not.toBeUndefined()
       expect(actualCollectionPreview.affiliation).toBe('Scientific Research University')
       expect(actualCollectionPreview.parentAlias).toBe('collectionsRepositoryTestCollection')
@@ -1356,8 +1357,7 @@ describe('CollectionsRepository', () => {
           TestConstants.TEST_NEW_DATASET_DTO,
           testSubCollectionAlias
         )
-      } catch (error: any) {
-        console.log(error.message)
+      } catch {
         throw new Error('Tests beforeAll(): Error while creating test dataset')
       }
       await uploadFileViaApi(testDatasetIds.numericId, testTextFile1Name).catch(() => {
@@ -1451,8 +1451,8 @@ describe('CollectionsRepository', () => {
       expect(actualFilePreview.fileType).toBe('Plain Text')
       expect(actualFilePreview.md5).toBe(expectedFileMd5)
       expect(actualFilePreview.name).toBe(expectedFileName)
-      expect(actualFilePreview.publicationStatuses[0]).toBe(PublicationStatus.Unpublished)
-      expect(actualFilePreview.publicationStatuses[1]).toBe(PublicationStatus.Draft)
+      expect(actualFilePreview.publicationStatuses).toContain(PublicationStatus.Unpublished)
+      expect(actualFilePreview.publicationStatuses).toContain(PublicationStatus.Draft)
       expect(actualFilePreview.sizeInBytes).toBe(12)
       expect(actualFilePreview.url).not.toBeUndefined()
       expect(actualFilePreview.releaseOrCreateDate).not.toBeUndefined()
@@ -1465,8 +1465,8 @@ describe('CollectionsRepository', () => {
       expect(actualDatasetPreview.description).toBe('This is the description of the dataset.')
       expect(actualDatasetPreview.persistentId).not.toBeUndefined()
       expect(actualDatasetPreview.persistentId).not.toBeUndefined()
-      expect(actualDatasetPreview.publicationStatuses[0]).toBe(PublicationStatus.Unpublished)
-      expect(actualDatasetPreview.publicationStatuses[1]).toBe(PublicationStatus.Draft)
+      expect(actualDatasetPreview.publicationStatuses).toContain(PublicationStatus.Unpublished)
+      expect(actualDatasetPreview.publicationStatuses).toContain(PublicationStatus.Draft)
       expect(actualDatasetPreview.versionId).not.toBeUndefined()
       expect(actualDatasetPreview.versionInfo.createTime).not.toBeUndefined()
       expect(actualDatasetPreview.versionInfo.lastUpdateTime).not.toBeUndefined()
@@ -1485,7 +1485,7 @@ describe('CollectionsRepository', () => {
       expect(actualCollectionPreview.imageUrl).toBe(undefined)
       expect(actualCollectionPreview.parentAlias).toBe(testCollectionAlias)
       expect(actualCollectionPreview.parentName).toBe(testCollectionName)
-      expect(actualCollectionPreview.publicationStatuses[0]).toBe(PublicationStatus.Unpublished)
+      expect(actualCollectionPreview.publicationStatuses).toContain(PublicationStatus.Unpublished)
       expect(actualCollectionPreview.releaseOrCreateDate).not.toBeUndefined()
       expect(actualCollectionPreview.affiliation).toBe('test affiliation')
       expect(actualCollectionPreview.type).toBe(CollectionItemType.COLLECTION)
@@ -1521,7 +1521,7 @@ describe('CollectionsRepository', () => {
       expect(actualFileResult.countPerObjectType.datasets).toBe(0)
       expect(actualFileResult.countPerObjectType.files).toBe(1)
 
-      const datasetSearchText = 'This is the description'
+      const datasetSearchText = 'of the dataset.'
 
       actual = await sut.getMyDataCollectionItems(
         roleIds,
@@ -1531,6 +1531,7 @@ describe('CollectionsRepository', () => {
         undefined,
         datasetSearchText
       )
+
       expect(actual.totalItemCount).toBe(1)
       expect((actual.items[0] as DatasetPreview).title).toBe(expectedDatasetDescription)
       expect(actual.countPerObjectType.collections).toBe(0)


### PR DESCRIPTION
## What this PR does / why we need it:
Avoids double encoding in the search api and my data api related use cases.
We were using `URLSearchParams` for query params and also `encodeURIComponent` for the search text so we were double encoding the `mydata_search_term` and the `q` query params.

## Special notes for your reviewer:

## Suggestions on how to test this:
Code review and tests passing.

## Is there a release notes update needed for this change?:
No
## Additional documentation:
No
