### PR TITLE
tests fix

### DIFF
--- a/test/integration/collections/CollectionsRepository.test.ts
+++ b/test/integration/collections/CollectionsRepository.test.ts
@@ -910,7 +910,7 @@ describe('CollectionsRepository', () => {
 
   describe('getCollectionItems for published tabular file', () => {
     let testDatasetIds: CreatedDatasetIdentifiers
-    const testTextFile4Name = 'test-file-4.tab'
+    const testTextFile4Name = 'test-file-4.tsv'
     const testSubCollectionAlias = 'collectionsRepositoryTestSubCollection'
 
     beforeAll(async () => {

--- a/test/integration/collections/CollectionsRepository.test.ts
+++ b/test/integration/collections/CollectionsRepository.test.ts
@@ -910,7 +910,7 @@ describe('CollectionsRepository', () => {
 
   describe('getCollectionItems for published tabular file', () => {
     let testDatasetIds: CreatedDatasetIdentifiers
-    const testTextFile4Name = 'test-file-4.tsv'
+    const testTextFile4Name = 'test-file-4.tab'
     const testSubCollectionAlias = 'collectionsRepositoryTestSubCollection'
 
     beforeAll(async () => {
@@ -997,7 +997,7 @@ describe('CollectionsRepository', () => {
       // TODO: uncomment this test when https://github.com/IQSS/dataverse/issues/12027 is fixed
       //  const expectedDatasetCitationFragment = `Admin, Dataverse; Owner, Dataverse, ${currentYear}, "Dataset created using the createDataset use case`
       const expectedDatasetDescription = 'Dataset created using the createDataset use case'
-      const expectedFileName = 'test-file-4.tab'
+      const expectedFileName = 'test-file-4.tsv'
       const expectedCollectionsName = 'Scientific Research'
 
       expect(actualFilePreview.checksum?.type).toBe('MD5')


### PR DESCRIPTION
## What this PR does / why we need it:

There was a change on DV with https://github.com/IQSS/dataverse/pull/12145 that caused tests to fail, this is meant to be a temporary patch since it seems there is a bug with this PR.

We did a few testing and provided a .tsv file and received .tab response.
When providing a .tab file we received a .tsv response.
=