### PR TITLE
Fix: avoid incorrect Filter Queries split causing value part to be truncated

### DIFF
--- a/src/collections/infra/repositories/CollectionsRepository.ts
+++ b/src/collections/infra/repositories/CollectionsRepository.ts
@@ -357,10 +357,13 @@ export class CollectionsRepository extends ApiRepository implements ICollections
 
     if (collectionSearchCriteria?.filterQueries) {
       collectionSearchCriteria.filterQueries.forEach((filterQuery) => {
-        const [filterQueryKey, filterQueryValue] = filterQuery.split(':')
+        const idx = filterQuery.indexOf(':')
+        if (idx === -1) return // Invalid filter query, skip it
+
+        const filterQueryKey = filterQuery.substring(0, idx).trim()
+        const filterQueryValue = filterQuery.substring(idx + 1).trim()
 
         const filterQueryValueWithQuotes = `"${filterQueryValue}"`
-
         const filterQueryToSet = `${filterQueryKey}:${filterQueryValueWithQuotes}`
 
         queryParams.append(GetCollectionItemsQueryParams.FILTERQUERY, filterQueryToSet)


### PR DESCRIPTION
## What this PR does / why we need it:
Fix a bug where filter queries containing multiple `:` characters (e.g., foo:John:Doe) are incorrectly split, causing the value part to be truncated.

## Which issue(s) this PR closes:

- Closes #350 

## Suggestions on how to test this:
Code visual inspection and check that tests are passing.

## Is there a release notes update needed for this change?:

## Additional documentation:
