### PR TITLE
Setup TS change to allow skipping the containers setup.

### DIFF
--- a/test/environment/setup.ts
+++ b/test/environment/setup.ts
@@ -15,11 +15,14 @@ const API_KEY_USER_ENDPOINT = '/builtin-users/dataverseAdmin/api-token'
 const API_KEY_USER_PASSWORD = 'admin1'
 
 export default async function setupTestEnvironment(): Promise<void> {
-  await setupContainers()
+  await setupContainers() //Set skipContainers to true to skip container setup and run tests against an already running instance
   await setupApiKey()
 }
 
-async function setupContainers(): Promise<void> {
+async function setupContainers(skipContainers?: boolean): Promise<void> {
+  if (skipContainers) {
+    return
+  }
   console.log('Cleaning up old container volumes...')
   fs.rmSync(`${__dirname}/docker-dev-volumes`, { recursive: true, force: true })
   console.log('Running test containers...')

--- a/test/environment/setup.ts
+++ b/test/environment/setup.ts
@@ -9,13 +9,13 @@ const CONTAINER_DATAVERSE_BOOTSTRAP_NAME = 'test_dataverse_bootstrap'
 const CONTAINER_DATAVERSE_BOOTSTRAP_END_MESSAGE =
   'Done, your instance has been configured for development. Have a nice day!'
 const CONTAINERS_STARTUP_TIMEOUT = 300000
-
+const SKIP_CONTAINERS = process.env.SKIP_CONTAINERS === 'true' // Set this environment variable to true to skip container setup and run tests against an already running instance
 const API_ALLOW_TOKEN_LOOKUP_ENDPOINT = '/admin/settings/:AllowApiTokenLookupViaApi'
 const API_KEY_USER_ENDPOINT = '/builtin-users/dataverseAdmin/api-token'
 const API_KEY_USER_PASSWORD = 'admin1'
 
 export default async function setupTestEnvironment(): Promise<void> {
-  await setupContainers() //Set skipContainers to true to skip container setup and run tests against an already running instance
+  await setupContainers(SKIP_CONTAINERS) //Set skipContainers to true to skip container setup and run tests against an already running instance
   await setupApiKey()
 }
 

--- a/test/integration/collections/CollectionsRepository.test.ts
+++ b/test/integration/collections/CollectionsRepository.test.ts
@@ -997,7 +997,7 @@ describe('CollectionsRepository', () => {
       // TODO: uncomment this test when https://github.com/IQSS/dataverse/issues/12027 is fixed
       //  const expectedDatasetCitationFragment = `Admin, Dataverse; Owner, Dataverse, ${currentYear}, "Dataset created using the createDataset use case`
       const expectedDatasetDescription = 'Dataset created using the createDataset use case'
-      const expectedFileName = 'test-file-4.tab'
+      const expectedFileName = 'test-file-4.tsv'
       const expectedCollectionsName = 'Scientific Research'
 
       expect(actualFilePreview.checksum?.type).toBe('MD5')


### PR DESCRIPTION
## What this PR does / why we need it:

When running tests, containers are started to run against but there are use cases like development or more complicated configurations that would be helpful to run against local installations that have been set up in a different way.

You can run a test for example with 
```npm run test GetCollection``` 
or 
```SKIP_CONTAINERS=true npm run test GetCollection```

You could also set ```const SKIP_CONTAINERS``` in setup.ts
