### PR TITLE
AccessRepository.ts omits credentials if using Bearer Token Authorization

### DIFF
--- a/src/access/infra/repositories/AccessRepository.ts
+++ b/src/access/infra/repositories/AccessRepository.ts
@@ -99,7 +99,7 @@ export class AccessRepository extends ApiRepository implements IAccessRepository
       throw new WriteError(this.buildFetchErrorMessage(response.status, responseData))
     }
 
-    return responseData.data.signedUrl as string
+    return this.getSignedUrlOrThrow(responseData)
   }
 
   private getFetchCredentials(withCredentials?: boolean): RequestCredentials | undefined {
@@ -149,7 +149,13 @@ export class AccessRepository extends ApiRepository implements IAccessRepository
       return await response.json()
     }
 
-    return await response.text()
+    const responseText = await response.text()
+
+    try {
+      return JSON.parse(responseText)
+    } catch {
+      return responseText
+    }
   }
 
   private buildFetchErrorMessage(status: number, responseData: any): string {
@@ -159,5 +165,15 @@ export class AccessRepository extends ApiRepository implements IAccessRepository
         : responseData?.message || responseData?.data?.message || 'unknown error'
 
     return `[${status}] ${message}`
+  }
+
+  private getSignedUrlOrThrow(responseData: any): string {
+    const signedUrl = responseData?.data?.signedUrl
+
+    if (typeof signedUrl !== 'string' || signedUrl.length === 0) {
+      throw new WriteError('Missing signedUrl in access download response.')
+    }
+
+    return signedUrl
   }
 }

--- a/src/access/infra/repositories/AccessRepository.ts
+++ b/src/access/infra/repositories/AccessRepository.ts
@@ -1,4 +1,11 @@
+import { ApiConfig, DataverseApiAuthMechanism } from '../../../core/infra/repositories/ApiConfig'
+import { WriteError } from '../../../core/domain/repositories/WriteError'
+import { ApiConstants } from '../../../core/infra/repositories/ApiConstants'
 import { ApiRepository } from '../../../core/infra/repositories/ApiRepository'
+import {
+  buildRequestConfig,
+  buildRequestUrl
+} from '../../../core/infra/repositories/apiConfigBuilders'
 import { GuestbookResponseDTO } from '../../domain/dtos/GuestbookResponseDTO'
 import { IAccessRepository } from '../../domain/repositories/IAccessRepository'
 
@@ -13,14 +20,7 @@ export class AccessRepository extends ApiRepository implements IAccessRepository
     const endpoint = this.buildApiEndpoint(`${this.accessResourceName}/datafile`, undefined, fileId)
     const queryParams = format ? { signed: true, format } : { signed: true }
 
-    return this.doPost(endpoint, guestbookResponse, queryParams)
-      .then((response) => {
-        const signedUrl = response.data.data.signedUrl
-        return signedUrl
-      })
-      .catch((error) => {
-        throw error
-      })
+    return await this.submitGuestbookDownload(endpoint, guestbookResponse, queryParams)
   }
 
   public async submitGuestbookForDatafilesDownload(
@@ -30,7 +30,7 @@ export class AccessRepository extends ApiRepository implements IAccessRepository
   ): Promise<string> {
     const queryParams = format ? { signed: true, format } : { signed: true }
 
-    return this.doPost(
+    return await this.submitGuestbookDownload(
       this.buildApiEndpoint(
         this.accessResourceName,
         `datafiles/${Array.isArray(fileIds) ? fileIds.join(',') : fileIds}`
@@ -38,13 +38,6 @@ export class AccessRepository extends ApiRepository implements IAccessRepository
       guestbookResponse,
       queryParams
     )
-      .then((response) => {
-        const signedUrl = response.data.data.signedUrl
-        return signedUrl
-      })
-      .catch((error) => {
-        throw error
-      })
   }
 
   public async submitGuestbookForDatasetDownload(
@@ -59,14 +52,7 @@ export class AccessRepository extends ApiRepository implements IAccessRepository
     )
     const queryParams = format ? { signed: true, format } : { signed: true }
 
-    return this.doPost(endpoint, guestbookResponse, queryParams)
-      .then((response) => {
-        const signedUrl = response.data.data.signedUrl
-        return signedUrl
-      })
-      .catch((error) => {
-        throw error
-      })
+    return await this.submitGuestbookDownload(endpoint, guestbookResponse, queryParams)
   }
 
   public async submitGuestbookForDatasetVersionDownload(
@@ -82,13 +68,96 @@ export class AccessRepository extends ApiRepository implements IAccessRepository
     )
     const queryParams = format ? { signed: true, format } : { signed: true }
 
-    return this.doPost(endpoint, guestbookResponse, queryParams)
-      .then((response) => {
-        const signedUrl = response.data.data.signedUrl
-        return signedUrl
-      })
-      .catch((error) => {
-        throw error
-      })
+    return await this.submitGuestbookDownload(endpoint, guestbookResponse, queryParams)
+  }
+
+  private async submitGuestbookDownload(
+    apiEndpoint: string,
+    guestbookResponse: GuestbookResponseDTO,
+    queryParams: object
+  ): Promise<string> {
+    const requestConfig = buildRequestConfig(
+      true,
+      queryParams,
+      ApiConstants.CONTENT_TYPE_APPLICATION_JSON
+    )
+    const response = await fetch(
+      this.buildUrlWithQueryParams(buildRequestUrl(apiEndpoint), queryParams),
+      {
+        method: 'POST',
+        headers: this.buildFetchHeaders(requestConfig.headers),
+        credentials: this.getFetchCredentials(requestConfig.withCredentials),
+        body: JSON.stringify(guestbookResponse)
+      }
+    ).catch((error) => {
+      throw new WriteError(error instanceof Error ? error.message : String(error))
+    })
+
+    const responseData = await this.parseResponseBody(response)
+
+    if (!response.ok) {
+      throw new WriteError(this.buildFetchErrorMessage(response.status, responseData))
+    }
+
+    return responseData.data.signedUrl as string
+  }
+
+  private getFetchCredentials(withCredentials?: boolean): RequestCredentials | undefined {
+    if (ApiConfig.dataverseApiAuthMechanism === DataverseApiAuthMechanism.BEARER_TOKEN) {
+      return 'omit'
+    }
+
+    if (withCredentials) {
+      return 'include'
+    }
+
+    return undefined
+  }
+
+  private buildUrlWithQueryParams(requestUrl: string, queryParams: object): string {
+    const url = new URL(requestUrl)
+
+    Object.entries(queryParams).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        url.searchParams.append(key, String(value))
+      }
+    })
+
+    return url.toString()
+  }
+
+  private buildFetchHeaders(headers?: Record<string, unknown>): Record<string, string> {
+    const fetchHeaders: Record<string, string> = {}
+
+    if (!headers) {
+      return fetchHeaders
+    }
+
+    Object.entries(headers).forEach(([key, value]) => {
+      if (value !== undefined) {
+        fetchHeaders[key] = String(value)
+      }
+    })
+
+    return fetchHeaders
+  }
+
+  private async parseResponseBody(response: Response): Promise<any> {
+    const contentType = response.headers.get('content-type') ?? ''
+
+    if (contentType.includes('application/json')) {
+      return await response.json()
+    }
+
+    return await response.text()
+  }
+
+  private buildFetchErrorMessage(status: number, responseData: any): string {
+    const message =
+      typeof responseData === 'string'
+        ? responseData
+        : responseData?.message || responseData?.data?.message || 'unknown error'
+
+    return `[${status}] ${message}`
   }
 }

--- a/test/integration/access/AccessRepository.test.ts
+++ b/test/integration/access/AccessRepository.test.ts
@@ -63,11 +63,14 @@ describe('AccessRepository', () => {
   })
 
   describe('submitGuestbookForDatafileDownload', () => {
-    test('should return signed url for datafile download', async () => {
+    test('should return signed url that can be used to download the datafile', async () => {
       const actual = await sut.submitGuestbookForDatafileDownload(testFileId, guestbookResponse)
+      const downloadResponse = await fetch(actual)
 
       expect(actual).toEqual(expect.any(String))
       expect(() => new URL(actual)).not.toThrow()
+      expect(downloadResponse.ok).toBe(true)
+      await expect(downloadResponse.text()).resolves.toBe('test file 1\n')
     })
 
     test('should return error when datafile does not exist', async () => {

--- a/test/unit/access/AccessRepository.test.ts
+++ b/test/unit/access/AccessRepository.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { AccessRepository } from '../../../src/access/infra/repositories/AccessRepository'
+import { GuestbookResponseDTO } from '../../../src/access/domain/dtos/GuestbookResponseDTO'
+import {
+  ApiConfig,
+  DataverseApiAuthMechanism
+} from '../../../src/core/infra/repositories/ApiConfig'
+import { TestConstants } from '../../testHelpers/TestConstants'
+
+describe('AccessRepository', () => {
+  const sut = new AccessRepository()
+  const guestbookResponse: GuestbookResponseDTO = {
+    guestbookResponse: {
+      answers: [{ id: 1, value: 'question 1' }]
+    }
+  }
+
+  beforeEach(() => {
+    window.localStorage.setItem(
+      TestConstants.TEST_BEARER_TOKEN_LOCAL_STORAGE_KEY,
+      JSON.stringify(TestConstants.TEST_DUMMY_BEARER_TOKEN)
+    )
+  })
+
+  afterEach(() => {
+    window.localStorage.clear()
+  })
+
+  test('uses fetch with credentials omit for bearer token auth', async () => {
+    ApiConfig.init(
+      TestConstants.TEST_API_URL,
+      DataverseApiAuthMechanism.BEARER_TOKEN,
+      undefined,
+      TestConstants.TEST_BEARER_TOKEN_LOCAL_STORAGE_KEY
+    )
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: jest.fn().mockResolvedValue({
+        data: {
+          signedUrl: 'https://signed.dataset'
+        }
+      })
+    } as unknown as Response)
+
+    global.fetch = fetchMock as typeof fetch
+
+    const actual = await sut.submitGuestbookForDatasetDownload(123, guestbookResponse, 'original')
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${TestConstants.TEST_API_URL}/access/dataset/123?signed=true&format=original`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${TestConstants.TEST_DUMMY_BEARER_TOKEN}`
+        },
+        credentials: 'omit',
+        body: JSON.stringify(guestbookResponse)
+      }
+    )
+    expect(actual).toBe('https://signed.dataset')
+  })
+})

--- a/test/unit/access/AccessRepository.test.ts
+++ b/test/unit/access/AccessRepository.test.ts
@@ -4,6 +4,7 @@
 
 import { AccessRepository } from '../../../src/access/infra/repositories/AccessRepository'
 import { GuestbookResponseDTO } from '../../../src/access/domain/dtos/GuestbookResponseDTO'
+import { WriteError } from '../../../src/core/domain/repositories/WriteError'
 import {
   ApiConfig,
   DataverseApiAuthMechanism
@@ -12,6 +13,7 @@ import { TestConstants } from '../../testHelpers/TestConstants'
 
 describe('AccessRepository', () => {
   const sut = new AccessRepository()
+  const originalFetch = global.fetch
   const guestbookResponse: GuestbookResponseDTO = {
     guestbookResponse: {
       answers: [{ id: 1, value: 'question 1' }]
@@ -26,6 +28,7 @@ describe('AccessRepository', () => {
   })
 
   afterEach(() => {
+    global.fetch = originalFetch
     window.localStorage.clear()
   })
 
@@ -65,5 +68,53 @@ describe('AccessRepository', () => {
       }
     )
     expect(actual).toBe('https://signed.dataset')
+  })
+
+  test('parses signed url from a JSON body when content-type is incorrect', async () => {
+    ApiConfig.init(
+      TestConstants.TEST_API_URL,
+      DataverseApiAuthMechanism.BEARER_TOKEN,
+      undefined,
+      TestConstants.TEST_BEARER_TOKEN_LOCAL_STORAGE_KEY
+    )
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'text/plain' }),
+      text: jest
+        .fn()
+        .mockResolvedValue(JSON.stringify({ data: { signedUrl: 'https://signed.text' } }))
+    } as unknown as Response)
+
+    global.fetch = fetchMock as typeof fetch
+
+    await expect(sut.submitGuestbookForDatasetDownload(123, guestbookResponse)).resolves.toBe(
+      'https://signed.text'
+    )
+  })
+
+  test('throws WriteError when signedUrl is missing from a successful response', async () => {
+    ApiConfig.init(
+      TestConstants.TEST_API_URL,
+      DataverseApiAuthMechanism.BEARER_TOKEN,
+      undefined,
+      TestConstants.TEST_BEARER_TOKEN_LOCAL_STORAGE_KEY
+    )
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: jest.fn().mockResolvedValue({
+        data: {}
+      })
+    } as unknown as Response)
+
+    global.fetch = fetchMock as typeof fetch
+
+    await expect(sut.submitGuestbookForDatasetDownload(123, guestbookResponse)).rejects.toThrow(
+      new WriteError('Missing signedUrl in access download response.')
+    )
   })
 })


### PR DESCRIPTION


## What this PR does / why we need it:
The Access API for download sometimes uses session cookies for authentication, which can be a problem if the user is running JSF and SPA in the same browser.  To work around this, this change omits session cookies for all API calls in AccessRepository.

## Which issue(s) this PR closes:

- Closes #437

## Related Dataverse PRs:

(https://github.com/IQSS/dataverse/issues/12267)


## Suggestions on how to test this:
Review tests
