### PR TITLE
Add pagination query parameters to Dataset&File Version Summaries use case 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This changelog follows the principles of [Keep a Changelog](https://keepachangel
 
 ### Changed
 
+- Add pagination query parameters to Dataset Version Summeries and File Version Summaries use cases
+
 ### Fixed
 
 ### Removed

--- a/docs/useCases.md
+++ b/docs/useCases.md
@@ -872,7 +872,7 @@ The `DatasetPreviewSubset`returned instance contains a property called `totalDat
 
 #### Get Dataset Versions Summaries
 
-Returns an array of [DatasetVersionSummaryInfo](../src/datasets/domain/models/DatasetVersionSummaryInfo.ts) that contains information about what changed in every specific version.
+Returns the total count of versions and an array of [DatasetVersionSummaryInfo](../src/datasets/domain/models/DatasetVersionSummaryInfo.ts) that contains information about what changed in every specific version.
 
 ##### Example call:
 
@@ -885,7 +885,7 @@ const datasetId = 'doi:10.77777/FK2/AAAAAA'
 
 getDatasetVersionsSummaries
   .execute(datasetId)
-  .then((datasetVersionsSummaries: DatasetVersionSummaryInfo[]) => {
+  .then((datasetVersionsSummaries: DatasetVersionSummarySubset) => {
     /* ... */
   })
 
@@ -2002,7 +2002,7 @@ The `fileId` parameter can be a string, for persistent identifiers, or a number,
 
 #### Get File Version Summaries
 
-Get the file versions summaries, return a list of summaries for each version
+Get the file versions summaries, return a total count of versions and a list of summaries for each version
 
 ##### Example call:
 
@@ -2013,7 +2013,7 @@ import { getFileVersionSummaries } from '@iqss/dataverse-client-javascript'
 
 const fileId = 1
 
-getFileVersionSummaries.execute(fileId).then((fileVersionSummaries: fileVersionSummaryInfo[]) => {
+getFileVersionSummaries.execute(fileId).then((fileVersionSummaries: fileVersionSummarySubset) => {
   /* ... */
 })
 

--- a/docs/useCases.md
+++ b/docs/useCases.md
@@ -858,7 +858,9 @@ getDatasetVersionsSummaries
 
 _See [use case](../src/datasets/domain/useCases/GetDatasetVersionsSummaries.ts) implementation_.
 
-The `datasetId` parameter can be a string, for persistent identifiers, or a number, for numeric identifiers.
+- The `datasetId` parameter can be a string, for persistent identifiers, or a number, for numeric identifiers.
+- **limit**: (number) Limit for pagination.
+- **offset**: (number) Offset for pagination.
 
 #### Get Dataset Linked Collections
 
@@ -1983,6 +1985,9 @@ getFileVersionSummaries.execute(fileId).then((fileVersionSummaries: fileVersionS
 ```
 
 _See [use case](../src/files/domain/useCases/GetFileVersionSummaries.ts) implementation_.
+
+- **limit**: (number) Limit for pagination.
+- **offset**: (number) Offset for pagination.
 
 ## Metadata Blocks
 

--- a/src/datasets/domain/models/DatasetVersionSummaryInfo.ts
+++ b/src/datasets/domain/models/DatasetVersionSummaryInfo.ts
@@ -6,6 +6,11 @@ export interface DatasetVersionSummaryInfo {
   publishedOn?: string
 }
 
+export interface DatasetVersionSummarySubset {
+  summaries: DatasetVersionSummaryInfo[]
+  totalCount: number
+}
+
 export type DatasetVersionSummary = {
   [key: string]:
     | SummaryUpdates

--- a/src/datasets/domain/repositories/IDatasetsRepository.ts
+++ b/src/datasets/domain/repositories/IDatasetsRepository.ts
@@ -66,7 +66,11 @@ export interface IDatasetsRepository {
     datasetId: number | string,
     includeMDC?: boolean
   ): Promise<DatasetDownloadCount>
-  getDatasetVersionsSummaries(datasetId: number | string): Promise<DatasetVersionSummaryInfo[]>
+  getDatasetVersionsSummaries(
+    datasetId: number | string,
+    limit?: number,
+    offset?: number
+  ): Promise<DatasetVersionSummaryInfo[]>
   deleteDatasetDraft(datasetId: number | string): Promise<void>
   linkDataset(datasetId: number | string, collectionIdOrAlias: number | string): Promise<void>
   unlinkDataset(datasetId: number | string, collectionIdOrAlias: number | string): Promise<void>

--- a/src/datasets/domain/repositories/IDatasetsRepository.ts
+++ b/src/datasets/domain/repositories/IDatasetsRepository.ts
@@ -8,7 +8,7 @@ import { DatasetDeaccessionDTO } from '../dtos/DatasetDeaccessionDTO'
 import { MetadataBlock } from '../../../metadataBlocks'
 import { DatasetVersionDiff } from '../models/DatasetVersionDiff'
 import { DatasetDownloadCount } from '../models/DatasetDownloadCount'
-import { DatasetVersionSummaryInfo } from '../models/DatasetVersionSummaryInfo'
+import { DatasetVersionSummarySubset } from '../models/DatasetVersionSummaryInfo'
 import { DatasetLinkedCollection } from '../models/DatasetLinkedCollection'
 import { CitationFormat } from '../models/CitationFormat'
 import { FormattedCitation } from '../models/FormattedCitation'
@@ -70,7 +70,7 @@ export interface IDatasetsRepository {
     datasetId: number | string,
     limit?: number,
     offset?: number
-  ): Promise<DatasetVersionSummaryInfo[]>
+  ): Promise<DatasetVersionSummarySubset>
   deleteDatasetDraft(datasetId: number | string): Promise<void>
   linkDataset(datasetId: number | string, collectionIdOrAlias: number | string): Promise<void>
   unlinkDataset(datasetId: number | string, collectionIdOrAlias: number | string): Promise<void>

--- a/src/datasets/domain/useCases/GetDatasetVersionsSummaries.ts
+++ b/src/datasets/domain/useCases/GetDatasetVersionsSummaries.ts
@@ -1,8 +1,8 @@
 import { UseCase } from '../../../core/domain/useCases/UseCase'
-import { DatasetVersionSummaryInfo } from '../models/DatasetVersionSummaryInfo'
+import { DatasetVersionSummarySubset } from '../models/DatasetVersionSummaryInfo'
 import { IDatasetsRepository } from '../repositories/IDatasetsRepository'
 
-export class GetDatasetVersionsSummaries implements UseCase<DatasetVersionSummaryInfo[]> {
+export class GetDatasetVersionsSummaries implements UseCase<DatasetVersionSummarySubset> {
   private datasetsRepository: IDatasetsRepository
 
   constructor(datasetsRepository: IDatasetsRepository) {
@@ -16,13 +16,13 @@ export class GetDatasetVersionsSummaries implements UseCase<DatasetVersionSummar
    * @param {number | string} [datasetId] - The dataset identifier, which can be a string (for persistent identifiers), or a number (for numeric identifiers).
    * @param {number} [limit] - Limit for pagination (optional).
    * @param {number} [offset] - Offset for pagination (optional).
-   * @returns {Promise<DatasetVersionSummaryInfo[]>} - An array of DatasetVersionSummaryInfo.
+   * @returns {Promise<DatasetVersionSummarySubset>} - A DatasetVersionSummarySubset containing the summaries and total count.
    */
   async execute(
     datasetId: number | string,
     limit?: number,
     offset?: number
-  ): Promise<DatasetVersionSummaryInfo[]> {
+  ): Promise<DatasetVersionSummarySubset> {
     return await this.datasetsRepository.getDatasetVersionsSummaries(datasetId, limit, offset)
   }
 }

--- a/src/datasets/domain/useCases/GetDatasetVersionsSummaries.ts
+++ b/src/datasets/domain/useCases/GetDatasetVersionsSummaries.ts
@@ -14,9 +14,15 @@ export class GetDatasetVersionsSummaries implements UseCase<DatasetVersionSummar
    * Draft versions will only be available to users who have permission to view unpublished drafts.
    *
    * @param {number | string} [datasetId] - The dataset identifier, which can be a string (for persistent identifiers), or a number (for numeric identifiers).
+   * @param {number} [limit] - Limit for pagination (optional).
+   * @param {number} [offset] - Offset for pagination (optional).
    * @returns {Promise<DatasetVersionSummaryInfo[]>} - An array of DatasetVersionSummaryInfo.
    */
-  async execute(datasetId: number | string): Promise<DatasetVersionSummaryInfo[]> {
-    return await this.datasetsRepository.getDatasetVersionsSummaries(datasetId)
+  async execute(
+    datasetId: number | string,
+    limit?: number,
+    offset?: number
+  ): Promise<DatasetVersionSummaryInfo[]> {
+    return await this.datasetsRepository.getDatasetVersionsSummaries(datasetId, limit, offset)
   }
 }

--- a/src/datasets/index.ts
+++ b/src/datasets/index.ts
@@ -141,7 +141,8 @@ export { CreatedDatasetIdentifiers } from './domain/models/CreatedDatasetIdentif
 export { VersionUpdateType } from './domain/models/Dataset'
 export {
   DatasetVersionSummaryInfo,
-  DatasetVersionSummaryStringValues
+  DatasetVersionSummaryStringValues,
+  DatasetVersionSummarySubset
 } from './domain/models/DatasetVersionSummaryInfo'
 export { DatasetLinkedCollection } from './domain/models/DatasetLinkedCollection'
 export { DatasetType } from './domain/models/DatasetType'

--- a/src/datasets/infra/repositories/DatasetsRepository.ts
+++ b/src/datasets/infra/repositories/DatasetsRepository.ts
@@ -310,10 +310,10 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
     limit?: number,
     offset?: number
   ): Promise<DatasetVersionSummaryInfo[]> {
-    const queryParams: { per_page?: string; start?: string } = {}
-
-    limit && (queryParams.per_page = limit.toString())
-    offset && (queryParams.start = offset.toString())
+    const queryParams: { limit?: string; offset?: string } = {
+      limit: limit?.toString(),
+      offset: offset?.toString()
+    }
 
     return this.doGet(
       this.buildApiEndpoint(this.datasetsResourceName, 'versions/compareSummary', datasetId),

--- a/src/datasets/infra/repositories/DatasetsRepository.ts
+++ b/src/datasets/infra/repositories/DatasetsRepository.ts
@@ -20,7 +20,7 @@ import { transformDatasetPreviewsResponseToDatasetPreviewSubset } from './transf
 import { DatasetVersionDiff } from '../../domain/models/DatasetVersionDiff'
 import { transformDatasetVersionDiffResponseToDatasetVersionDiff } from './transformers/datasetVersionDiffTransformers'
 import { DatasetDownloadCount } from '../../domain/models/DatasetDownloadCount'
-import { DatasetVersionSummaryInfo } from '../../domain/models/DatasetVersionSummaryInfo'
+import { DatasetVersionSummarySubset } from '../../domain/models/DatasetVersionSummaryInfo'
 import { DatasetLinkedCollection } from '../../domain/models/DatasetLinkedCollection'
 import { CitationFormat } from '../../domain/models/CitationFormat'
 import { transformDatasetLinkedCollectionsResponseToDatasetLinkedCollection } from './transformers/datasetLinkedCollectionsTransformers'
@@ -309,10 +309,15 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
     datasetId: string | number,
     limit?: number,
     offset?: number
-  ): Promise<DatasetVersionSummaryInfo[]> {
-    const queryParams: { limit?: string; offset?: string } = {
-      limit: limit?.toString(),
-      offset: offset?.toString()
+  ): Promise<DatasetVersionSummarySubset> {
+    const queryParams = new URLSearchParams()
+
+    if (limit) {
+      queryParams.set('limit', limit.toString())
+    }
+
+    if (offset) {
+      queryParams.set('offset', offset.toString())
     }
 
     return this.doGet(
@@ -320,7 +325,10 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
       true,
       queryParams
     )
-      .then((response) => response.data.data)
+      .then((response) => ({
+        summaries: response.data.data,
+        totalCount: response.data.totalCount
+      }))
       .catch((error) => {
         throw error
       })

--- a/src/datasets/infra/repositories/DatasetsRepository.ts
+++ b/src/datasets/infra/repositories/DatasetsRepository.ts
@@ -306,11 +306,19 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
   }
 
   public async getDatasetVersionsSummaries(
-    datasetId: string | number
+    datasetId: string | number,
+    limit?: number,
+    offset?: number
   ): Promise<DatasetVersionSummaryInfo[]> {
+    const queryParams: { per_page?: string; start?: string } = {}
+
+    limit && (queryParams.per_page = limit.toString())
+    offset && (queryParams.start = offset.toString())
+
     return this.doGet(
       this.buildApiEndpoint(this.datasetsResourceName, 'versions/compareSummary', datasetId),
-      true
+      true,
+      queryParams
     )
       .then((response) => response.data.data)
       .catch((error) => {

--- a/src/files/domain/models/FileVersionSummaryInfo.ts
+++ b/src/files/domain/models/FileVersionSummaryInfo.ts
@@ -11,6 +11,11 @@ export interface FileVersionSummaryInfo {
   versionNote?: string
 }
 
+export interface FileVersionSummarySubset {
+  summaries: FileVersionSummaryInfo[]
+  totalCount: number
+}
+
 export type FileDifferenceSummary = {
   file?: FileChangeType
   fileAccess?: 'Restricted' | 'Unrestricted'

--- a/src/files/domain/repositories/IFilesRepository.ts
+++ b/src/files/domain/repositories/IFilesRepository.ts
@@ -88,7 +88,11 @@ export interface IFilesRepository {
     replace?: boolean
   ): Promise<void>
 
-  getFileVersionSummaries(fileId: number | string): Promise<FileVersionSummaryInfo[]>
+  getFileVersionSummaries(
+    fileId: number | string,
+    limit?: number,
+    offset?: number
+  ): Promise<FileVersionSummaryInfo[]>
 
   isFileDeleted(fileId: number | string): Promise<boolean>
 }

--- a/src/files/domain/repositories/IFilesRepository.ts
+++ b/src/files/domain/repositories/IFilesRepository.ts
@@ -10,7 +10,7 @@ import { FileUploadDestination } from '../models/FileUploadDestination'
 import { UploadedFileDTO } from '../dtos/UploadedFileDTO'
 import { UpdateFileMetadataDTO } from '../dtos/UpdateFileMetadataDTO'
 import { RestrictFileDTO } from '../dtos/RestrictFileDTO'
-import { FileVersionSummaryInfo } from '../models/FileVersionSummaryInfo'
+import { FileVersionSummarySubset } from '../models/FileVersionSummaryInfo'
 
 export interface IFilesRepository {
   getDatasetFiles(
@@ -92,7 +92,7 @@ export interface IFilesRepository {
     fileId: number | string,
     limit?: number,
     offset?: number
-  ): Promise<FileVersionSummaryInfo[]>
+  ): Promise<FileVersionSummarySubset>
 
   isFileDeleted(fileId: number | string): Promise<boolean>
 }

--- a/src/files/domain/useCases/GetFileVersionSummaries.ts
+++ b/src/files/domain/useCases/GetFileVersionSummaries.ts
@@ -1,8 +1,8 @@
 import { UseCase } from '../../../core/domain/useCases/UseCase'
-import { FileVersionSummaryInfo } from '../models/FileVersionSummaryInfo'
+import { FileVersionSummarySubset } from '../models/FileVersionSummaryInfo'
 import { IFilesRepository } from '../repositories/IFilesRepository'
 
-export class GetFileVersionSummaries implements UseCase<FileVersionSummaryInfo[]> {
+export class GetFileVersionSummaries implements UseCase<FileVersionSummarySubset> {
   private filesRepository: IFilesRepository
 
   constructor(filesRepository: IFilesRepository) {
@@ -15,13 +15,13 @@ export class GetFileVersionSummaries implements UseCase<FileVersionSummaryInfo[]
    * @param {number | string} [fileId] - The file identifier, which can be a string (for persistent identifiers), or a number (for numeric identifiers).
    * @param {number} [limit] - Limit for pagination (optional).
    * @param {number} [offset] - Offset for pagination (optional).
-   * @returns {Promise<FileVersionSummaryInfo[]>} - An array of FileVersionSummaryInfo.
+   * @returns {Promise<FileVersionSummarySubset>} - A FileVersionSummarySubset containing the summaries and total count.
    */
   async execute(
     fileId: number | string,
     limit?: number,
     offset?: number
-  ): Promise<FileVersionSummaryInfo[]> {
+  ): Promise<FileVersionSummarySubset> {
     return await this.filesRepository.getFileVersionSummaries(fileId, limit, offset)
   }
 }

--- a/src/files/domain/useCases/GetFileVersionSummaries.ts
+++ b/src/files/domain/useCases/GetFileVersionSummaries.ts
@@ -13,9 +13,15 @@ export class GetFileVersionSummaries implements UseCase<FileVersionSummaryInfo[]
    * Returns a list of versions for a given file including a summary of differences between consecutive versions
    *
    * @param {number | string} [fileId] - The file identifier, which can be a string (for persistent identifiers), or a number (for numeric identifiers).
+   * @param {number} [limit] - Limit for pagination (optional).
+   * @param {number} [offset] - Offset for pagination (optional).
    * @returns {Promise<FileVersionSummaryInfo[]>} - An array of FileVersionSummaryInfo.
    */
-  async execute(fileId: number | string): Promise<FileVersionSummaryInfo[]> {
-    return await this.filesRepository.getFileVersionSummaries(fileId)
+  async execute(
+    fileId: number | string,
+    limit?: number,
+    offset?: number
+  ): Promise<FileVersionSummaryInfo[]> {
+    return await this.filesRepository.getFileVersionSummaries(fileId, limit, offset)
   }
 }

--- a/src/files/index.ts
+++ b/src/files/index.ts
@@ -93,3 +93,10 @@ export { FilesSubset } from './domain/models/FilesSubset'
 export { FilePreview, FilePreviewChecksum } from './domain/models/FilePreview'
 export { UploadedFileDTO } from './domain/dtos/UploadedFileDTO'
 export { UpdateFileMetadataDTO } from './domain/dtos/UpdateFileMetadataDTO'
+export {
+  FileVersionSummaryInfo,
+  FileDifferenceSummary,
+  FileChangeType,
+  FileMetadataChange,
+  FileVersionSummarySubset
+} from './domain/models/FileVersionSummaryInfo'

--- a/src/files/infra/repositories/FilesRepository.ts
+++ b/src/files/infra/repositories/FilesRepository.ts
@@ -22,7 +22,7 @@ import { UploadedFileDTO } from '../../domain/dtos/UploadedFileDTO'
 import { UpdateFileMetadataDTO } from '../../domain/dtos/UpdateFileMetadataDTO'
 import { ApiConstants } from '../../../core/infra/repositories/ApiConstants'
 import { RestrictFileDTO } from '../../domain/dtos/RestrictFileDTO'
-import { FileVersionSummaryInfo } from '../../domain/models/FileVersionSummaryInfo'
+import { FileVersionSummarySubset } from '../../domain/models/FileVersionSummaryInfo'
 import { transformFileVersionSummaryInfoResponseToFileVersionSummaryInfo } from './transformers/fileVersionSummaryInfoTransformers'
 
 export interface GetFilesQueryParams {
@@ -427,10 +427,15 @@ export class FilesRepository extends ApiRepository implements IFilesRepository {
     fileId: number | string,
     limit?: number,
     offset?: number
-  ): Promise<FileVersionSummaryInfo[]> {
-    const queryParams: { limit?: string; offset?: string } = {
-      limit: limit?.toString(),
-      offset: offset?.toString()
+  ): Promise<FileVersionSummarySubset> {
+    const queryParams = new URLSearchParams()
+
+    if (limit) {
+      queryParams.set('limit', limit.toString())
+    }
+
+    if (offset) {
+      queryParams.set('offset', offset.toString())
     }
 
     return this.doGet(

--- a/src/files/infra/repositories/FilesRepository.ts
+++ b/src/files/infra/repositories/FilesRepository.ts
@@ -428,10 +428,10 @@ export class FilesRepository extends ApiRepository implements IFilesRepository {
     limit?: number,
     offset?: number
   ): Promise<FileVersionSummaryInfo[]> {
-    const queryParams: { per_page?: string; start?: string } = {}
-
-    limit && (queryParams.per_page = limit.toString())
-    offset && (queryParams.start = offset.toString())
+    const queryParams: { limit?: string; offset?: string } = {
+      limit: limit?.toString(),
+      offset: offset?.toString()
+    }
 
     return this.doGet(
       this.buildApiEndpoint(this.filesResourceName, 'versionDifferences', fileId),

--- a/src/files/infra/repositories/FilesRepository.ts
+++ b/src/files/infra/repositories/FilesRepository.ts
@@ -423,10 +423,20 @@ export class FilesRepository extends ApiRepository implements IFilesRepository {
       })
   }
 
-  public async getFileVersionSummaries(fileId: number | string): Promise<FileVersionSummaryInfo[]> {
+  public async getFileVersionSummaries(
+    fileId: number | string,
+    limit?: number,
+    offset?: number
+  ): Promise<FileVersionSummaryInfo[]> {
+    const queryParams: { per_page?: string; start?: string } = {}
+
+    limit && (queryParams.per_page = limit.toString())
+    offset && (queryParams.start = offset.toString())
+
     return this.doGet(
       this.buildApiEndpoint(this.filesResourceName, 'versionDifferences', fileId),
-      true
+      true,
+      queryParams
     )
       .then((response) => transformFileVersionSummaryInfoResponseToFileVersionSummaryInfo(response))
       .catch((error) => {

--- a/src/files/infra/repositories/transformers/fileVersionSummaryInfoTransformers.ts
+++ b/src/files/infra/repositories/transformers/fileVersionSummaryInfoTransformers.ts
@@ -2,7 +2,8 @@ import { AxiosResponse } from 'axios'
 import {
   FileVersionSummaryInfo,
   FileMetadataChange,
-  FileDifferenceSummary
+  FileDifferenceSummary,
+  FileVersionSummarySubset
 } from '../../../domain/models/FileVersionSummaryInfo'
 import { DatasetVersionState } from '../../../../datasets/domain/models/Dataset'
 
@@ -29,10 +30,11 @@ export interface FileVersionSummaryInfoPayload {
 
 export const transformFileVersionSummaryInfoResponseToFileVersionSummaryInfo = (
   response: AxiosResponse
-): FileVersionSummaryInfo[] => {
+): FileVersionSummarySubset => {
   const payload = response.data.data
+  const totalCount = response.data.totalCount
 
-  return payload.map((item: FileVersionSummaryInfoPayload): FileVersionSummaryInfo => {
+  const summaries = payload.map((item: FileVersionSummaryInfoPayload): FileVersionSummaryInfo => {
     const summary = item.fileDifferenceSummary || {}
 
     const fileDifferenceSummary: FileDifferenceSummary = {
@@ -54,4 +56,9 @@ export const transformFileVersionSummaryInfoResponseToFileVersionSummaryInfo = (
       versionNote: item.versionNote
     }
   })
+
+  return {
+    summaries,
+    totalCount
+  }
 }

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -1306,7 +1306,6 @@ describe('DatasetsRepository', () => {
       )
 
       const actual = await sut.getDatasetVersionsSummaries(testDatasetIds.numericId)
-      console.log('actual summaries', actual)
 
       expect(actual.summaries.length).toBeGreaterThan(0)
       expect(actual.totalCount).toBeGreaterThan(0)

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -42,8 +42,7 @@ import {
   createCollectionViaApi,
   deleteCollectionViaApi,
   publishCollectionViaApi,
-  ROOT_COLLECTION_ALIAS,
-  setStorageDriverViaApi
+  ROOT_COLLECTION_ALIAS
 } from '../../testHelpers/collections/collectionHelper'
 import {
   calculateBlobChecksum,
@@ -1292,7 +1291,6 @@ describe('DatasetsRepository', () => {
     beforeAll(async () => {
       await createCollectionViaApi(testDatasetVersionsCollectionAlias)
       await publishCollectionViaApi(testDatasetVersionsCollectionAlias)
-      await setStorageDriverViaApi(testDatasetVersionsCollectionAlias, 'LocalStack')
     })
 
     afterAll(async () => {
@@ -1306,10 +1304,12 @@ describe('DatasetsRepository', () => {
       )
 
       const actual = await sut.getDatasetVersionsSummaries(testDatasetIds.numericId)
+      console.log('actual summaries', actual)
 
-      expect(actual.length).toBeGreaterThan(0)
-      expect(actual[0].versionNumber).toBe('DRAFT')
-      expect(actual[0].summary).toBe(DatasetVersionSummaryStringValues.firstDraft)
+      expect(actual.summaries.length).toBeGreaterThan(0)
+      expect(actual.totalCount).toBeGreaterThan(0)
+      expect(actual.summaries[0].versionNumber).toBe('DRAFT')
+      expect(actual.summaries[0].summary).toBe(DatasetVersionSummaryStringValues.firstDraft)
 
       await deleteUnpublishedDatasetViaApi(testDatasetIds.numericId)
     })
@@ -1325,9 +1325,10 @@ describe('DatasetsRepository', () => {
 
       const actual = await sut.getDatasetVersionsSummaries(testDatasetIds.numericId)
 
-      expect(actual.length).toBeGreaterThan(0)
-      expect(actual[0].versionNumber).toBe('1.0')
-      expect(actual[0].summary).toBe(DatasetVersionSummaryStringValues.firstPublished)
+      expect(actual.summaries.length).toBeGreaterThan(0)
+      expect(actual.totalCount).toBeGreaterThan(0)
+      expect(actual.summaries[0].versionNumber).toBe('1.0')
+      expect(actual.summaries[0].summary).toBe(DatasetVersionSummaryStringValues.firstPublished)
 
       await deletePublishedDatasetViaApi(testDatasetIds.persistentId)
     })
@@ -1348,9 +1349,10 @@ describe('DatasetsRepository', () => {
 
       const actual = await sut.getDatasetVersionsSummaries(testDatasetIds.numericId)
 
-      expect(actual.length).toBeGreaterThan(0)
-      expect(actual[0].versionNumber).toBe('1.0')
-      expect(actual[0].summary).toStrictEqual(deaccessionReason)
+      expect(actual.summaries.length).toBeGreaterThan(0)
+      expect(actual.totalCount).toBeGreaterThan(0)
+      expect(actual.summaries[0].versionNumber).toBe('1.0')
+      expect(actual.summaries[0].summary).toStrictEqual(deaccessionReason)
 
       await deletePublishedDatasetViaApi(testDatasetIds.persistentId)
     })
@@ -1387,9 +1389,10 @@ describe('DatasetsRepository', () => {
 
       const actual = await sut.getDatasetVersionsSummaries(testDatasetIds.numericId)
 
-      expect(actual.length).toEqual(2)
-      expect(actual[0].versionNumber).toBe('DRAFT')
-      expect(actual[0].summary).toMatchObject<DatasetVersionSummary>({
+      expect(actual.summaries.length).toEqual(2)
+      expect(actual.totalCount).toEqual(2)
+      expect(actual.summaries[0].versionNumber).toBe('DRAFT')
+      expect(actual.summaries[0].summary).toMatchObject<DatasetVersionSummary>({
         'Citation Metadata': {
           Title: {
             added: 0,
@@ -1407,8 +1410,8 @@ describe('DatasetsRepository', () => {
         termsAccessChanged: false
       })
 
-      expect(actual[1].versionNumber).toBe('1.0')
-      expect(actual[1].summary).toBe(DatasetVersionSummaryStringValues.firstPublished)
+      expect(actual.summaries[1].versionNumber).toBe('1.0')
+      expect(actual.summaries[1].summary).toBe(DatasetVersionSummaryStringValues.firstPublished)
 
       await deletePublishedDatasetViaApi(testDatasetIds.persistentId)
     })
@@ -1454,10 +1457,11 @@ describe('DatasetsRepository', () => {
 
       const actual = await sut.getDatasetVersionsSummaries(testDatasetIds.numericId)
 
-      expect(actual.length).toEqual(2)
+      expect(actual.summaries.length).toEqual(2)
+      expect(actual.totalCount).toEqual(2)
 
-      expect(actual[0].versionNumber).toBe('DRAFT')
-      expect(actual[0].summary).toMatchObject<DatasetVersionSummary>({
+      expect(actual.summaries[0].versionNumber).toBe('DRAFT')
+      expect(actual.summaries[0].summary).toMatchObject<DatasetVersionSummary>({
         files: {
           added: 1,
           removed: 0,
@@ -1467,8 +1471,8 @@ describe('DatasetsRepository', () => {
         },
         termsAccessChanged: false
       })
-      expect(actual[1].versionNumber).toBe('1.0')
-      expect(actual[1].summary).toBe(DatasetVersionSummaryStringValues.firstPublished)
+      expect(actual.summaries[1].versionNumber).toBe('1.0')
+      expect(actual.summaries[1].summary).toBe(DatasetVersionSummaryStringValues.firstPublished)
 
       await deletePublishedDatasetViaApi(testDatasetIds.persistentId)
     })
@@ -1517,27 +1521,34 @@ describe('DatasetsRepository', () => {
         await waitForNoLocks(testDatasetIds.numericId, 10)
       }
 
+      const summaries = await sut.getDatasetVersionsSummaries(testDatasetIds.numericId)
+      console.log('summaries', summaries)
+
       const firstPage = await sut.getDatasetVersionsSummaries(testDatasetIds.numericId, 5, 0)
 
-      expect(firstPage.length).toBe(5)
-      expect(firstPage[0].versionNumber).toBe('1.21')
-      expect(firstPage[4].versionNumber).toBe('1.17')
+      expect(firstPage.summaries.length).toBe(5)
+      expect(firstPage.totalCount).toBe(22)
+      expect(firstPage.summaries[0].versionNumber).toBe('1.21')
+      expect(firstPage.summaries[4].versionNumber).toBe('1.17')
 
       // Test pagination with limit=5, offset=5 (second page)
       const secondPage = await sut.getDatasetVersionsSummaries(testDatasetIds.numericId, 5, 5)
-      expect(secondPage.length).toBe(5)
-      expect(secondPage[0].versionNumber).toBe('1.16')
-      expect(secondPage[4].versionNumber).toBe('1.12')
+      expect(secondPage.summaries.length).toBe(5)
+      expect(secondPage.totalCount).toBe(22)
+      expect(secondPage.summaries[0].versionNumber).toBe('1.16')
+      expect(secondPage.summaries[4].versionNumber).toBe('1.12')
 
       // Test pagination with limit=5, offset=10 (third page)
       const thirdPage = await sut.getDatasetVersionsSummaries(testDatasetIds.numericId, 5, 10)
-      expect(thirdPage.length).toBe(5)
-      expect(thirdPage[0].versionNumber).toBe('1.11')
-      expect(thirdPage[4].versionNumber).toBe('1.7')
+      expect(thirdPage.summaries.length).toBe(5)
+      expect(thirdPage.totalCount).toBe(22)
+      expect(thirdPage.summaries[0].versionNumber).toBe('1.11')
+      expect(thirdPage.summaries[4].versionNumber).toBe('1.7')
 
       // Test that all versions are returned without pagination
       const allVersions = await sut.getDatasetVersionsSummaries(testDatasetIds.numericId)
-      expect(allVersions.length).toBe(22) // 1 initial + 21 updates
+      expect(allVersions.summaries.length).toBe(22) // 1 initial + 21 updates
+      expect(allVersions.totalCount).toBe(22)
 
       await deletePublishedDatasetViaApi(testDatasetIds.persistentId)
     }, 180000)

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -1482,6 +1482,65 @@ describe('DatasetsRepository', () => {
         expectedError
       )
     })
+
+    test('should return dataset versions summaries with pagination', async () => {
+      const testDatasetIds = await createDataset.execute(
+        TestConstants.TEST_NEW_DATASET_DTO,
+        testDatasetVersionsCollectionAlias
+      )
+
+      await publishDataset.execute(testDatasetIds.numericId, VersionUpdateType.MAJOR)
+      await waitForNoLocks(testDatasetIds.numericId, 10)
+
+      const metadataBlocksRepository = new MetadataBlocksRepository()
+      const citationMetadataBlock = await metadataBlocksRepository.getMetadataBlockByName(
+        'citation'
+      )
+
+      for (let i = 1; i <= 21; i++) {
+        await sut.updateDataset(
+          testDatasetIds.numericId,
+          {
+            metadataBlockValues: [
+              {
+                name: 'citation',
+                fields: {
+                  title: `Updated Dataset Title - Version ${i}`
+                }
+              }
+            ]
+          },
+          [citationMetadataBlock]
+        )
+
+        await publishDataset.execute(testDatasetIds.numericId, VersionUpdateType.MINOR)
+        await waitForNoLocks(testDatasetIds.numericId, 10)
+      }
+
+      const firstPage = await sut.getDatasetVersionsSummaries(testDatasetIds.numericId, 5, 0)
+
+      expect(firstPage.length).toBe(5)
+      expect(firstPage[0].versionNumber).toBe('1.21')
+      expect(firstPage[4].versionNumber).toBe('1.17')
+
+      // Test pagination with limit=5, offset=5 (second page)
+      const secondPage = await sut.getDatasetVersionsSummaries(testDatasetIds.numericId, 5, 5)
+      expect(secondPage.length).toBe(5)
+      expect(secondPage[0].versionNumber).toBe('1.16')
+      expect(secondPage[4].versionNumber).toBe('1.12')
+
+      // Test pagination with limit=5, offset=10 (third page)
+      const thirdPage = await sut.getDatasetVersionsSummaries(testDatasetIds.numericId, 5, 10)
+      expect(thirdPage.length).toBe(5)
+      expect(thirdPage[0].versionNumber).toBe('1.11')
+      expect(thirdPage[4].versionNumber).toBe('1.7')
+
+      // Test that all versions are returned without pagination
+      const allVersions = await sut.getDatasetVersionsSummaries(testDatasetIds.numericId)
+      expect(allVersions.length).toBe(22) // 1 initial + 21 updates
+
+      await deletePublishedDatasetViaApi(testDatasetIds.persistentId)
+    }, 180000)
   })
 
   describe('getDatasetDownloadCount', () => {

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -42,7 +42,8 @@ import {
   createCollectionViaApi,
   deleteCollectionViaApi,
   publishCollectionViaApi,
-  ROOT_COLLECTION_ALIAS
+  ROOT_COLLECTION_ALIAS,
+  setStorageDriverViaApi
 } from '../../testHelpers/collections/collectionHelper'
 import {
   calculateBlobChecksum,
@@ -1291,6 +1292,7 @@ describe('DatasetsRepository', () => {
     beforeAll(async () => {
       await createCollectionViaApi(testDatasetVersionsCollectionAlias)
       await publishCollectionViaApi(testDatasetVersionsCollectionAlias)
+      await setStorageDriverViaApi(testDatasetVersionsCollectionAlias, 'LocalStack')
     })
 
     afterAll(async () => {

--- a/test/integration/files/FilesRepository.test.ts
+++ b/test/integration/files/FilesRepository.test.ts
@@ -930,8 +930,9 @@ describe('FilesRepository', () => {
         fileDifferenceSummary: { file: 'Added' }
       }
 
-      expect(actual).toHaveLength(1)
-      expect(actual[0]).toEqual(fileSummmaries)
+      expect(actual.summaries).toHaveLength(1)
+      expect(actual.totalCount).toBe(1)
+      expect(actual.summaries[0]).toEqual(fileSummmaries)
       deleteUnpublishedDatasetViaApi(fileTestDatasetIds.numericId)
     })
 
@@ -955,7 +956,7 @@ describe('FilesRepository', () => {
 
       const publishedFileVersionSummmaries: FileVersionSummaryInfo = {
         datasetVersion: '1.0',
-        publishedDate: publishedFileVersionSummariesActual[0].publishedDate,
+        publishedDate: publishedFileVersionSummariesActual.summaries[0].publishedDate,
         versionState: DatasetVersionState.RELEASED,
         contributors: 'Dataverse Admin',
         datafileId: testFile.id,
@@ -963,8 +964,11 @@ describe('FilesRepository', () => {
         fileDifferenceSummary: { file: 'Added' }
       }
 
-      expect(publishedFileVersionSummariesActual).toHaveLength(1)
-      expect(publishedFileVersionSummariesActual[0]).toEqual(publishedFileVersionSummmaries)
+      expect(publishedFileVersionSummariesActual.summaries).toHaveLength(1)
+      expect(publishedFileVersionSummariesActual.totalCount).toBe(1)
+      expect(publishedFileVersionSummariesActual.summaries[0]).toEqual(
+        publishedFileVersionSummmaries
+      )
 
       await deaccessionDatasetViaApi(fileTestDatasetIds.numericId, '1.0').catch(() => {
         throw new Error('Error while deaccessioning test Dataset')
@@ -974,7 +978,7 @@ describe('FilesRepository', () => {
 
       const fileSummmaries: FileVersionSummaryInfo = {
         datasetVersion: '1.0',
-        publishedDate: publishedFileVersionSummariesActual[0].publishedDate,
+        publishedDate: publishedFileVersionSummariesActual.summaries[0].publishedDate,
         versionState: DatasetVersionState.DEACCESSIONED,
         contributors: 'Dataverse Admin',
         datafileId: testFile.id,
@@ -985,8 +989,9 @@ describe('FilesRepository', () => {
         }
       }
 
-      expect(actual).toHaveLength(1)
-      expect(actual[0]).toEqual(fileSummmaries)
+      expect(actual.summaries).toHaveLength(1)
+      expect(actual.totalCount).toBe(1)
+      expect(actual.summaries[0]).toEqual(fileSummmaries)
       deletePublishedDatasetViaApi(fileTestDatasetIds.persistentId)
     })
 
@@ -1008,7 +1013,8 @@ describe('FilesRepository', () => {
       const testFile = datasetFiles.files[0]
       const actual = await sut.getFileVersionSummaries(testFile.id)
 
-      expect(actual).toHaveLength(1)
+      expect(actual.summaries).toHaveLength(1)
+      expect(actual.totalCount).toBe(1)
 
       await sut.updateFileMetadata(testFile.id, {
         description: 'My description test.',
@@ -1044,8 +1050,9 @@ describe('FilesRepository', () => {
         }
       }
 
-      expect(updatedFileVersionSummariesActual).toHaveLength(2)
-      expect(updatedFileVersionSummariesActual[0]).toEqual(updatedFileVersionSummaries)
+      expect(updatedFileVersionSummariesActual.summaries).toHaveLength(2)
+      expect(updatedFileVersionSummariesActual.totalCount).toBe(2)
+      expect(updatedFileVersionSummariesActual.summaries[0]).toEqual(updatedFileVersionSummaries)
       deletePublishedDatasetViaApi(fileTestDatasetIds.persistentId)
     })
 
@@ -1081,22 +1088,26 @@ describe('FilesRepository', () => {
 
       const firstPage = await sut.getFileVersionSummaries(paginationTestFile.id, 5, 0)
 
-      expect(firstPage.length).toBe(5)
-      expect(firstPage[0].datasetVersion).toBe('22.0')
-      expect(firstPage[4].datasetVersion).toBe('18.0')
+      expect(firstPage.summaries.length).toBe(5)
+      expect(firstPage.totalCount).toBe(22)
+      expect(firstPage.summaries[0].datasetVersion).toBe('22.0')
+      expect(firstPage.summaries[4].datasetVersion).toBe('18.0')
 
       const secondPage = await sut.getFileVersionSummaries(paginationTestFile.id, 5, 5)
-      expect(secondPage.length).toBe(5)
-      expect(secondPage[0].datasetVersion).toBe('17.0')
-      expect(secondPage[4].datasetVersion).toBe('13.0')
+      expect(secondPage.summaries.length).toBe(5)
+      expect(secondPage.totalCount).toBe(22)
+      expect(secondPage.summaries[0].datasetVersion).toBe('17.0')
+      expect(secondPage.summaries[4].datasetVersion).toBe('13.0')
 
       const thirdPage = await sut.getFileVersionSummaries(paginationTestFile.id, 5, 10)
-      expect(thirdPage.length).toBe(5)
-      expect(thirdPage[0].datasetVersion).toBe('12.0')
-      expect(thirdPage[4].datasetVersion).toBe('8.0')
+      expect(thirdPage.summaries.length).toBe(5)
+      expect(thirdPage.totalCount).toBe(22)
+      expect(thirdPage.summaries[0].datasetVersion).toBe('12.0')
+      expect(thirdPage.summaries[4].datasetVersion).toBe('8.0')
 
       const allVersions = await sut.getFileVersionSummaries(paginationTestFile.id)
-      expect(allVersions.length).toBe(22)
+      expect(allVersions.summaries.length).toBe(22)
+      expect(allVersions.totalCount).toBe(22)
 
       await deletePublishedDatasetViaApi(paginationTestDatasetIds.persistentId)
     }, 180000)

--- a/test/integration/files/FilesRepository.test.ts
+++ b/test/integration/files/FilesRepository.test.ts
@@ -1047,6 +1047,58 @@ describe('FilesRepository', () => {
       deletePublishedDatasetViaApi(fileTestDatasetIds.persistentId)
     })
 
+    test('should return file version summaries with pagination', async () => {
+      // Create a new dataset and upload a file
+      const paginationTestDatasetIds = await createDataset.execute(
+        TestConstants.TEST_NEW_DATASET_DTO
+      )
+      await uploadFileViaApi(paginationTestDatasetIds.numericId, testTextFile1Name)
+
+      // Publish initial version (creates version 1.0)
+      await publishDatasetViaApi(paginationTestDatasetIds.numericId)
+      await waitForNoLocks(paginationTestDatasetIds.numericId, 10)
+
+      // Get the file ID
+      const datasetFiles = await sut.getDatasetFiles(
+        paginationTestDatasetIds.numericId,
+        latestDatasetVersionId,
+        false,
+        FileOrderCriteria.NAME_AZ
+      )
+      const paginationTestFile = datasetFiles.files[0]
+
+      for (let i = 1; i <= 21; i++) {
+        await sut.updateFileMetadata(paginationTestFile.id, {
+          description: `File description update ${i}`,
+          label: `updated-file-${i}.txt`
+        })
+
+        await publishDatasetViaApi(paginationTestDatasetIds.numericId)
+        await waitForNoLocks(paginationTestDatasetIds.numericId, 10)
+      }
+
+      const firstPage = await sut.getFileVersionSummaries(paginationTestFile.id, 5, 0)
+
+      expect(firstPage.length).toBe(5)
+      expect(firstPage[0].datasetVersion).toBe('1.21')
+      expect(firstPage[4].datasetVersion).toBe('1.17')
+
+      const secondPage = await sut.getFileVersionSummaries(paginationTestFile.id, 5, 5)
+      expect(secondPage.length).toBe(5)
+      expect(secondPage[0].datasetVersion).toBe('1.16')
+      expect(secondPage[4].datasetVersion).toBe('1.12')
+
+      const thirdPage = await sut.getFileVersionSummaries(paginationTestFile.id, 5, 10)
+      expect(thirdPage.length).toBe(5)
+      expect(thirdPage[0].datasetVersion).toBe('1.11')
+      expect(thirdPage[4].datasetVersion).toBe('1.7')
+
+      const allVersions = await sut.getFileVersionSummaries(paginationTestFile.id)
+      expect(allVersions.length).toBe(22)
+
+      await deletePublishedDatasetViaApi(paginationTestDatasetIds.persistentId)
+    }, 180000)
+
     test('should return error when file does not exist', async () => {
       const expectedError = new ReadError(`[404] File with ID ${nonExistentFiledId} not found.`)
 

--- a/test/integration/files/FilesRepository.test.ts
+++ b/test/integration/files/FilesRepository.test.ts
@@ -925,6 +925,8 @@ describe('FilesRepository', () => {
         contributors: 'Dataverse Admin',
         datafileId: testFile.id,
         persistentId: testFile.persistentId,
+        publishedDate: '',
+        versionNote: undefined,
         fileDifferenceSummary: { file: 'Added' }
       }
 
@@ -1022,7 +1024,7 @@ describe('FilesRepository', () => {
         contributors: 'Dataverse Admin',
         datafileId: testFile.id,
         persistentId: testFile.persistentId,
-        publishedDate: actual[0].publishedDate,
+        publishedDate: '',
         versionNote: undefined,
         fileDifferenceSummary: {
           fileMetadata: [
@@ -1080,18 +1082,18 @@ describe('FilesRepository', () => {
       const firstPage = await sut.getFileVersionSummaries(paginationTestFile.id, 5, 0)
 
       expect(firstPage.length).toBe(5)
-      expect(firstPage[0].datasetVersion).toBe('1.21')
-      expect(firstPage[4].datasetVersion).toBe('1.17')
+      expect(firstPage[0].datasetVersion).toBe('22.0')
+      expect(firstPage[4].datasetVersion).toBe('18.0')
 
       const secondPage = await sut.getFileVersionSummaries(paginationTestFile.id, 5, 5)
       expect(secondPage.length).toBe(5)
-      expect(secondPage[0].datasetVersion).toBe('1.16')
-      expect(secondPage[4].datasetVersion).toBe('1.12')
+      expect(secondPage[0].datasetVersion).toBe('17.0')
+      expect(secondPage[4].datasetVersion).toBe('13.0')
 
       const thirdPage = await sut.getFileVersionSummaries(paginationTestFile.id, 5, 10)
       expect(thirdPage.length).toBe(5)
-      expect(thirdPage[0].datasetVersion).toBe('1.11')
-      expect(thirdPage[4].datasetVersion).toBe('1.7')
+      expect(thirdPage[0].datasetVersion).toBe('12.0')
+      expect(thirdPage[4].datasetVersion).toBe('8.0')
 
       const allVersions = await sut.getFileVersionSummaries(paginationTestFile.id)
       expect(allVersions.length).toBe(22)

--- a/test/integration/notifications/NotificationsRepository.test.ts
+++ b/test/integration/notifications/NotificationsRepository.test.ts
@@ -54,10 +54,10 @@ describe('NotificationsRepository', () => {
     expect(publishedNotification).toHaveProperty('sentTimestamp')
 
     expect(publishedNotification?.subjectText).toContain(
-      'Dataset created using the createDataset use case'
+      `Dataset "${TestConstants.TEST_NEW_DATASET_DTO.metadataBlockValues[0].fields.title}" has been published`
     )
     expect(publishedNotification?.messageText).toContain(
-      'Your dataset named Dataset created using the createDataset use case'
+      `Your dataset named "${TestConstants.TEST_NEW_DATASET_DTO.metadataBlockValues[0].fields.title}"`
     )
   })
 

--- a/test/integration/notifications/NotificationsRepository.test.ts
+++ b/test/integration/notifications/NotificationsRepository.test.ts
@@ -56,8 +56,9 @@ describe('NotificationsRepository', () => {
     expect(publishedNotification?.subjectText).toContain(
       `Dataset "${TestConstants.TEST_NEW_DATASET_DTO.metadataBlockValues[0].fields.title}" has been published`
     )
+
     expect(publishedNotification?.messageText).toContain(
-      `Your dataset named "${TestConstants.TEST_NEW_DATASET_DTO.metadataBlockValues[0].fields.title}"`
+      `Your dataset named ${TestConstants.TEST_NEW_DATASET_DTO.metadataBlockValues[0].fields.title}`
     )
   })
 

--- a/test/unit/datasets/DatasetsRepository.test.ts
+++ b/test/unit/datasets/DatasetsRepository.test.ts
@@ -1055,7 +1055,8 @@ describe('DatasetsRepository', () => {
     const testDatasetVersionSummariesResponse = {
       data: {
         status: 'OK',
-        data: [testDatasetVersionSummaries]
+        data: [testDatasetVersionSummaries],
+        totalCount: 1
       }
     }
 
@@ -1072,7 +1073,10 @@ describe('DatasetsRepository', () => {
           expectedApiEndpoint,
           TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY
         )
-        expect(actual).toStrictEqual([testDatasetVersionSummaries])
+        expect(actual).toStrictEqual({
+          summaries: [testDatasetVersionSummaries],
+          totalCount: 1
+        })
 
         // Session cookie auth
         ApiConfig.init(TestConstants.TEST_API_URL, DataverseApiAuthMechanism.SESSION_COOKIE)
@@ -1083,7 +1087,10 @@ describe('DatasetsRepository', () => {
           expectedApiEndpoint,
           TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE
         )
-        expect(actual).toStrictEqual([testDatasetVersionSummaries])
+        expect(actual).toStrictEqual({
+          summaries: [testDatasetVersionSummaries],
+          totalCount: 1
+        })
       })
 
       test('should return error result on error response', async () => {
@@ -1113,7 +1120,10 @@ describe('DatasetsRepository', () => {
           expectedApiEndpoint,
           TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY
         )
-        expect(actual).toStrictEqual([testDatasetVersionSummaries])
+        expect(actual).toStrictEqual({
+          summaries: [testDatasetVersionSummaries],
+          totalCount: 1
+        })
 
         // Session cookie auth
         ApiConfig.init(TestConstants.TEST_API_URL, DataverseApiAuthMechanism.SESSION_COOKIE)
@@ -1124,7 +1134,10 @@ describe('DatasetsRepository', () => {
           expectedApiEndpoint,
           TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE
         )
-        expect(actual).toStrictEqual([testDatasetVersionSummaries])
+        expect(actual).toStrictEqual({
+          summaries: [testDatasetVersionSummaries],
+          totalCount: 1
+        })
       })
 
       test('should return error result on error response', async () => {

--- a/test/unit/datasets/DatasetsRepository.test.ts
+++ b/test/unit/datasets/DatasetsRepository.test.ts
@@ -12,7 +12,11 @@ import {
   createUpdateDatasetRequestPayload
 } from '../../testHelpers/datasets/datasetHelper'
 import { TestConstants } from '../../testHelpers/TestConstants'
-import { DatasetNotNumberedVersion, DatasetPreviewSubset } from '../../../src/datasets'
+import {
+  DatasetNotNumberedVersion,
+  DatasetPreviewSubset,
+  DatasetVersionSummarySubset
+} from '../../../src/datasets'
 import { createDatasetUserPermissionsModel } from '../../testHelpers/datasets/datasetUserPermissionsHelper'
 import {
   createDatasetLockModel,
@@ -1050,13 +1054,16 @@ describe('DatasetsRepository', () => {
   })
 
   describe('getDatasetVersionSummaries', () => {
-    const testDatasetVersionSummaries = createDatasetVersionSummaryModel()
+    const testDatasetVersionSummariesSubset: DatasetVersionSummarySubset = {
+      summaries: [createDatasetVersionSummaryModel()],
+      totalCount: 1
+    }
 
     const testDatasetVersionSummariesResponse = {
       data: {
         status: 'OK',
-        data: [testDatasetVersionSummaries],
-        totalCount: 1
+        data: testDatasetVersionSummariesSubset.summaries,
+        totalCount: testDatasetVersionSummariesSubset.totalCount
       }
     }
 
@@ -1069,28 +1076,37 @@ describe('DatasetsRepository', () => {
         // API Key auth
         let actual = await sut.getDatasetVersionsSummaries(testDatasetModel.id)
 
-        expect(axios.get).toHaveBeenCalledWith(
+        const expectedRequestParams = new URLSearchParams()
+
+        const expectedRequestConfigApiKey = {
+          params: expectedRequestParams,
+          headers: TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY.headers
+        }
+
+        expect(axios.get).toHaveBeenNthCalledWith(
+          1,
           expectedApiEndpoint,
-          TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY
+          expectedRequestConfigApiKey
         )
-        expect(actual).toStrictEqual({
-          summaries: [testDatasetVersionSummaries],
-          totalCount: 1
-        })
+        expect(actual).toStrictEqual(testDatasetVersionSummariesSubset)
 
         // Session cookie auth
         ApiConfig.init(TestConstants.TEST_API_URL, DataverseApiAuthMechanism.SESSION_COOKIE)
 
         actual = await sut.getDatasetVersionsSummaries(testDatasetModel.id)
 
-        expect(axios.get).toHaveBeenCalledWith(
+        const expectedRequestConfigSessionCookie = {
+          params: expectedRequestParams,
+          headers: TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE.headers,
+          withCredentials: true
+        }
+
+        expect(axios.get).toHaveBeenNthCalledWith(
+          2,
           expectedApiEndpoint,
-          TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE
+          expectedRequestConfigSessionCookie
         )
-        expect(actual).toStrictEqual({
-          summaries: [testDatasetVersionSummaries],
-          totalCount: 1
-        })
+        expect(actual).toStrictEqual(testDatasetVersionSummariesSubset)
       })
 
       test('should return error result on error response', async () => {
@@ -1099,10 +1115,14 @@ describe('DatasetsRepository', () => {
         let error = undefined as unknown as ReadError
         await sut.getDatasetVersionsSummaries(testDatasetModel.id).catch((e) => (error = e))
 
-        expect(axios.get).toHaveBeenCalledWith(
-          expectedApiEndpoint,
-          TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY
-        )
+        const expectedRequestParams = new URLSearchParams()
+
+        const expectedRequestConfigApiKey = {
+          params: expectedRequestParams,
+          headers: TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY.headers
+        }
+
+        expect(axios.get).toHaveBeenCalledWith(expectedApiEndpoint, expectedRequestConfigApiKey)
         expect(error).toBeInstanceOf(ReadError)
       })
     })
@@ -1116,28 +1136,37 @@ describe('DatasetsRepository', () => {
         // API Key auth
         let actual = await sut.getDatasetVersionsSummaries(TestConstants.TEST_DUMMY_PERSISTENT_ID)
 
-        expect(axios.get).toHaveBeenCalledWith(
+        const expectedRequestParams = new URLSearchParams()
+
+        const expectedRequestConfigApiKey = {
+          params: expectedRequestParams,
+          headers: TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY.headers
+        }
+
+        expect(axios.get).toHaveBeenNthCalledWith(
+          1,
           expectedApiEndpoint,
-          TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY
+          expectedRequestConfigApiKey
         )
-        expect(actual).toStrictEqual({
-          summaries: [testDatasetVersionSummaries],
-          totalCount: 1
-        })
+        expect(actual).toStrictEqual(testDatasetVersionSummariesSubset)
 
         // Session cookie auth
         ApiConfig.init(TestConstants.TEST_API_URL, DataverseApiAuthMechanism.SESSION_COOKIE)
 
         actual = await sut.getDatasetVersionsSummaries(TestConstants.TEST_DUMMY_PERSISTENT_ID)
 
-        expect(axios.get).toHaveBeenCalledWith(
+        const expectedRequestConfigSessionCookie = {
+          params: expectedRequestParams,
+          headers: TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE.headers,
+          withCredentials: true
+        }
+
+        expect(axios.get).toHaveBeenNthCalledWith(
+          2,
           expectedApiEndpoint,
-          TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_SESSION_COOKIE
+          expectedRequestConfigSessionCookie
         )
-        expect(actual).toStrictEqual({
-          summaries: [testDatasetVersionSummaries],
-          totalCount: 1
-        })
+        expect(actual).toStrictEqual(testDatasetVersionSummariesSubset)
       })
 
       test('should return error result on error response', async () => {
@@ -1148,10 +1177,14 @@ describe('DatasetsRepository', () => {
           .getDatasetVersionsSummaries(TestConstants.TEST_DUMMY_PERSISTENT_ID)
           .catch((e) => (error = e))
 
-        expect(axios.get).toHaveBeenCalledWith(
-          expectedApiEndpoint,
-          TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY
-        )
+        const expectedRequestParams = new URLSearchParams()
+
+        const expectedRequestConfigApiKey = {
+          params: expectedRequestParams,
+          headers: TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY.headers
+        }
+
+        expect(axios.get).toHaveBeenCalledWith(expectedApiEndpoint, expectedRequestConfigApiKey)
         expect(error).toBeInstanceOf(ReadError)
       })
     })

--- a/test/unit/datasets/GetDatasetVersionsSummaries.test.ts
+++ b/test/unit/datasets/GetDatasetVersionsSummaries.test.ts
@@ -2,21 +2,25 @@ import { ReadError } from '../../../src/core/domain/repositories/ReadError'
 import { IDatasetsRepository } from '../../../src/datasets/domain/repositories/IDatasetsRepository'
 import { createDatasetVersionSummaryModel } from '../../testHelpers/datasets/datasetVersionsSummariesHelper'
 import { GetDatasetVersionsSummaries } from '../../../src/datasets/domain/useCases/GetDatasetVersionsSummaries'
+import { DatasetVersionSummarySubset } from '../../../src/datasets/domain/models/DatasetVersionSummaryInfo'
 
 const testDatasetId = 1
 
 describe('execute', () => {
   test('should return dataset versions summaries on repository success', async () => {
-    const testDatasetVersionsSummaries = [createDatasetVersionSummaryModel()]
+    const testDatasetVersionsSummariesSubset: DatasetVersionSummarySubset = {
+      summaries: [createDatasetVersionSummaryModel()],
+      totalCount: 1
+    }
     const datasetsRepositoryStub: IDatasetsRepository = {} as IDatasetsRepository
     datasetsRepositoryStub.getDatasetVersionsSummaries = jest
       .fn()
-      .mockResolvedValue(testDatasetVersionsSummaries)
+      .mockResolvedValue(testDatasetVersionsSummariesSubset)
     const sut = new GetDatasetVersionsSummaries(datasetsRepositoryStub)
 
     const actual = await sut.execute(testDatasetId)
 
-    expect(actual).toEqual(testDatasetVersionsSummaries)
+    expect(actual).toEqual(testDatasetVersionsSummariesSubset)
     expect(datasetsRepositoryStub.getDatasetVersionsSummaries).toHaveBeenCalledWith(
       testDatasetId,
       undefined,

--- a/test/unit/datasets/GetDatasetVersionsSummaries.test.ts
+++ b/test/unit/datasets/GetDatasetVersionsSummaries.test.ts
@@ -17,7 +17,11 @@ describe('execute', () => {
     const actual = await sut.execute(testDatasetId)
 
     expect(actual).toEqual(testDatasetVersionsSummaries)
-    expect(datasetsRepositoryStub.getDatasetVersionsSummaries).toHaveBeenCalledWith(testDatasetId)
+    expect(datasetsRepositoryStub.getDatasetVersionsSummaries).toHaveBeenCalledWith(
+      testDatasetId,
+      undefined,
+      undefined
+    )
   })
 
   test('should return error result on repository error', async () => {

--- a/test/unit/files/GetFileVersionSummaries.test.ts
+++ b/test/unit/files/GetFileVersionSummaries.test.ts
@@ -7,7 +7,6 @@ describe('execute', () => {
   test('should return file on repository success when passing numeric id', async () => {
     const filesRepositoryStub: IFilesRepository = {} as IFilesRepository
     const fileVersionSummariesSubset: FileVersionSummarySubset = {
-      totalCount: 1,
       summaries: [
         {
           datasetVersion: '1.0',

--- a/test/unit/files/GetFileVersionSummaries.test.ts
+++ b/test/unit/files/GetFileVersionSummaries.test.ts
@@ -1,32 +1,38 @@
 import { IFilesRepository } from '../../../src/files/domain/repositories/IFilesRepository'
 import { ReadError } from '../../../src'
 import { GetFileVersionSummaries } from '../../../src/files/domain/useCases/GetFileVersionSummaries'
-import { FileVersionSummaryInfo } from '../../../src/files/domain/models/FileVersionSummaryInfo'
+import { FileVersionSummarySubset } from '../../../src/files/domain/models/FileVersionSummaryInfo'
 
 describe('execute', () => {
   test('should return file on repository success when passing numeric id', async () => {
     const filesRepositoryStub: IFilesRepository = {} as IFilesRepository
-    const fileVersionSummaries: FileVersionSummaryInfo[] = [
-      {
-        datasetVersion: '1.0',
-        contributors: 'John Doe',
-        publishedDate: '2023-01-01',
-        fileDifferenceSummary: {
-          fileMetadata: [
-            {
-              name: 'file.txt',
-              action: 'Added'
-            }
-          ]
-        },
-        datafileId: 1
-      }
-    ]
-    filesRepositoryStub.getFileVersionSummaries = jest.fn().mockResolvedValue(fileVersionSummaries)
+    const fileVersionSummariesSubset: FileVersionSummarySubset = {
+      totalCount: 1,
+      summaries: [
+        {
+          datasetVersion: '1.0',
+          contributors: 'John Doe',
+          publishedDate: '2023-01-01',
+          fileDifferenceSummary: {
+            fileMetadata: [
+              {
+                name: 'file.txt',
+                action: 'Added'
+              }
+            ]
+          },
+          datafileId: 1
+        }
+      ],
+      totalCount: 1
+    }
+    filesRepositoryStub.getFileVersionSummaries = jest
+      .fn()
+      .mockResolvedValue(fileVersionSummariesSubset)
 
     const sut = new GetFileVersionSummaries(filesRepositoryStub)
     const actualFileVersionSummaries = await sut.execute(1)
-    expect(actualFileVersionSummaries).toEqual(fileVersionSummaries)
+    expect(actualFileVersionSummaries).toEqual(fileVersionSummariesSubset)
   })
 
   test('should return error result on repository error', async () => {


### PR DESCRIPTION
## What this PR does / why we need it:
Add pagination query parameters to Dataset&File Version Summaries use case 

## Which issue(s) this PR closes:

- Closes #394 

## Related Dataverse PRs:

- Depends on #https://github.com/IQSS/dataverse/pull/11859

## Special notes for your reviewer:

## Suggestions on how to test this:

## Is there a release notes or changelog update needed for this change?:
yes

## Additional documentation:
