### PR TITLE
fix client package self-reference and alpha publish workflow

### DIFF
--- a/.github/workflows/deploy_alpha.yml
+++ b/.github/workflows/deploy_alpha.yml
@@ -71,17 +71,19 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc
+          CURRENT_PACKAGE_VERSION=$(jq -r '.version' package.json)
+          BASE_VERSION=${CURRENT_PACKAGE_VERSION%%-alpha.*}
 
-          LATEST_VERSION=$(npm show @IQSS/dataverse-client-javascript versions --registry=https://npm.pkg.github.com/ --json | jq -r '.[]' | grep "^2.0.0-alpha." | sort -V | tail -n 1)
+          LATEST_VERSION=$(npm show @iqss/dataverse-client-javascript versions --registry=https://npm.pkg.github.com/ --json | jq -r '.[]' | grep "^${BASE_VERSION}-alpha\\." | sort -V | tail -n 1)
 
           if [ -z "$LATEST_VERSION" ]; then
             NEW_INCREMENTAL_NUMBER=1
           else
-            CURRENT_INCREMENTAL_NUMBER=$(echo $LATEST_VERSION | sed 's/2.0.0-alpha.//')
+            CURRENT_INCREMENTAL_NUMBER=$(echo "$LATEST_VERSION" | sed "s/^${BASE_VERSION}-alpha\\.//")
             NEW_INCREMENTAL_NUMBER=$((CURRENT_INCREMENTAL_NUMBER + 1))
           fi
 
-          NEW_VERSION="2.0.0-alpha.${NEW_INCREMENTAL_NUMBER}"
+          NEW_VERSION="${BASE_VERSION}-alpha.${NEW_INCREMENTAL_NUMBER}"
 
           echo "Latest version: $LATEST_VERSION"
           echo "New version: $NEW_VERSION"
@@ -92,7 +94,6 @@ jobs:
       - name: Publish package
         run: |
           echo "$(jq '.publishConfig.registry = "https://npm.pkg.github.com"' package.json)" > package.json
-          echo "$( jq '.name = "@IQSS/dataverse-client-javascript"' package.json )" > package.json
-          npm publish --@IQSS:registry=https://npm.pkg.github.com
+          npm publish --@iqss:registry=https://npm.pkg.github.com
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy_pr.yml
+++ b/.github/workflows/deploy_pr.yml
@@ -73,7 +73,6 @@ jobs:
       - name: Publish package
         run: |
           echo "$(jq '.publishConfig.registry = "https://npm.pkg.github.com"' package.json)" > package.json
-          echo "$( jq '.name = "@IQSS/dataverse-client-javascript"' package.json )" > package.json
-          npm publish --@IQSS:registry=https://npm.pkg.github.com
+          npm publish --@iqss:registry=https://npm.pkg.github.com
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "ts-node": "^10.9.2"
   },
   "dependencies": {
-    "@iqss/dataverse-client-javascript": "^2.1.0",
     "@types/node": "^18.15.11",
     "@types/turndown": "^5.0.1",
     "axios": "^1.12.2",


### PR DESCRIPTION
## What this PR does / why we need it:

- Removes the self-dependency from @IQSS/dataverse-client-javascript
- Fxes GitHub Packages publish workflows to use the correct lowercase package name and the current base version for alpha releases.


## Which issue(s) this PR closes:

- Closes #

## Related Dataverse PRs:

- Depends on #

## Special notes for your reviewer:

## Suggestions on how to test this:

## Is there a release notes or changelog update needed for this change?:

## Additional documentation:
