### PR TITLE
update getCollectionMetadataBlocks use case to support passing a dataset type

### DIFF
--- a/docs/useCases.md
+++ b/docs/useCases.md
@@ -2012,6 +2012,8 @@ The `collectionIdOrAlias` is a generic collection identifier, which can be eithe
 
 There is a second optional parameter called `onlyDisplayedOnCreate` which indicates whether or not to return only the metadata blocks that are displayed on dataset creation. The default value is false.
 
+There is a third optional parameter called `datasetType` which will include additional fields from metadata blocks linked to the provided type, if any. Before using this parameter, you will probably want to [list available dataset types](#get-dataset-available-dataset-types) for your installation.
+
 ## Users
 
 ### Users read use cases

--- a/src/metadataBlocks/domain/repositories/IMetadataBlocksRepository.ts
+++ b/src/metadataBlocks/domain/repositories/IMetadataBlocksRepository.ts
@@ -5,7 +5,8 @@ export interface IMetadataBlocksRepository {
 
   getCollectionMetadataBlocks(
     collectionIdOrAlias: number | string,
-    onlyDisplayedOnCreate: boolean
+    onlyDisplayedOnCreate: boolean,
+    datasetType?: string
   ): Promise<MetadataBlock[]>
 
   getAllMetadataBlocks(): Promise<MetadataBlock[]>

--- a/src/metadataBlocks/domain/useCases/GetCollectionMetadataBlocks.ts
+++ b/src/metadataBlocks/domain/useCases/GetCollectionMetadataBlocks.ts
@@ -16,15 +16,18 @@ export class GetCollectionMetadataBlocks implements UseCase<MetadataBlock[]> {
    * @param {number | string} [collectionIdOrAlias = ':root'] - A generic collection identifier, which can be either a string (for queries by CollectionAlias), or a number (for queries by CollectionId)
    * If this parameter is not set, the default value is: ':root'
    * @param {boolean} [onlyDisplayedOnCreate=false] - Indicates whether or not to return only the metadata blocks that are displayed on dataset creation. The default value is false.
+   * @param {string} [datasetType] - The name of the dataset type. If provided, additional fields from metadata blocks linked to this dataset type will be returned.
    * @returns {Promise<MetadataBlock[]>}
    */
   async execute(
     collectionIdOrAlias: number | string = ROOT_COLLECTION_ID,
-    onlyDisplayedOnCreate = false
+    onlyDisplayedOnCreate = false,
+    datasetType?: string
   ): Promise<MetadataBlock[]> {
     return await this.metadataBlocksRepository.getCollectionMetadataBlocks(
       collectionIdOrAlias,
-      onlyDisplayedOnCreate
+      onlyDisplayedOnCreate,
+      datasetType
     )
   }
 }

--- a/src/metadataBlocks/infra/repositories/MetadataBlocksRepository.ts
+++ b/src/metadataBlocks/infra/repositories/MetadataBlocksRepository.ts
@@ -17,11 +17,13 @@ export class MetadataBlocksRepository extends ApiRepository implements IMetadata
 
   public async getCollectionMetadataBlocks(
     collectionIdOrAlias: string | number,
-    onlyDisplayedOnCreate: boolean
+    onlyDisplayedOnCreate: boolean,
+    datasetType?: string
   ): Promise<MetadataBlock[]> {
     return this.doGet(`/dataverses/${collectionIdOrAlias}/metadatablocks`, true, {
       onlyDisplayedOnCreate: onlyDisplayedOnCreate,
-      returnDatasetFieldTypes: true
+      returnDatasetFieldTypes: true,
+      datasetType: datasetType
     })
       .then((response) => transformMetadataBlocksResponseToMetadataBlocks(response))
       .catch((error) => {


### PR DESCRIPTION
## What this PR does / why we need it:

The promise of a dataset type has been that if you link a metadata block with it (e.g. linking CodeMeta to a software type), those extra fields will be available to you (displayed on create) when you create a dataset.

## Which issue(s) this PR closes:

- Closes #210

## Related Dataverse PRs:

- Builds upon this PR, which should be tested and merged first: https://github.com/IQSS/dataverse-client-javascript/pull/373

## Special notes for your reviewer:

The existing code doesn't have any tests that I could find. yolo!

If you point me to the tests I'm happy to edit them.

If you want me to write tests from scratch, I'm happy to do that too. 😄 

## Suggestions on how to test this:

First, add a dataset type called "foobar" that's associated with a non-citation metadata block like geospatial.

Then, try something like this:

```
const getBlocks = await getCollectionMetadataBlocks.execute(':root', true, 'foobar')
console.log(getBlocks);
```

## Is there a release notes or changelog update needed for this change?:

Yes, coming.

## Additional documentation:

None.