### PR TITLE
SCORE option in SortType enum

### DIFF
--- a/src/collections/domain/models/CollectionSearchCriteria.ts
+++ b/src/collections/domain/models/CollectionSearchCriteria.ts
@@ -2,7 +2,8 @@ import { CollectionItemType } from './CollectionItemType'
 
 export enum SortType {
   NAME = 'name',
-  DATE = 'date'
+  DATE = 'date',
+  SCORE = 'score'
 }
 
 export enum OrderType {


### PR DESCRIPTION
## What this PR does / why we need it:
This just adds a new `SCORE` option to the `SortType` enum

## Which issue(s) this PR closes:

- Closes #309 

## Suggestions on how to test this:
Code review and tests passing.
