### PR TITLE
feat: add optional datasetType to DatasetDTO and include in transform…

### DIFF
--- a/src/datasets/domain/dtos/DatasetDTO.ts
+++ b/src/datasets/domain/dtos/DatasetDTO.ts
@@ -3,6 +3,7 @@ import { DatasetLicense } from '../models/Dataset'
 export interface DatasetDTO {
   license?: DatasetLicense
   metadataBlockValues: DatasetMetadataBlockValuesDTO[]
+  datasetType?: string
 }
 
 export interface DatasetMetadataBlockValuesDTO {

--- a/src/datasets/infra/repositories/transformers/datasetTransformers.ts
+++ b/src/datasets/infra/repositories/transformers/datasetTransformers.ts
@@ -105,7 +105,8 @@ export const transformDatasetModelToNewDatasetRequestPayload = (
         dataset.metadataBlockValues,
         metadataBlocks
       )
-    }
+    },
+    ...(dataset.datasetType && { datasetType: dataset.datasetType })
   }
 }
 


### PR DESCRIPTION

This pull request introduces support for handling the `datasetType` property in the dataset DTO and ensures it is correctly included in payload transformations. The main changes are grouped by DTO updates and transformer logic enhancements.

DTO updates:

* Added an optional `datasetType` property to the `DatasetDTO` interface in `src/datasets/domain/dtos/DatasetDTO.ts`, allowing datasets to specify their type.

Transformer logic enhancements:

* Updated the `transformDatasetModelToNewDatasetRequestPayload` function in `src/datasets/infra/repositories/transformers/datasetTransformers.ts` to conditionally include `datasetType` in the payload if it is present in the dataset.

