### PR TITLE
452 fix flaky test

### DIFF
--- a/test/functional/datasets/GetDatasetAvailableDatasetTypes.test.ts
+++ b/test/functional/datasets/GetDatasetAvailableDatasetTypes.test.ts
@@ -24,7 +24,7 @@ describe('getDatasetAvailableDatasetTypes', () => {
         displayName: 'Dataset'
       }
 
-      expect(actualDatasetTypes).toContain(expectedDatasetType)
+      expect(actualDatasetTypes).toContainEqual(expectedDatasetType)
     })
   })
 })

--- a/test/functional/datasets/GetDatasetAvailableDatasetTypes.test.ts
+++ b/test/functional/datasets/GetDatasetAvailableDatasetTypes.test.ts
@@ -14,18 +14,17 @@ describe('getDatasetAvailableDatasetTypes', () => {
 
     test('should return available dataset types', async () => {
       const actualDatasetTypes: DatasetType[] = await getDatasetAvailableDatasetTypes.execute()
-      const expectedDatasetTypes = [
-        {
-          id: 1,
-          name: 'dataset',
-          linkedMetadataBlocks: [],
-          availableLicenses: [],
-          description:
-            'A study, experiment, set of observations, or publication. A dataset can comprise a single file or multiple files.',
-          displayName: 'Dataset'
-        }
-      ]
-      expect(actualDatasetTypes).toEqual(expectedDatasetTypes)
+      const expectedDatasetType = {
+        id: 1,
+        name: 'dataset',
+        linkedMetadataBlocks: [],
+        availableLicenses: [],
+        description:
+          'A study, experiment, set of observations, or publication. A dataset can comprise a single file or multiple files.',
+        displayName: 'Dataset'
+      }
+
+      expect(actualDatasetTypes).toContain(expectedDatasetType)
     })
   })
 })


### PR DESCRIPTION
## What this PR does / why we need it:
Updates GetDatasetAvailableDatasetTypes so it doesn't fail if there is an additional datasetType returned due to a concurrent test.

## Which issue(s) this PR closes:

- Closes #452 


