### PR TITLE
feat: add config setting "bearerTokenGetFunction"

### DIFF
--- a/src/core/infra/repositories/ApiConfig.ts
+++ b/src/core/infra/repositories/ApiConfig.ts
@@ -10,7 +10,7 @@ export class ApiConfig {
     dataverseApiAuthMechanism: DataverseApiAuthMechanism,
     dataverseApiKey?: string,
     bearerTokenLocalStorageKey?: string,
-    bearerTokenGetFunction?: () => string
+    bearerTokenGetFunction?: () => string | null
   ) {
     this.dataverseApiUrl = dataverseApiUrl
     this.dataverseApiAuthMechanism = dataverseApiAuthMechanism

--- a/src/core/infra/repositories/ApiConfig.ts
+++ b/src/core/infra/repositories/ApiConfig.ts
@@ -3,17 +3,20 @@ export class ApiConfig {
   static dataverseApiAuthMechanism: DataverseApiAuthMechanism
   static dataverseApiKey?: string
   static bearerTokenLocalStorageKey?: string
+  static bearerTokenGetFunction?: () => string | null
 
   static init(
     dataverseApiUrl: string,
     dataverseApiAuthMechanism: DataverseApiAuthMechanism,
     dataverseApiKey?: string,
-    bearerTokenLocalStorageKey?: string
+    bearerTokenLocalStorageKey?: string,
+    bearerTokenGetFunction?: () => string
   ) {
     this.dataverseApiUrl = dataverseApiUrl
     this.dataverseApiAuthMechanism = dataverseApiAuthMechanism
     this.dataverseApiKey = dataverseApiKey
     this.bearerTokenLocalStorageKey = bearerTokenLocalStorageKey
+    this.bearerTokenGetFunction = bearerTokenGetFunction
   }
 }
 

--- a/src/core/infra/repositories/apiConfigBuilders.ts
+++ b/src/core/infra/repositories/apiConfigBuilders.ts
@@ -41,13 +41,19 @@ export const buildRequestConfig = (
       break
 
     case DataverseApiAuthMechanism.BEARER_TOKEN: {
-      if (!ApiConfig.bearerTokenLocalStorageKey) {
+      if (!(ApiConfig.bearerTokenLocalStorageKey || ApiConfig.bearerTokenGetFunction)) {
         throw new Error(
-          'Bearer token local storage key is not set in the ApiConfig, when using bearer token auth mechanism you must set the bearerTokenLocalStorageKey'
+          'Bearer token local storage key or get function is not set in the ApiConfig, when using bearer token auth mechanism you must set the bearerTokenLocalStorageKey or bearerTokenGetFunction'
         )
       }
 
-      const token = getLocalStorageItem<string>(ApiConfig.bearerTokenLocalStorageKey)
+      let token
+
+      if (ApiConfig.bearerTokenLocalStorageKey) {
+        token = getLocalStorageItem<string>(ApiConfig.bearerTokenLocalStorageKey)
+      } else if (ApiConfig.bearerTokenGetFunction) {
+        token = ApiConfig.bearerTokenGetFunction()
+      }
 
       if (token) {
         requestConfig.headers.Authorization = `Bearer ${token}`


### PR DESCRIPTION
## What this PR does / why we need it:

This PR adds a config setting `bearerTokenGetFunction` to define a custom function to retrieve the bearer token. This is more flexible than the current `bearerTokenLocalStorageKey` setting.

## Which issue(s) this PR closes:

- Closes #396

## Related Dataverse PRs:

/

## Special notes for your reviewer:

/

## Suggestions on how to test this:

I've tested this by initializing with the following config:

```
ApiConfig.init(
  "http://localhost:8080/api",
  DataverseApiAuthMechanism.BEARER_TOKEN,
  undefined,
  undefined,
  () => {
    const value = localStorage.getItem("oidc.default");
    if (value) {
      const token = JSON.parse(value).tokens?.accessToken;
      return token || null;
    } else {
      return null;
    }
  }
);
```

and confirmed that bearer-token-authenticated requests are correctly sent.

## Is there a release notes or changelog update needed for this change?:

Yes, that would be good.

## Additional documentation:

/