### PR TITLE
File: Use Case Get Available Dataset File Categories

### DIFF
--- a/docs/useCases.md
+++ b/docs/useCases.md
@@ -37,6 +37,7 @@ The different use cases currently available in the package are classified below,
     - [List All Datasets](#list-all-datasets)
     - [Get Dataset Versions Summaries](#get-dataset-versions-summaries)
     - [Get Dataset Linked Collections](#get-dataset-linked-collections)
+    - [Get Dataset Available Categories](#get-dataset-available-categories)
   - [Datasets write use cases](#datasets-write-use-cases)
     - [Create a Dataset](#create-a-dataset)
     - [Update a Dataset](#update-a-dataset)
@@ -1048,6 +1049,28 @@ The `includeMDC` parameter is optional.
 - Setting `includeMDC` to True will ignore the `MDCStartDate` setting and return a total count.
 - If MDC isn't enabled, the download count will return a total count, without `MDCStartDate`.
 - If MDC is enabled but the `includeMDC` is false, the count will be limited to the time before `MDCStartDate`
+
+#### Get Dataset Available Categories
+
+Returns a list of available file categories that may be applied to the files of a given dataset.
+
+###### Example call:
+
+```typescript
+import { getDatasetAvailableCategories } from '@iqss/dataverse-client-javascript'
+
+/* ... */
+
+const datasetId = 1
+
+getDatasetAvailableCategories.execute(datasetId).then((categories: String[]) => {
+  /* ... */
+})
+```
+
+_See [use case](../src/files/domain/useCases/GetDatasetAvailableCategories.ts) implementation_.
+
+The `datasetId` parameter is a number for numeric identifiers or string for persistent identifiers.
 
 ## Files
 

--- a/docs/useCases.md
+++ b/docs/useCases.md
@@ -1070,7 +1070,7 @@ getDatasetAvailableCategories.execute(datasetId).then((categories: String[]) => 
 })
 ```
 
-_See [use case](../src/files/domain/useCases/GetDatasetAvailableCategories.ts) implementation_.
+_See [use case](../src/datasets/domain/useCases/GetDatasetAvailableCategories.ts) implementation_.
 
 The `datasetId` parameter is a number for numeric identifiers or string for persistent identifiers.
 

--- a/docs/useCases.md
+++ b/docs/useCases.md
@@ -65,6 +65,8 @@ The different use cases currently available in the package are classified below,
     - [Replace a File](#replace-a-file)
     - [Restrict or Unrestrict a File](#restrict-or-unrestrict-a-file)
     - [Update File Metadata](#update-file-metadata)
+    - [Update File Categories](#update-file-categories)
+    - [Update File Tabular Tags](#update-file-tabular-tags)
 - [Metadata Blocks](#metadata-blocks)
   - [Metadata Blocks read use cases](#metadata-blocks-read-use-cases)
     - [Get All Facetable Metadata Fields](#get-all-facetable-metadata-fields)

--- a/src/datasets/domain/repositories/IDatasetsRepository.ts
+++ b/src/datasets/domain/repositories/IDatasetsRepository.ts
@@ -65,4 +65,5 @@ export interface IDatasetsRepository {
   linkDataset(datasetId: number, collectionAlias: string): Promise<void>
   unlinkDataset(datasetId: number, collectionAlias: string): Promise<void>
   getDatasetLinkedCollections(datasetId: number | string): Promise<DatasetLinkedCollection[]>
+  getDatasetAvailableCategories(datasetId: number | string): Promise<string[]>
 }

--- a/src/datasets/domain/useCases/GetDatasetAvailableCategories.ts
+++ b/src/datasets/domain/useCases/GetDatasetAvailableCategories.ts
@@ -1,0 +1,20 @@
+import { UseCase } from '../../../core/domain/useCases/UseCase'
+import { IDatasetsRepository } from '../repositories/IDatasetsRepository'
+
+export class GetDatasetAvailableCategories implements UseCase<string[]> {
+  private readonly datasetsRepository: IDatasetsRepository
+
+  constructor(datasetsRepository: IDatasetsRepository) {
+    this.datasetsRepository = datasetsRepository
+  }
+
+  /**
+   * Retrieves the available file categories for a dataset.
+   *
+   * @param {number | string} [datasetId] - Persistent dataset identifier
+   * @returns {Promise<string[]>} - List of available file categories
+   */
+  async execute(datasetId: number | string): Promise<string[]> {
+    return this.datasetsRepository.getDatasetAvailableCategories(datasetId)
+  }
+}

--- a/src/datasets/index.ts
+++ b/src/datasets/index.ts
@@ -23,6 +23,7 @@ import { DeleteDatasetDraft } from './domain/useCases/DeleteDatasetDraft'
 import { LinkDataset } from './domain/useCases/LinkDataset'
 import { UnlinkDataset } from './domain/useCases/UnlinkDataset'
 import { GetDatasetLinkedCollections } from './domain/useCases/GetDatasetLinkedCollections'
+import { GetDatasetAvailableCategories } from './domain/useCases/GetDatasetAvailableCategories'
 
 const datasetsRepository = new DatasetsRepository()
 
@@ -60,6 +61,7 @@ const deleteDatasetDraft = new DeleteDatasetDraft(datasetsRepository)
 const linkDataset = new LinkDataset(datasetsRepository)
 const unlinkDataset = new UnlinkDataset(datasetsRepository)
 const getDatasetLinkedCollections = new GetDatasetLinkedCollections(datasetsRepository)
+const getDatasetAvailableCategories = new GetDatasetAvailableCategories(datasetsRepository)
 
 export {
   getDataset,
@@ -80,7 +82,8 @@ export {
   deleteDatasetDraft,
   linkDataset,
   unlinkDataset,
-  getDatasetLinkedCollections
+  getDatasetLinkedCollections,
+  getDatasetAvailableCategories
 }
 export { DatasetNotNumberedVersion } from './domain/models/DatasetNotNumberedVersion'
 export { DatasetUserPermissions } from './domain/models/DatasetUserPermissions'

--- a/src/datasets/index.ts
+++ b/src/datasets/index.ts
@@ -85,7 +85,7 @@ export {
   linkDataset,
   unlinkDataset,
   getDatasetLinkedCollections,
-  getDatasetAvailableCategories
+  getDatasetAvailableCategories,
   getDatasetCitationInOtherFormats
 }
 export { DatasetNotNumberedVersion } from './domain/models/DatasetNotNumberedVersion'

--- a/src/datasets/infra/repositories/DatasetsRepository.ts
+++ b/src/datasets/infra/repositories/DatasetsRepository.ts
@@ -317,4 +317,15 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
         throw error
       })
   }
+
+  public async getDatasetAvailableCategories(datasetId: number | string): Promise<string[]> {
+    return this.doGet(
+      this.buildApiEndpoint(this.datasetsResourceName, 'availableFileCategories', datasetId),
+      true
+    )
+      .then((response) => response.data.data as string[])
+      .catch((error) => {
+        throw error
+      })
+  }
 }

--- a/src/files/domain/useCases/UpdateFileCategories.ts
+++ b/src/files/domain/useCases/UpdateFileCategories.ts
@@ -10,7 +10,7 @@ export class UpdateFileCategories implements UseCase<void> {
 
   /**
    * Updates the  categories for a particular File.
-   * More detailed information about updating a file's categories behavior can be found in https://guides.dataverse.org/en/latest/api/native-api.html#updating-file-metadata
+   * More detailed information about updating a file's categories behavior can be found in https://guides.dataverse.org/en/latest/api/native-api.html#updating-file-metadata-categories
    *
    * @param {number | string} [fileId] - The file identifier, which can be a string (for persistent identifiers), or a number (for numeric identifiers).
    * @param {string[]} [categories] - The categories to be added to the file.

--- a/src/files/domain/useCases/UpdateFileTabularTags.ts
+++ b/src/files/domain/useCases/UpdateFileTabularTags.ts
@@ -10,7 +10,7 @@ export class UpdateFileTabularTags implements UseCase<void> {
 
   /**
    * Updates the tabular tabular Tags for a particular File.
-   * More detailed information about updating a file's tabularTags behavior can be found in https://guides.dataverse.org/en/latest/api/native-api.html#updating-file-metadata
+   * More detailed information about updating a file's tabularTags behavior can be found in https://guides.dataverse.org/en/latest/api/native-api.html#updating-file-tabular-tags
    *
    * @param {number | string} [fileId] - The file identifier, which can be a string (for persistent identifiers), or a number (for numeric identifiers).
    * @param {string[]} [tabularTags] - The tabular tags to be added to the file.

--- a/test/functional/datasets/GetDatasetAvailableCategories.test.ts
+++ b/test/functional/datasets/GetDatasetAvailableCategories.test.ts
@@ -1,0 +1,37 @@
+import { ApiConfig, createDataset, getDatasetAvailableCategories, ReadError } from '../../../src'
+import { DataverseApiAuthMechanism } from '../../../src/core/infra/repositories/ApiConfig'
+import { deleteUnpublishedDatasetViaApi } from '../../testHelpers/datasets/datasetHelper'
+import { CreatedDatasetIdentifiers } from '../../../src/datasets/domain/models/CreatedDatasetIdentifiers'
+import { TestConstants } from '../../testHelpers/TestConstants'
+
+describe('execute', () => {
+  let createdDatasetIdentifiers: CreatedDatasetIdentifiers
+  beforeEach(async () => {
+    ApiConfig.init(
+      TestConstants.TEST_API_URL,
+      DataverseApiAuthMechanism.API_KEY,
+      process.env.TEST_API_KEY
+    )
+    createdDatasetIdentifiers = await createDataset.execute(TestConstants.TEST_NEW_DATASET_DTO)
+  })
+
+  afterEach(async () => {
+    deleteUnpublishedDatasetViaApi(createdDatasetIdentifiers.numericId)
+  })
+
+  it('should return categories array when a dataset has files categories', async () => {
+    const defaultCategories = ['Code', 'Data', 'Documentation']
+    const categoriesList = await getDatasetAvailableCategories.execute(
+      createdDatasetIdentifiers.numericId
+    )
+    expect(categoriesList.sort()).toEqual(defaultCategories.sort())
+  })
+
+  it('should return error when dataset does not exist', async () => {
+    const nonExistentDatasetId = 99999
+
+    await expect(
+      getDatasetAvailableCategories.execute(nonExistentDatasetId)
+    ).rejects.toBeInstanceOf(ReadError)
+  })
+})

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -1505,11 +1505,12 @@ describe('DatasetsRepository', () => {
   describe('getDatasetAvailableCategories', () => {
     let testDatasetIds: CreatedDatasetIdentifiers
 
-    beforeEach(async () => {
+    beforeAll(async () => {
       testDatasetIds = await createDataset.execute(TestConstants.TEST_NEW_DATASET_DTO)
-      // Dataset is in draft, so we need to publish it first
-      await sut.publishDataset(testDatasetIds.numericId, VersionUpdateType.MAJOR)
-      await waitForNoLocks(testDatasetIds.numericId, 10)
+    })
+
+    afterAll(async () => {
+      await deletePublishedDatasetViaApi(testDatasetIds.persistentId)
     })
 
     test('should get available categories', async () => {

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -1526,6 +1526,17 @@ describe('DatasetsRepository', () => {
       expect(actual.sort()).toEqual(fileMetadata.categories.sort())
     })
 
+    test('should get available categorie if dataset id is persistent id', async () => {
+      const fileMetadata = {
+        description: 'test description',
+        directoryLabel: 'directoryLabel',
+        categories: ['category1', 'category2', 'Documentation', 'Data', 'Code']
+      }
+
+      const actual = await sut.getDatasetAvailableCategories(testDatasetIds.persistentId)
+      expect(actual.sort()).toEqual(fileMetadata.categories.sort())
+    })
+
     test('should return error when dataset does not exist', async () => {
       await expect(sut.getDatasetAvailableCategories(nonExistentTestDatasetId)).rejects.toThrow()
     })

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -1501,4 +1501,32 @@ describe('DatasetsRepository', () => {
       await expect(sut.getDatasetLinkedCollections(nonExistentTestDatasetId)).rejects.toThrow()
     })
   })
+
+  describe('getDatasetAvailableCategories', () => {
+    let testDatasetIds: CreatedDatasetIdentifiers
+
+    beforeEach(async () => {
+      testDatasetIds = await createDataset.execute(TestConstants.TEST_NEW_DATASET_DTO)
+      // Dataset is in draft, so we need to publish it first
+      await sut.publishDataset(testDatasetIds.numericId, VersionUpdateType.MAJOR)
+      await waitForNoLocks(testDatasetIds.numericId, 10)
+    })
+
+    test('should get available categories', async () => {
+      const fileMetadata = {
+        description: 'test description',
+        directoryLabel: 'directoryLabel',
+        categories: ['category1', 'category2', 'Documentation', 'Data', 'Code']
+      }
+
+      await uploadFileViaApi(testDatasetIds.numericId, testTextFile1Name, fileMetadata)
+
+      const actual = await sut.getDatasetAvailableCategories(testDatasetIds.numericId)
+      expect(actual.sort()).toEqual(fileMetadata.categories.sort())
+    })
+
+    test('should return error when dataset does not exist', async () => {
+      await expect(sut.getDatasetAvailableCategories(nonExistentTestDatasetId)).rejects.toThrow()
+    })
+  })
 })

--- a/test/testHelpers/roles/roleHelper.ts
+++ b/test/testHelpers/roles/roleHelper.ts
@@ -105,7 +105,7 @@ export const createSuperAdminRoleArray = (): Role[] => {
         'DeleteDatasetDraft'
       ],
       description:
-        'For datasets, a person who can edit License + Terms, edit Permissions, and publish datasets and link datasets.',
+        'For datasets, a person who can edit License + Terms, edit Permissions, and publish and link datasets.',
       id: 7
     },
     {

--- a/test/testHelpers/roles/roleHelper.ts
+++ b/test/testHelpers/roles/roleHelper.ts
@@ -42,9 +42,7 @@ export const createSuperAdminRoleArray = (): Role[] => {
         'ManageDatasetPermissions',
         'ManageFilePermissions',
         'PublishDataverse',
-        'LinkDataverse',
         'PublishDataset',
-        'LinkDataset',
         'DeleteDataverse',
         'DeleteDatasetDraft'
       ],
@@ -101,11 +99,10 @@ export const createSuperAdminRoleArray = (): Role[] => {
         'ManageDatasetPermissions',
         'ManageFilePermissions',
         'PublishDataset',
-        'LinkDataset',
         'DeleteDatasetDraft'
       ],
       description:
-        'For datasets, a person who can edit License + Terms, edit Permissions, and publish and link datasets.',
+        'For datasets, a person who can edit License + Terms, edit Permissions, and publish datasets.',
       id: 7
     },
     {

--- a/test/testHelpers/roles/roleHelper.ts
+++ b/test/testHelpers/roles/roleHelper.ts
@@ -101,10 +101,11 @@ export const createSuperAdminRoleArray = (): Role[] => {
         'ManageDatasetPermissions',
         'ManageFilePermissions',
         'PublishDataset',
+        'LinkDataset',
         'DeleteDatasetDraft'
       ],
       description:
-        'For datasets, a person who can edit License + Terms, edit Permissions, and publish datasets.',
+        'For datasets, a person who can edit License + Terms, edit Permissions, and publish datasets and link datasets.',
       id: 7
     },
     {


### PR DESCRIPTION
## What this PR does / why we need it:
In JSF, when we update Tags -> Edit Tags, there is a list of available categories populated from the dropdown lists, and some of them could be customized categories from other files in the same dataset.

## Which issue(s) this PR closes:

- Closes #336 

## Related Dataverse PRs:

- Depends on https://github.com/IQSS/dataverse/pull/11668

## Special notes for your reviewer:
RoleHelper for testing changed because[ Revert "feat: "Link Dataset/Dataverse" permission"](https://github.com/IQSS/dataverse/pull/11682/files#diff-f7f8c09756ce44634bf7d9a243e628166a608079fffe7cd71f77f56f949114f6)

## Suggestions on how to test this:

## Is there a release notes update needed for this change?:

## Additional documentation:
