### PR TITLE
 Use Case for Getting Available Dataset Types

### DIFF
--- a/docs/useCases.md
+++ b/docs/useCases.md
@@ -1125,7 +1125,7 @@ import { getDatasetAvailableDatasetTypes } from '@iqss/dataverse-client-javascri
 
 /* ... */
 
-getDatasetAvailableDatasetTypes.execute().then((categories: String[]) => {
+getDatasetAvailableDatasetTypes.execute().then((datasetTypes: DatasetType[]) => {
   /* ... */
 })
 ```

--- a/docs/useCases.md
+++ b/docs/useCases.md
@@ -38,6 +38,7 @@ The different use cases currently available in the package are classified below,
     - [Get Dataset Versions Summaries](#get-dataset-versions-summaries)
     - [Get Dataset Linked Collections](#get-dataset-linked-collections)
     - [Get Dataset Available Categories](#get-dataset-available-categories)
+    - [Get Dataset Available Dataset Types](#get-dataset-available-dataset-types)
   - [Datasets write use cases](#datasets-write-use-cases)
     - [Create a Dataset](#create-a-dataset)
     - [Update a Dataset](#update-a-dataset)
@@ -1112,6 +1113,24 @@ getDatasetAvailableCategories.execute(datasetId).then((categories: String[]) => 
 _See [use case](../src/datasets/domain/useCases/GetDatasetAvailableCategories.ts) implementation_.
 
 The `datasetId` parameter is a number for numeric identifiers or string for persistent identifiers.
+
+#### Get Dataset Available Dataset Types
+
+Returns a list of available dataset types that can be used at dataset creation. By default, only the type "dataset" is returned.
+
+###### Example call:
+
+```typescript
+import { getDatasetAvailableDatasetTypes } from '@iqss/dataverse-client-javascript'
+
+/* ... */
+
+getDatasetAvailableDatasetTypes.execute().then((categories: String[]) => {
+  /* ... */
+})
+```
+
+_See [use case](../src/datasets/domain/useCases/GetDatasetAvailableDatasetTypes.ts) implementation_.
 
 ## Files
 

--- a/docs/useCases.md
+++ b/docs/useCases.md
@@ -810,6 +810,24 @@ getDatasetLinkedCollections
 
 _See [use case](../src/datasets/domain/useCases/GetDatasetLinkedCollections.ts) implementation_.
 
+#### Get Dataset Available Dataset Types
+
+Returns a list of available dataset types that can be used at dataset creation. By default, only the type "dataset" is returned.
+
+###### Example call:
+
+```typescript
+import { getDatasetAvailableDatasetTypes } from '@iqss/dataverse-client-javascript'
+
+/* ... */
+
+getDatasetAvailableDatasetTypes.execute().then((datasetTypes: DatasetType[]) => {
+  /* ... */
+})
+```
+
+_See [use case](../src/datasets/domain/useCases/GetDatasetAvailableDatasetTypes.ts) implementation_.
+
 ### Datasets Write Use Cases
 
 #### Create a Dataset
@@ -1132,24 +1150,6 @@ getDatasetTemplates.execute(collectionIdOrAlias).then((datasetTemplates: Dataset
 ```
 
 _See [use case](../src/datasets/domain/useCases/GetDatasetTemplates.ts)_ definition.
-
-#### Get Dataset Available Dataset Types
-
-Returns a list of available dataset types that can be used at dataset creation. By default, only the type "dataset" is returned.
-
-###### Example call:
-
-```typescript
-import { getDatasetAvailableDatasetTypes } from '@iqss/dataverse-client-javascript'
-
-/* ... */
-
-getDatasetAvailableDatasetTypes.execute().then((datasetTypes: DatasetType[]) => {
-  /* ... */
-})
-```
-
-_See [use case](../src/datasets/domain/useCases/GetDatasetAvailableDatasetTypes.ts) implementation_.
 
 ## Files
 

--- a/src/datasets/domain/models/DatasetType.ts
+++ b/src/datasets/domain/models/DatasetType.ts
@@ -1,0 +1,6 @@
+export interface DatasetType {
+  id: number
+  name: string
+  linkedMetadataBlocks?: string[]
+  availableLicenses?: string[]
+}

--- a/src/datasets/domain/repositories/IDatasetsRepository.ts
+++ b/src/datasets/domain/repositories/IDatasetsRepository.ts
@@ -12,6 +12,7 @@ import { DatasetVersionSummaryInfo } from '../models/DatasetVersionSummaryInfo'
 import { DatasetLinkedCollection } from '../models/DatasetLinkedCollection'
 import { CitationFormat } from '../models/CitationFormat'
 import { FormattedCitation } from '../models/FormattedCitation'
+import { DatasetType } from '../models/DatasetType'
 
 export interface IDatasetsRepository {
   getDataset(
@@ -74,4 +75,5 @@ export interface IDatasetsRepository {
     format: CitationFormat,
     includeDeaccessioned?: boolean
   ): Promise<FormattedCitation>
+  getDatasetAvailableDatasetTypes(): Promise<DatasetType[]>
 }

--- a/src/datasets/domain/useCases/GetDatasetAvailableDatasetTypes.ts
+++ b/src/datasets/domain/useCases/GetDatasetAvailableDatasetTypes.ts
@@ -1,0 +1,20 @@
+import { UseCase } from '../../../core/domain/useCases/UseCase'
+import { DatasetType } from '../models/DatasetType'
+import { IDatasetsRepository } from '../repositories/IDatasetsRepository'
+
+export class GetDatasetAvailableDatasetTypes implements UseCase<DatasetType[]> {
+  private datasetsRepository: IDatasetsRepository
+
+  constructor(datasetsRepository: IDatasetsRepository) {
+    this.datasetsRepository = datasetsRepository
+  }
+
+  /**
+   * Returns the list of available dataset types that can be selected when creating a dataset.
+   *
+   * @returns {Promise<DatasetType[]>}
+   */
+  async execute(): Promise<DatasetType[]> {
+    return await this.datasetsRepository.getDatasetAvailableDatasetTypes()
+  }
+}

--- a/src/datasets/index.ts
+++ b/src/datasets/index.ts
@@ -24,6 +24,7 @@ import { LinkDataset } from './domain/useCases/LinkDataset'
 import { UnlinkDataset } from './domain/useCases/UnlinkDataset'
 import { GetDatasetLinkedCollections } from './domain/useCases/GetDatasetLinkedCollections'
 import { GetDatasetAvailableCategories } from './domain/useCases/GetDatasetAvailableCategories'
+import { GetDatasetAvailableDatasetTypes } from './domain/useCases/GetDatasetAvailableDatasetTypes'
 import { GetDatasetCitationInOtherFormats } from './domain/useCases/GetDatasetCitationInOtherFormats'
 
 const datasetsRepository = new DatasetsRepository()
@@ -63,6 +64,7 @@ const linkDataset = new LinkDataset(datasetsRepository)
 const unlinkDataset = new UnlinkDataset(datasetsRepository)
 const getDatasetLinkedCollections = new GetDatasetLinkedCollections(datasetsRepository)
 const getDatasetAvailableCategories = new GetDatasetAvailableCategories(datasetsRepository)
+const getDatasetAvailableDatasetTypes = new GetDatasetAvailableDatasetTypes(datasetsRepository)
 const getDatasetCitationInOtherFormats = new GetDatasetCitationInOtherFormats(datasetsRepository)
 
 export {
@@ -86,6 +88,7 @@ export {
   unlinkDataset,
   getDatasetLinkedCollections,
   getDatasetAvailableCategories,
+  getDatasetAvailableDatasetTypes,
   getDatasetCitationInOtherFormats
 }
 export { DatasetNotNumberedVersion } from './domain/models/DatasetNotNumberedVersion'
@@ -121,3 +124,4 @@ export {
   DatasetVersionSummaryStringValues
 } from './domain/models/DatasetVersionSummaryInfo'
 export { DatasetLinkedCollection } from './domain/models/DatasetLinkedCollection'
+export { DatasetType } from './domain/models/DatasetType'

--- a/src/datasets/infra/repositories/DatasetsRepository.ts
+++ b/src/datasets/infra/repositories/DatasetsRepository.ts
@@ -24,6 +24,7 @@ import { DatasetLinkedCollection } from '../../domain/models/DatasetLinkedCollec
 import { CitationFormat } from '../../domain/models/CitationFormat'
 import { transformDatasetLinkedCollectionsResponseToDatasetLinkedCollection } from './transformers/datasetLinkedCollectionsTransformers'
 import { FormattedCitation } from '../../domain/models/FormattedCitation'
+import { DatasetType } from '../../domain/models/DatasetType'
 
 export interface GetAllDatasetPreviewsQueryParams {
   per_page?: number
@@ -353,6 +354,14 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
       true
     )
       .then((response) => response.data.data as string[])
+      .catch((error) => {
+        throw error
+      })
+  }
+
+  public async getDatasetAvailableDatasetTypes(): Promise<DatasetType[]> {
+    return this.doGet(this.buildApiEndpoint(this.datasetsResourceName, 'datasetTypes'))
+      .then((response) => response.data.data)
       .catch((error) => {
         throw error
       })

--- a/test/functional/datasets/GetDatasetAvailableDatasetTypes.test.ts
+++ b/test/functional/datasets/GetDatasetAvailableDatasetTypes.test.ts
@@ -1,0 +1,29 @@
+import { ApiConfig, DatasetType, getDatasetAvailableDatasetTypes } from '../../../src'
+import { DataverseApiAuthMechanism } from '../../../src/core/infra/repositories/ApiConfig'
+import { TestConstants } from '../../testHelpers/TestConstants'
+
+describe('getDatasetAvailableDatasetTypes', () => {
+  describe('execute', () => {
+    beforeAll(async () => {
+      ApiConfig.init(
+        TestConstants.TEST_API_URL,
+        DataverseApiAuthMechanism.API_KEY,
+        process.env.TEST_API_KEY
+      )
+    })
+
+    test('should return available dataset types', async () => {
+      const actualDatasetTypes: DatasetType[] = await getDatasetAvailableDatasetTypes.execute()
+      const expectedDatasetTypes = [
+        {
+          id: 1,
+          name: 'dataset',
+          linkedMetadataBlocks: [],
+          availableLicenses: []
+        }
+      ]
+
+      expect(actualDatasetTypes).toEqual(expectedDatasetTypes)
+    })
+  })
+})

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -20,7 +20,9 @@ import {
   CreatedDatasetIdentifiers,
   DatasetDTO,
   DatasetDeaccessionDTO,
-  publishDataset
+  publishDataset,
+  DatasetType,
+  getDatasetAvailableDatasetTypes
 } from '../../../src/datasets'
 import { ApiConfig, WriteError } from '../../../src'
 import { DataverseApiAuthMechanism } from '../../../src/core/infra/repositories/ApiConfig'
@@ -1647,6 +1649,22 @@ describe('DatasetsRepository', () => {
 
     test('should return error when dataset does not exist', async () => {
       await expect(sut.getDatasetAvailableCategories(nonExistentTestDatasetId)).rejects.toThrow()
+    })
+  })
+
+  describe('getDatasetAvailableDatasetTypes', () => {
+    test('should return available dataset types', async () => {
+      const actualDatasetTypes: DatasetType[] = await getDatasetAvailableDatasetTypes.execute()
+      const expectedDatasetTypes = [
+        {
+          id: 1,
+          name: 'dataset',
+          linkedMetadataBlocks: [],
+          availableLicenses: []
+        }
+      ]
+
+      expect(actualDatasetTypes).toEqual(expectedDatasetTypes)
     })
   })
 })

--- a/test/unit/datasets/GetDatasetAvailableDatasetTypes.test.ts
+++ b/test/unit/datasets/GetDatasetAvailableDatasetTypes.test.ts
@@ -1,0 +1,49 @@
+import { ReadError } from '../../../src'
+import { DatasetType } from '../../../src'
+import { IDatasetsRepository } from '../../../src/datasets/domain/repositories/IDatasetsRepository'
+import { GetDatasetAvailableDatasetTypes } from '../../../src/datasets/domain/useCases/GetDatasetAvailableDatasetTypes'
+
+describe('GetDatasetAvailableDatasetTypes', () => {
+  describe('execute', () => {
+    test('should return datasetTypes array on repository success', async () => {
+      const datasetTypesRepositoryStub: IDatasetsRepository = {} as IDatasetsRepository
+
+      const testDatasetTypes: DatasetType[] = [
+        {
+          id: 1,
+          name: 'dataset',
+          linkedMetadataBlocks: [],
+          availableLicenses: []
+        },
+        {
+          id: 2,
+          name: 'software',
+          linkedMetadataBlocks: ['codeMeta20'],
+          availableLicenses: ['MIT', 'Apache-2.0']
+        }
+      ]
+
+      datasetTypesRepositoryStub.getDatasetAvailableDatasetTypes = jest
+        .fn()
+        .mockResolvedValue(testDatasetTypes)
+      const sut = new GetDatasetAvailableDatasetTypes(datasetTypesRepositoryStub)
+
+      const actual = await sut.execute()
+
+      expect(actual).toEqual(testDatasetTypes)
+      expect(datasetTypesRepositoryStub.getDatasetAvailableDatasetTypes).toHaveBeenCalledTimes(1)
+    })
+
+    test('should return error result on repository error', async () => {
+      const datasetsRepositoryStub: IDatasetsRepository = {} as IDatasetsRepository
+      const expectedError = new ReadError('Failed to fetch dataset types')
+      datasetsRepositoryStub.getDatasetAvailableDatasetTypes = jest
+        .fn()
+        .mockRejectedValue(expectedError)
+      const sut = new GetDatasetAvailableDatasetTypes(datasetsRepositoryStub)
+
+      await expect(sut.execute()).rejects.toThrow(ReadError)
+      expect(datasetsRepositoryStub.getDatasetAvailableDatasetTypes).toHaveBeenCalledTimes(1)
+    })
+  })
+})


### PR DESCRIPTION
## What this PR does / why we need it:

This PR allows for listing the available [dataset types](https://github.com/IQSS/dataverse-pm/issues/307) ([docs](https://guides.dataverse.org/en/6.7.1/user/dataset-management.html#dataset-types)) when creating a dataset. We're thinking about using a "review" dataset type in the context of [Trusted Data](https://github.com/IQSS/dataverse-pm/issues/425).

## Which issue(s) this PR closes:

- Closes #363

## Related Dataverse PRs:

It's a long story. I have opened a few PRs but after speaking with @ChengShi-1 it sounds like making the "get" PR (this one) first makes the most sense.

The next PR would setting the dataset type. I created the following PR for this but I'll probably create a fresh one that builds on this "get" PR:

- https://github.com/IQSS/dataverse-client-javascript/pull/360

## Special notes for your reviewer:

This PR is modeled off getDatasetAvailableCategories and getAvailableStandardLicenses.

I'll leave comments under "files changed" for specific lines of code.

## Suggestions on how to test this:

Run the tests.

## Is there a release notes update needed for this change?:

Yes, something like this:

"You can list available dataset types."

## Additional documentation:

Included.