### PR TITLE
Update includeDeaccessioned to GetFile use case

### DIFF
--- a/docs/useCases.md
+++ b/docs/useCases.md
@@ -1007,6 +1007,8 @@ The `fileId` parameter can be a string, for persistent identifiers, or a number,
 
 The optional `datasetVersionId` parameter can correspond to a numeric version identifier, as in the previous example, or a [DatasetNotNumberedVersion](../src/datasets/domain/models/DatasetNotNumberedVersion.ts) enum value. If not set, the default value is `DatasetNotNumberedVersion.LATEST`.
 
+There is an optional third parameter called `includeDeaccessioned`, which indicates whether to consider deaccessioned versions or not in the file search. If not set, the default value is `false`.
+
 #### Get a File and its Dataset
 
 Returns a tuple of [FileModel](../src/files/domain/models/FileModel.ts) and [Dataset](../src/datasets/domain/models/Dataset.ts) objects (`[FileModel, Dataset]`), given the search parameters to identify the file.
@@ -1035,6 +1037,8 @@ _See [use case](../src/files/domain/useCases/GetFileAndDataset.ts)_ definition.
 The `fileId` parameter can be a string, for persistent identifiers, or a number, for numeric identifiers.
 
 The optional `datasetVersionId` parameter can correspond to a numeric version identifier, as in the previous example, or a [DatasetNotNumberedVersion](../src/datasets/domain/models/DatasetNotNumberedVersion.ts) enum value. If not set, the default value is `DatasetNotNumberedVersion.LATEST`.
+
+There is an optional third parameter called `includeDeaccessioned`, which indicates whether to consider deaccessioned versions or not in the file search. If not set, the default value is `false`.
 
 #### Get File Citation Text
 

--- a/src/files/domain/repositories/IFilesRepository.ts
+++ b/src/files/domain/repositories/IFilesRepository.ts
@@ -47,7 +47,8 @@ export interface IFilesRepository {
   getFile(
     fileId: number | string,
     datasetVersionId: string,
-    returnDatasetVersion: boolean
+    returnDatasetVersion: boolean,
+    includeDeaccessioned: boolean
   ): Promise<FileModel | [FileModel, Dataset]>
 
   getFileCitation(

--- a/src/files/domain/useCases/GetFile.ts
+++ b/src/files/domain/useCases/GetFile.ts
@@ -11,12 +11,19 @@ export class GetFile implements UseCase<FileModel> {
    *
    * @param {number | string} [fileId] - The File identifier, which can be a string (for persistent identifiers), or a number (for numeric identifiers).
    * @param {string | DatasetNotNumberedVersion} [datasetVersionId=DatasetNotNumberedVersion.LATEST] - The dataset version identifier, which can be a version-specific numeric string (for example, 1.0) or a DatasetNotNumberedVersion enum value. If this parameter is not set, the default value is: DatasetNotNumberedVersion.LATEST
+   * @param {boolean} [includeDeaccessioned=false] - If true, the file will be returned even if it has been deaccessioned.
    * @returns {Promise<FileModel>}
    */
   async execute(
     fileId: number | string,
-    datasetVersionId: string | DatasetNotNumberedVersion = DatasetNotNumberedVersion.LATEST
+    datasetVersionId: string | DatasetNotNumberedVersion = DatasetNotNumberedVersion.LATEST,
+    includeDeaccessioned = false
   ): Promise<FileModel> {
-    return (await this.filesRepository.getFile(fileId, datasetVersionId, false)) as FileModel
+    return (await this.filesRepository.getFile(
+      fileId,
+      datasetVersionId,
+      false,
+      includeDeaccessioned
+    )) as FileModel
   }
 }

--- a/src/files/domain/useCases/GetFileAndDataset.ts
+++ b/src/files/domain/useCases/GetFileAndDataset.ts
@@ -11,15 +11,19 @@ export class GetFileAndDataset implements UseCase<[FileModel, Dataset]> {
    *
    * @param {number | string} [fileId] - The File identifier, which can be a string (for persistent identifiers), or a number (for numeric identifiers).
    * @param {string | DatasetNotNumberedVersion} [datasetVersionId=DatasetNotNumberedVersion.LATEST] - The dataset version identifier, which can be a version-specific numeric string (for example, 1.0) or a DatasetNotNumberedVersion enum value. If this parameter is not set, the default value is: DatasetNotNumberedVersion.LATEST
+   * @param {boolean} [includeDeaccessioned=false] - If true, the file will be returned even if it has been deaccessioned.
    * @returns {Promise<[FileModel, Dataset]>}
    */
   async execute(
     fileId: number | string,
-    datasetVersionId: string | DatasetNotNumberedVersion = DatasetNotNumberedVersion.LATEST
+    datasetVersionId: string | DatasetNotNumberedVersion = DatasetNotNumberedVersion.LATEST,
+    includeDeaccessioned = false
   ): Promise<[FileModel, Dataset]> {
-    return (await this.filesRepository.getFile(fileId, datasetVersionId, true)) as [
-      FileModel,
-      Dataset
-    ]
+    return (await this.filesRepository.getFile(
+      fileId,
+      datasetVersionId,
+      true,
+      includeDeaccessioned
+    )) as [FileModel, Dataset]
   }
 }

--- a/src/files/infra/repositories/FilesRepository.ts
+++ b/src/files/infra/repositories/FilesRepository.ts
@@ -196,14 +196,16 @@ export class FilesRepository extends ApiRepository implements IFilesRepository {
   public async getFile(
     fileId: number | string,
     datasetVersionId: string,
-    returnDatasetVersion: boolean
+    returnDatasetVersion: boolean,
+    includeDeaccessioned: boolean
   ): Promise<FileModel | [FileModel, Dataset]> {
     return this.doGet(
       this.buildApiEndpoint(this.filesResourceName, `versions/${datasetVersionId}`, fileId),
       true,
       {
         returnDatasetVersion: returnDatasetVersion,
-        returnOwners: true
+        returnOwners: true,
+        includeDeaccessioned: includeDeaccessioned
       }
     )
       .then((response) => transformFileResponseToFile(response, returnDatasetVersion))

--- a/test/integration/files/FilesRepository.test.ts
+++ b/test/integration/files/FilesRepository.test.ts
@@ -62,8 +62,6 @@ describe('FilesRepository', () => {
 
   let testFileId: number
   let testFilePersistentId: string
-  let deaccessionedTestFileId: number
-  let deaccessionedFileTestDatasetIds: CreatedDatasetIdentifiers
 
   beforeAll(async () => {
     ApiConfig.init(
@@ -505,18 +503,22 @@ describe('FilesRepository', () => {
     describe('getFile with deaccessioned dataset', () => {
       test('should return file if dataset is deaccessioned, and includeDeaccessioned is true', async () => {
         const testTextFile1Name = 'test-file-1.txt'
-        deaccessionedFileTestDatasetIds = await createDataset.execute(
+
+        const deaccessionedFileTestDatasetIds = await createDataset.execute(
           TestConstants.TEST_NEW_DATASET_DTO
         )
 
-        await publishDatasetViaApi(deaccessionedFileTestDatasetIds.numericId)
-        await waitForNoLocks(deaccessionedFileTestDatasetIds.numericId, 10)
-
-        uploadFileViaApi(deaccessionedFileTestDatasetIds.numericId, testTextFile1Name).catch(() => {
-          throw new Error(`Error while uploading file ${testTextFile1Name}`)
+        await uploadFileViaApi(deaccessionedFileTestDatasetIds.numericId, testTextFile1Name).catch(
+          () => {
+            throw new Error(`Error while uploading file ${testTextFile1Name}`)
+          }
+        )
+        await publishDatasetViaApi(deaccessionedFileTestDatasetIds.numericId).catch(() => {
+          throw new Error('Error while publishing test Dataset')
         })
-
-        await deaccessionDatasetViaApi(deaccessionedFileTestDatasetIds.numericId, '1.0')
+        await waitForNoLocks(deaccessionedFileTestDatasetIds.numericId, 10).catch(() => {
+          throw new Error('Error while waiting for no locks')
+        })
 
         const datasetFiles = await sut.getDatasetFiles(
           deaccessionedFileTestDatasetIds.numericId,
@@ -524,27 +526,13 @@ describe('FilesRepository', () => {
           false,
           FileOrderCriteria.NAME_AZ
         )
-        deaccessionedTestFileId = datasetFiles.files[0].id
+        const deaccessionedTestFileId = datasetFiles.files[0].id
 
-        const actual = (await sut.getFile(
-          deaccessionedTestFileId,
-          DatasetNotNumberedVersion.LATEST,
-          false,
-          true
-        )) as FileModel
+        await deaccessionDatasetViaApi(deaccessionedFileTestDatasetIds.numericId, '1.0')
+
+        const actual = (await sut.getFile(deaccessionedTestFileId, '1.0', false, true)) as FileModel
 
         expect(actual.name).toBe(testTextFile1Name)
-      })
-
-      test('should return error if dataset is deaccessioned, and includeDeaccessioned is false', async () => {
-        const expectedError = new ReadError(
-          `[404] "File metadata for file with id ${deaccessionedTestFileId} in dataset version 1.0 not found"`
-        )
-
-        await expect(sut.getFile(deaccessionedTestFileId, '1.0', false, false)).rejects.toThrow(
-          expectedError
-        )
-
         deletePublishedDatasetViaApi(deaccessionedFileTestDatasetIds.persistentId)
       })
     })

--- a/test/integration/files/FilesRepository.test.ts
+++ b/test/integration/files/FilesRepository.test.ts
@@ -23,7 +23,6 @@ import {
 } from '../../../src/files/domain/models/FileCriteria'
 import {
   DatasetNotNumberedVersion,
-  Dataset,
   CreatedDatasetIdentifiers,
   createDataset
 } from '../../../src/datasets'
@@ -63,6 +62,8 @@ describe('FilesRepository', () => {
 
   let testFileId: number
   let testFilePersistentId: string
+  let deaccessionedTestFileId: number
+  let deaccessionedFileTestDatasetIds: CreatedDatasetIdentifiers
 
   beforeAll(async () => {
     ApiConfig.init(
@@ -474,6 +475,7 @@ describe('FilesRepository', () => {
         const actual: FileModel = (await sut.getFile(
           testFileId,
           DatasetNotNumberedVersion.LATEST,
+          false,
           false
         )) as FileModel
 
@@ -484,35 +486,75 @@ describe('FilesRepository', () => {
         const actual: FileModel = (await sut.getFile(
           testFileId,
           DatasetNotNumberedVersion.DRAFT,
+          false,
           false
         )) as FileModel
 
         expect(actual.name).toBe(testTextFile1Name)
       })
 
-      test('should return file and dataset when providing id, version, and returnDatasetVersion is true', async () => {
-        const actual = (await sut.getFile(testFileId, DatasetNotNumberedVersion.DRAFT, true)) as [
-          FileModel,
-          Dataset
-        ]
-
-        expect(actual[0].name).toBe(testTextFile1Name)
-        expect(actual[1].id).toBe(testDatasetIds.numericId)
-      })
-
       test('should return error when file does not exist', async () => {
         const expectedError = new ReadError(`[404] File with ID ${nonExistentFiledId} not found.`)
 
         await expect(
-          sut.getFile(nonExistentFiledId, DatasetNotNumberedVersion.LATEST, false)
+          sut.getFile(nonExistentFiledId, DatasetNotNumberedVersion.LATEST, false, false)
         ).rejects.toThrow(expectedError)
       })
     })
+
+    describe('getFile with deaccessioned dataset', () => {
+      test('should return file if dataset is deaccessioned, and includeDeaccessioned is true', async () => {
+        const testTextFile1Name = 'test-file-1.txt'
+        deaccessionedFileTestDatasetIds = await createDataset.execute(
+          TestConstants.TEST_NEW_DATASET_DTO
+        )
+
+        await publishDatasetViaApi(deaccessionedFileTestDatasetIds.numericId)
+        await waitForNoLocks(deaccessionedFileTestDatasetIds.numericId, 10)
+
+        uploadFileViaApi(deaccessionedFileTestDatasetIds.numericId, testTextFile1Name).catch(() => {
+          throw new Error(`Error while uploading file ${testTextFile1Name}`)
+        })
+
+        await deaccessionDatasetViaApi(deaccessionedFileTestDatasetIds.numericId, '1.0')
+
+        const datasetFiles = await sut.getDatasetFiles(
+          deaccessionedFileTestDatasetIds.numericId,
+          latestDatasetVersionId,
+          false,
+          FileOrderCriteria.NAME_AZ
+        )
+        deaccessionedTestFileId = datasetFiles.files[0].id
+
+        const actual = (await sut.getFile(
+          deaccessionedTestFileId,
+          DatasetNotNumberedVersion.LATEST,
+          false,
+          true
+        )) as FileModel
+
+        expect(actual.name).toBe(testTextFile1Name)
+      })
+
+      test('should return error if dataset is deaccessioned, and includeDeaccessioned is false', async () => {
+        const expectedError = new ReadError(
+          `[404] "File metadata for file with id ${deaccessionedTestFileId} in dataset version 1.0 not found"`
+        )
+
+        await expect(sut.getFile(deaccessionedTestFileId, '1.0', false, false)).rejects.toThrow(
+          expectedError
+        )
+
+        deletePublishedDatasetViaApi(deaccessionedFileTestDatasetIds.persistentId)
+      })
+    })
+
     describe('by persistent id', () => {
       test('should return file when providing a valid persistent id', async () => {
         const actual = (await sut.getFile(
           testFilePersistentId,
           DatasetNotNumberedVersion.LATEST,
+          false,
           false
         )) as FileModel
 
@@ -523,6 +565,7 @@ describe('FilesRepository', () => {
         const actual = (await sut.getFile(
           testFilePersistentId,
           DatasetNotNumberedVersion.DRAFT,
+          false,
           false
         )) as FileModel
 
@@ -536,7 +579,7 @@ describe('FilesRepository', () => {
         )
 
         await expect(
-          sut.getFile(nonExistentFiledPersistentId, DatasetNotNumberedVersion.LATEST, false)
+          sut.getFile(nonExistentFiledPersistentId, DatasetNotNumberedVersion.LATEST, false, false)
         ).rejects.toThrow(expectedError)
       })
     })
@@ -672,6 +715,7 @@ describe('FilesRepository', () => {
       const fileInfo: FileModel = (await sut.getFile(
         testFileId,
         DatasetNotNumberedVersion.LATEST,
+        false,
         false
       )) as FileModel
 

--- a/test/integration/files/FilesRepository.test.ts
+++ b/test/integration/files/FilesRepository.test.ts
@@ -501,10 +501,13 @@ describe('FilesRepository', () => {
     })
 
     describe('getFile with deaccessioned dataset', () => {
-      test('should return file if dataset is deaccessioned, and includeDeaccessioned is true', async () => {
-        const testTextFile1Name = 'test-file-1.txt'
+      const testTextFile1Name = 'test-file-1.txt'
 
-        const deaccessionedFileTestDatasetIds = await createDataset.execute(
+      let deaccessionedFileTestDatasetIds: CreatedDatasetIdentifiers
+      let deaccessionedTestFileId: number
+
+      beforeAll(async () => {
+        deaccessionedFileTestDatasetIds = await createDataset.execute(
           TestConstants.TEST_NEW_DATASET_DTO
         )
 
@@ -513,9 +516,11 @@ describe('FilesRepository', () => {
             throw new Error(`Error while uploading file ${testTextFile1Name}`)
           }
         )
+
         await publishDatasetViaApi(deaccessionedFileTestDatasetIds.numericId).catch(() => {
           throw new Error('Error while publishing test Dataset')
         })
+
         await waitForNoLocks(deaccessionedFileTestDatasetIds.numericId, 10).catch(() => {
           throw new Error('Error while waiting for no locks')
         })
@@ -526,14 +531,37 @@ describe('FilesRepository', () => {
           false,
           FileOrderCriteria.NAME_AZ
         )
-        const deaccessionedTestFileId = datasetFiles.files[0].id
+        deaccessionedTestFileId = datasetFiles.files[0].id
 
-        await deaccessionDatasetViaApi(deaccessionedFileTestDatasetIds.numericId, '1.0')
+        await deaccessionDatasetViaApi(deaccessionedFileTestDatasetIds.numericId, '1.0').catch(
+          () => {
+            throw new Error('Error while deaccessioning the dataset')
+          }
+        )
+      })
 
+      afterAll(async () => {
+        await deletePublishedDatasetViaApi(deaccessionedFileTestDatasetIds.persistentId).catch(
+          () => {
+            throw new Error('Error while deleting the test dataset')
+          }
+        )
+      })
+
+      test('should return file if dataset is deaccessioned, and includeDeaccessioned is true', async () => {
         const actual = (await sut.getFile(deaccessionedTestFileId, '1.0', false, true)) as FileModel
 
         expect(actual.name).toBe(testTextFile1Name)
-        deletePublishedDatasetViaApi(deaccessionedFileTestDatasetIds.persistentId)
+      })
+
+      test('should throw error if dataset is deaccessioned, and includeDeaccessioned is false', async () => {
+        const expectedError = new ReadError(
+          `[404] "File metadata for file with id ${deaccessionedTestFileId} in dataset version 1.0 not found"`
+        )
+
+        await expect(sut.getFile(deaccessionedTestFileId, '1.0', false, false)).rejects.toThrow(
+          expectedError
+        )
       })
     })
 

--- a/test/integration/files/FilesRepository.test.ts
+++ b/test/integration/files/FilesRepository.test.ts
@@ -24,7 +24,8 @@ import {
 import {
   DatasetNotNumberedVersion,
   CreatedDatasetIdentifiers,
-  createDataset
+  createDataset,
+  Dataset
 } from '../../../src/datasets'
 import { FileModel } from '../../../src/files/domain/models/FileModel'
 import { FileCounts } from '../../../src/files/domain/models/FileCounts'
@@ -489,6 +490,18 @@ describe('FilesRepository', () => {
         )) as FileModel
 
         expect(actual.name).toBe(testTextFile1Name)
+      })
+
+      test('should return file and dataset when providing id, version, and returnDatasetVersion is true', async () => {
+        const actual = (await sut.getFile(
+          testFileId,
+          DatasetNotNumberedVersion.DRAFT,
+          true,
+          false
+        )) as [FileModel, Dataset]
+
+        expect(actual[0].name).toBe(testTextFile1Name)
+        expect(actual[1].id).toBe(testDatasetIds.numericId)
       })
 
       test('should return error when file does not exist', async () => {

--- a/test/unit/files/FilesRepository.test.ts
+++ b/test/unit/files/FilesRepository.test.ts
@@ -1016,6 +1016,7 @@ describe('FilesRepository', () => {
     }
 
     const expectedRequestParams = {
+      includeDeaccessioned: false,
       returnDatasetVersion: false,
       returnOwners: true
     }

--- a/test/unit/files/FilesRepository.test.ts
+++ b/test/unit/files/FilesRepository.test.ts
@@ -1043,13 +1043,13 @@ describe('FilesRepository', () => {
         jest.spyOn(axios, 'get').mockResolvedValue(testGetFileResponse)
 
         // API Key auth
-        let actual = await sut.getFile(testFile.id, DatasetNotNumberedVersion.LATEST, false)
+        let actual = await sut.getFile(testFile.id, DatasetNotNumberedVersion.LATEST, false, false)
         expect(axios.get).toHaveBeenCalledWith(expectedApiEndpoint, expectedRequestConfigApiKey)
         expect(actual).toEqual(createFileModel())
 
         // Session cookie auth
         ApiConfig.init(TestConstants.TEST_API_URL, DataverseApiAuthMechanism.SESSION_COOKIE)
-        actual = await sut.getFile(testFile.id, DatasetNotNumberedVersion.LATEST, false)
+        actual = await sut.getFile(testFile.id, DatasetNotNumberedVersion.LATEST, false, false)
         expect(axios.get).toHaveBeenCalledWith(
           expectedApiEndpoint,
           expectedRequestConfigSessionCookie
@@ -1061,7 +1061,7 @@ describe('FilesRepository', () => {
         jest.spyOn(axios, 'get').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
 
         await expect(
-          sut.getFile(testFile.id, DatasetNotNumberedVersion.LATEST, false)
+          sut.getFile(testFile.id, DatasetNotNumberedVersion.LATEST, false, false)
         ).rejects.toThrow(ReadError)
       })
     })
@@ -1076,6 +1076,7 @@ describe('FilesRepository', () => {
         let actual = await sut.getFile(
           TestConstants.TEST_DUMMY_PERSISTENT_ID,
           DatasetNotNumberedVersion.LATEST,
+          false,
           false
         )
         expect(axios.get).toHaveBeenCalledWith(expectedApiEndpoint, expectedRequestConfigApiKey)
@@ -1086,6 +1087,7 @@ describe('FilesRepository', () => {
         actual = await sut.getFile(
           TestConstants.TEST_DUMMY_PERSISTENT_ID,
           DatasetNotNumberedVersion.LATEST,
+          false,
           false
         )
         expect(axios.get).toHaveBeenCalledWith(
@@ -1102,6 +1104,7 @@ describe('FilesRepository', () => {
           sut.getFile(
             TestConstants.TEST_DUMMY_PERSISTENT_ID,
             DatasetNotNumberedVersion.LATEST,
+            false,
             false
           )
         ).rejects.toThrow(ReadError)

--- a/test/unit/files/GetFile.test.ts
+++ b/test/unit/files/GetFile.test.ts
@@ -16,6 +16,7 @@ describe('execute', () => {
     expect(filesRepositoryStub.getFile).toHaveBeenCalledWith(
       1,
       DatasetNotNumberedVersion.LATEST,
+      false,
       false
     )
   })
@@ -33,6 +34,7 @@ describe('execute', () => {
     expect(filesRepositoryStub.getFile).toHaveBeenCalledWith(
       'doi:10.5072/FK2/J8SJZB',
       DatasetNotNumberedVersion.LATEST,
+      false,
       false
     )
   })
@@ -47,7 +49,34 @@ describe('execute', () => {
     const actual = await sut.execute('doi:10.5072/FK2/J8SJZB', '2.0')
 
     expect(actual).toEqual(testFile)
-    expect(filesRepositoryStub.getFile).toHaveBeenCalledWith('doi:10.5072/FK2/J8SJZB', '2.0', false)
+    expect(filesRepositoryStub.getFile).toHaveBeenCalledWith(
+      'doi:10.5072/FK2/J8SJZB',
+      '2.0',
+      false,
+      false
+    )
+  })
+
+  test('should return file on repository success when includeDeaccession is true', async () => {
+    const testFile = createFileModel()
+    const filesRepositoryStub: IFilesRepository = {} as IFilesRepository
+    filesRepositoryStub.getFile = jest.fn().mockResolvedValue(testFile)
+
+    const sut = new GetFile(filesRepositoryStub)
+
+    const actual = await sut.execute(
+      'doi:10.5072/FK2/J8SJZB',
+      DatasetNotNumberedVersion.LATEST,
+      true
+    )
+
+    expect(actual).toEqual(testFile)
+    expect(filesRepositoryStub.getFile).toHaveBeenCalledWith(
+      'doi:10.5072/FK2/J8SJZB',
+      DatasetNotNumberedVersion.LATEST,
+      false,
+      true
+    )
   })
 
   test('should return error result on repository error', async () => {

--- a/test/unit/files/GetFileAndDataset.test.ts
+++ b/test/unit/files/GetFileAndDataset.test.ts
@@ -21,7 +21,8 @@ describe('execute', () => {
     expect(filesRepositoryStub.getFile).toHaveBeenCalledWith(
       1,
       DatasetNotNumberedVersion.LATEST,
-      true
+      true,
+      false
     )
   })
 
@@ -37,7 +38,8 @@ describe('execute', () => {
     expect(filesRepositoryStub.getFile).toHaveBeenCalledWith(
       'doi:10.5072/FK2/J8SJZB',
       DatasetNotNumberedVersion.LATEST,
-      true
+      true,
+      false
     )
   })
 
@@ -50,7 +52,33 @@ describe('execute', () => {
 
     expect(actual[0]).toEqual(testFile)
     expect(actual[1]).toEqual(testDataset)
-    expect(filesRepositoryStub.getFile).toHaveBeenCalledWith('doi:10.5072/FK2/J8SJZB', '2.0', true)
+    expect(filesRepositoryStub.getFile).toHaveBeenCalledWith(
+      'doi:10.5072/FK2/J8SJZB',
+      '2.0',
+      true,
+      false
+    )
+  })
+
+  test('should return file and dataset on repository success when includeDeaccession is true', async () => {
+    const filesRepositoryStub = <IFilesRepository>{}
+    filesRepositoryStub.getFile = jest.fn().mockResolvedValue(testTuple)
+    const sut = new GetFileAndDataset(filesRepositoryStub)
+
+    const actual = await sut.execute(
+      'doi:10.5072/FK2/J8SJZB',
+      DatasetNotNumberedVersion.LATEST,
+      true
+    )
+
+    expect(actual[0]).toEqual(testFile)
+    expect(actual[1]).toEqual(testDataset)
+    expect(filesRepositoryStub.getFile).toHaveBeenCalledWith(
+      'doi:10.5072/FK2/J8SJZB',
+      DatasetNotNumberedVersion.LATEST,
+      true,
+      true
+    )
   })
 
   test('should return error result on repository error', async () => {


### PR DESCRIPTION
## What this PR does / why we need it:
In order to correctly get the file which is deaccessioned, we need include the includeDeaccessioned, so even though the dataset is deaccessioned, by applying includeDeaccessioned = true to the GETFile endpoint, the owner could get right response to access the deaccessioned file.

## Which issue(s) this PR closes:

- Closes #321 
