### PR TITLE
feat: introduce DatasetTypeDTO and remove optional from id property in DatasetType model

### DIFF
--- a/src/datasets/domain/dtos/DatasetTypeDTO.ts
+++ b/src/datasets/domain/dtos/DatasetTypeDTO.ts
@@ -1,0 +1,3 @@
+import { DatasetType } from '../models/DatasetType'
+
+export type DatasetTypeDTO = Omit<DatasetType, 'id'>

--- a/src/datasets/domain/models/DatasetType.ts
+++ b/src/datasets/domain/models/DatasetType.ts
@@ -1,5 +1,5 @@
 export interface DatasetType {
-  id?: number
+  id: number
   name: string
   linkedMetadataBlocks?: string[]
   availableLicenses?: string[]

--- a/src/datasets/domain/repositories/IDatasetsRepository.ts
+++ b/src/datasets/domain/repositories/IDatasetsRepository.ts
@@ -14,6 +14,7 @@ import { CitationFormat } from '../models/CitationFormat'
 import { FormattedCitation } from '../models/FormattedCitation'
 import { DatasetTemplate } from '../models/DatasetTemplate'
 import { DatasetType } from '../models/DatasetType'
+import { DatasetTypeDTO } from '../dtos/DatasetTypeDTO'
 
 export interface IDatasetsRepository {
   getDataset(
@@ -80,7 +81,7 @@ export interface IDatasetsRepository {
   getDatasetTemplates(collectionIdOrAlias: number | string): Promise<DatasetTemplate[]>
   getDatasetAvailableDatasetTypes(): Promise<DatasetType[]>
   getDatasetAvailableDatasetType(datasetTypeId: number | string): Promise<DatasetType>
-  addDatasetType(datasetType: DatasetType): Promise<DatasetType>
+  addDatasetType(datasetType: DatasetTypeDTO): Promise<DatasetType>
   linkDatasetTypeWithMetadataBlocks(
     datasetTypeId: number | string,
     metadataBlocks: string[]

--- a/src/datasets/domain/useCases/AddDatasetType.ts
+++ b/src/datasets/domain/useCases/AddDatasetType.ts
@@ -1,4 +1,5 @@
 import { UseCase } from '../../../core/domain/useCases/UseCase'
+import { DatasetTypeDTO } from '../dtos/DatasetTypeDTO'
 import { DatasetType } from '../models/DatasetType'
 import { IDatasetsRepository } from '../repositories/IDatasetsRepository'
 
@@ -12,7 +13,7 @@ export class AddDatasetType implements UseCase<DatasetType> {
   /**
    * Add a dataset type that can be selected when creating a dataset.
    */
-  async execute(datasetType: DatasetType): Promise<DatasetType> {
+  async execute(datasetType: DatasetTypeDTO): Promise<DatasetType> {
     return await this.datasetsRepository.addDatasetType(datasetType)
   }
 }

--- a/src/datasets/index.ts
+++ b/src/datasets/index.ts
@@ -145,3 +145,4 @@ export {
 } from './domain/models/DatasetVersionSummaryInfo'
 export { DatasetLinkedCollection } from './domain/models/DatasetLinkedCollection'
 export { DatasetType } from './domain/models/DatasetType'
+export { DatasetTypeDTO } from './domain/dtos/DatasetTypeDTO'

--- a/src/datasets/infra/repositories/DatasetsRepository.ts
+++ b/src/datasets/infra/repositories/DatasetsRepository.ts
@@ -29,6 +29,7 @@ import { DatasetTemplate } from '../../domain/models/DatasetTemplate'
 import { DatasetTemplatePayload } from './transformers/DatasetTemplatePayload'
 import { transformDatasetTemplatePayloadToDatasetTemplate } from './transformers/datasetTemplateTransformers'
 import { DatasetType } from '../../domain/models/DatasetType'
+import { DatasetTypeDTO } from '../../domain/dtos/DatasetTypeDTO'
 
 export interface GetAllDatasetPreviewsQueryParams {
   per_page?: number
@@ -416,7 +417,7 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
       })
   }
 
-  public async addDatasetType(datasetType: DatasetType): Promise<DatasetType> {
+  public async addDatasetType(datasetType: DatasetTypeDTO): Promise<DatasetType> {
     return this.doPost(
       this.buildApiEndpoint(this.datasetsResourceName, 'datasetTypes'),
       datasetType


### PR DESCRIPTION
## What this PR does / why we need it:
Adds a new DTO interface used to define the object structure requested for creating a dataset type.
With this change we don't use the `DatasetType` one for this same purpose and we just leave it for defining the structure of a dataset type after it was created.

## Suggestions on how to test this:
Check tests are passing.

## Is there a release notes or changelog update needed for this change?:
No.

