### PR TITLE
specify datasetType when creating a dataset

### DIFF
--- a/src/datasets/domain/repositories/IDatasetsRepository.ts
+++ b/src/datasets/domain/repositories/IDatasetsRepository.ts
@@ -44,7 +44,8 @@ export interface IDatasetsRepository {
   createDataset(
     newDataset: DatasetDTO,
     datasetMetadataBlocks: MetadataBlock[],
-    collectionId: string
+    collectionId: string,
+    datasetType?: string
   ): Promise<CreatedDatasetIdentifiers>
   publishDataset(datasetId: number | string, versionUpdateType: VersionUpdateType): Promise<void>
   updateDataset(

--- a/src/datasets/domain/useCases/CreateDataset.ts
+++ b/src/datasets/domain/useCases/CreateDataset.ts
@@ -20,6 +20,7 @@ export class CreateDataset extends DatasetWriteUseCase<CreatedDatasetIdentifiers
    *
    * @param {DatasetDTO} [newDataset] - DatasetDTO object including the new dataset metadata field values for each metadata block.
    * @param {string} [collectionId] - Specifies the collection identifier where the new dataset should be created (optional, defaults to :root).
+   * @param {string} [datasetType] - Specifies the dataset type (optional, when omitted, defaults to "dataset").
    * @returns {Promise<CreatedDatasetIdentifiers>}
    * @throws {ResourceValidationError} - If there are validation errors related to the provided information.
    * @throws {ReadError} - If there are errors while reading data.

--- a/src/datasets/domain/useCases/CreateDataset.ts
+++ b/src/datasets/domain/useCases/CreateDataset.ts
@@ -27,10 +27,16 @@ export class CreateDataset extends DatasetWriteUseCase<CreatedDatasetIdentifiers
    */
   async execute(
     newDataset: DatasetDTO,
-    collectionId = ROOT_COLLECTION_ID
+    collectionId = ROOT_COLLECTION_ID,
+    datasetType?: string
   ): Promise<CreatedDatasetIdentifiers> {
     const metadataBlocks = await this.getNewDatasetMetadataBlocks(newDataset)
     this.getNewDatasetValidator().validate(newDataset, metadataBlocks)
-    return this.getDatasetsRepository().createDataset(newDataset, metadataBlocks, collectionId)
+    return this.getDatasetsRepository().createDataset(
+      newDataset,
+      metadataBlocks,
+      collectionId,
+      datasetType
+    )
   }
 }

--- a/src/datasets/infra/repositories/DatasetsRepository.ts
+++ b/src/datasets/infra/repositories/DatasetsRepository.ts
@@ -203,11 +203,16 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
   public async createDataset(
     newDataset: DatasetDTO,
     datasetMetadataBlocks: MetadataBlock[],
-    collectionId: string
+    collectionId: string,
+    datasetType?: string
   ): Promise<CreatedDatasetIdentifiers> {
     return this.doPost(
       `/dataverses/${collectionId}/datasets`,
-      transformDatasetModelToNewDatasetRequestPayload(newDataset, datasetMetadataBlocks)
+      transformDatasetModelToNewDatasetRequestPayload(
+        newDataset,
+        datasetMetadataBlocks,
+        datasetType
+      )
     )
       .then((response) => {
         const responseData = response.data.data

--- a/src/datasets/infra/repositories/transformers/datasetTransformers.ts
+++ b/src/datasets/infra/repositories/transformers/datasetTransformers.ts
@@ -35,6 +35,7 @@ export interface NewDatasetRequestPayload {
     license?: DatasetLicense
     metadataBlocks: Record<string, MetadataBlockRequestPayload>
   }
+  datasetType?: string
 }
 
 export interface MetadataBlockRequestPayload {
@@ -96,9 +97,11 @@ export const transformDatasetModelToUpdateDatasetRequestPayload = (
 
 export const transformDatasetModelToNewDatasetRequestPayload = (
   dataset: DatasetDTO,
-  metadataBlocks: MetadataBlock[]
+  metadataBlocks: MetadataBlock[],
+  datasetType?: string
 ): NewDatasetRequestPayload => {
   return {
+    datasetType: datasetType,
     datasetVersion: {
       ...(dataset.license && { license: dataset.license }),
       metadataBlocks: transformMetadataBlockModelsToRequestPayload(

--- a/test/functional/datasets/PublishDataset.test.ts
+++ b/test/functional/datasets/PublishDataset.test.ts
@@ -12,6 +12,10 @@ import {
   waitForNoLocks,
   deletePublishedDatasetViaApi
 } from '../../testHelpers/datasets/datasetHelper'
+import { ROOT_COLLECTION_ID } from '../../../src/collections/domain/models/Collection'
+
+// "dataset" is the default so this is equivalent to not passing a datasetType
+const datasetType = 'dataset'
 
 const testNewDataset = {
   license: {
@@ -61,7 +65,11 @@ describe('execute', () => {
   })
 
   test('should successfully publish a dataset', async () => {
-    const createdDatasetIdentifiers = await createDataset.execute(testNewDataset)
+    const createdDatasetIdentifiers = await createDataset.execute(
+      testNewDataset,
+      ROOT_COLLECTION_ID,
+      datasetType
+    )
 
     const response = await publishDataset.execute(
       createdDatasetIdentifiers.persistentId,
@@ -74,7 +82,11 @@ describe('execute', () => {
   })
 
   test('should successfully publish a dataset with update current version', async () => {
-    const createdDatasetIdentifiers = await createDataset.execute(testNewDataset)
+    const createdDatasetIdentifiers = await createDataset.execute(
+      testNewDataset,
+      ROOT_COLLECTION_ID,
+      datasetType
+    )
 
     const firstPublishResponse = await publishDataset.execute(
       createdDatasetIdentifiers.persistentId,

--- a/test/testHelpers/datasets/datasetHelper.ts
+++ b/test/testHelpers/datasets/datasetHelper.ts
@@ -694,9 +694,11 @@ export const createDatasetMetadataBlockModel = (): MetadataBlock => {
 }
 
 export const createNewDatasetRequestPayload = (
-  license?: DatasetLicense
+  license?: DatasetLicense,
+  datasetType?: string
 ): NewDatasetRequestPayload => {
   return {
+    datasetType: datasetType,
     datasetVersion: {
       ...(license && { license }),
       metadataBlocks: {

--- a/test/unit/datasets/CreateDataset.test.ts
+++ b/test/unit/datasets/CreateDataset.test.ts
@@ -51,7 +51,8 @@ describe('execute', () => {
     expect(datasetsRepositoryStub.createDataset).toHaveBeenCalledWith(
       testDataset,
       testMetadataBlocks,
-      ROOT_COLLECTION_ID
+      ROOT_COLLECTION_ID,
+      undefined
     )
   })
 
@@ -111,7 +112,8 @@ describe('execute', () => {
     expect(datasetsRepositoryStub.createDataset).toHaveBeenCalledWith(
       testDataset,
       testMetadataBlocks,
-      ROOT_COLLECTION_ID
+      ROOT_COLLECTION_ID,
+      undefined
     )
   })
 

--- a/test/unit/datasets/CreateDataset.test.ts
+++ b/test/unit/datasets/CreateDataset.test.ts
@@ -56,6 +56,47 @@ describe('execute', () => {
     )
   })
 
+  test('should return a dataset type', async () => {
+    const testCreatedDatasetIdentifiers: CreatedDatasetIdentifiers = {
+      persistentId: 'test',
+      numericId: 1
+    }
+
+    const datasetsRepositoryStub = <IDatasetsRepository>{}
+    datasetsRepositoryStub.createDataset = jest
+      .fn()
+      .mockResolvedValue(testCreatedDatasetIdentifiers)
+
+    const datasetValidatorStub = <ResourceValidator>{}
+    datasetValidatorStub.validate = jest.fn().mockResolvedValue(undefined)
+
+    const metadataBlocksRepositoryStub = <IMetadataBlocksRepository>{}
+    metadataBlocksRepositoryStub.getMetadataBlockByName = jest
+      .fn()
+      .mockResolvedValue(testMetadataBlocks[0])
+
+    const sut = new CreateDataset(
+      datasetsRepositoryStub,
+      metadataBlocksRepositoryStub,
+      datasetValidatorStub
+    )
+
+    const actual = await sut.execute(testDataset, ROOT_COLLECTION_ID, 'software')
+
+    expect(actual).toEqual(testCreatedDatasetIdentifiers)
+
+    expect(metadataBlocksRepositoryStub.getMetadataBlockByName).toHaveBeenCalledWith(
+      testMetadataBlocks[0].name
+    )
+    expect(datasetValidatorStub.validate).toHaveBeenCalledWith(testDataset, testMetadataBlocks)
+    expect(datasetsRepositoryStub.createDataset).toHaveBeenCalledWith(
+      testDataset,
+      testMetadataBlocks,
+      ROOT_COLLECTION_ID,
+      'software'
+    )
+  })
+
   test('should throw ResourceValidationError and not call repository when validation is unsuccessful', async () => {
     const datasetsRepositoryMock = <IDatasetsRepository>{}
     datasetsRepositoryMock.createDataset = jest.fn().mockResolvedValue(undefined)

--- a/test/unit/datasets/datasetTransformers.test.ts
+++ b/test/unit/datasets/datasetTransformers.test.ts
@@ -16,7 +16,7 @@ describe('transformNewDatasetModelToRequestPayload', () => {
     expect(actual).toEqual(expectedNewDatasetRequestPayload)
   })
 
-  it('should correctly transform a new dataset model to a new dataset request payload when it contains a license', () => {
+  it('should correctly transform a new dataset model to a new dataset request payload when it contains a license and a datasetType', () => {
     const testDataset = createDatasetDTO(
       undefined,
       undefined,
@@ -26,10 +26,16 @@ describe('transformNewDatasetModelToRequestPayload', () => {
       createDatasetLicenseModel()
     )
     const testMetadataBlocks = [createDatasetMetadataBlockModel()]
+    const datasetType = 'software'
     const expectedNewDatasetRequestPayload = createNewDatasetRequestPayload(
-      createDatasetLicenseModel()
+      createDatasetLicenseModel(),
+      datasetType
     )
-    const actual = transformDatasetModelToNewDatasetRequestPayload(testDataset, testMetadataBlocks)
+    const actual = transformDatasetModelToNewDatasetRequestPayload(
+      testDataset,
+      testMetadataBlocks,
+      datasetType
+    )
 
     expect(actual).toEqual(expectedNewDatasetRequestPayload)
   })


### PR DESCRIPTION
## What this PR does / why we need it:

At dataset creation time, we need to allow `datasetType` to be passed so that types other than the default ("dataset") can be persisted to the database.

## Which issue(s) this PR closes:

- Intended for this issue but we'll make a fresh PR: #359

## Related Dataverse PRs:

- Frontend PR that that uses this PR: https://github.com/IQSS/dataverse-frontend/pull/822
- Parent project, Trusted Data: https://github.com/IQSS/dataverse-pm/issues/425

## Special notes for your reviewer:

We also need to support listing dataset types ( https://guides.dataverse.org/en/6.7.1/api/native-api.html#list-dataset-types ) but perhaps that should be a separate issue and pull request?

## Suggestions on how to test this:

- On the backend, create a datasetType such as "software" or "review": https://guides.dataverse.org/en/6.7.1/api/native-api.html#add-dataset-type
- Use that type to create a dataset of that type by supplying it in the `datasetType` field. In the JSON, it looks like this:

```
{
  "datasetType": "software",
  "datasetVersion": {
    "license": {
      "name": "CC0 1.0",
      "uri": "http://creativecommons.org/publicdomain/zero/1.0"
    },
    "metadataBlocks": {
      "citation": {
        "fields": [
          {
            "value": "pyDataverse",
            "typeClass": "primitive",
            "multiple": false,
            "typeName": "title"
          },
...
```

## Is there a release notes update needed for this change?:

Yes, we should add something like this:

You can now specify a datasetType when creating a dataset.

## Additional documentation:

None.