### PR TITLE
Use Cases of Editing Guestbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog follows the principles of [Keep a Changelog](https://keepachangel
 
 ### Added
 
+- Guestbooke: Added `editGuestbook` use case.
 - Guestbooks: Added `getGuestbookResponsesByGuestbookId` use case and repository support for retrieving paginated guestbook responses with total count as structured JSON.
 - Guestbooks: Added `downloadGuestbookResponsesByCollectionId` and `downloadGuestbookResponsesOfAGuestbook` use cases and repository support for exporting guestbook responses as raw CSV content.
 - Guestbooks: Added optional `includeStats` support to `getGuestbooksByCollectionId`, returning `usageCount` and `responseCount` when requested.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This changelog follows the principles of [Keep a Changelog](https://keepachangel
 
 ### Added
 
-- Guestbooke: Added `editGuestbook` use case.
+- Guestbooks: Added `editGuestbook` use case.
 - Guestbooks: Added `getGuestbookResponsesByGuestbookId` use case and repository support for retrieving paginated guestbook responses with total count as structured JSON.
 - Guestbooks: Added `downloadGuestbookResponsesByCollectionId` and `downloadGuestbookResponsesOfAGuestbook` use cases and repository support for exporting guestbook responses as raw CSV content.
 - Guestbooks: Added optional `includeStats` support to `getGuestbooksByCollectionId`, returning `usageCount` and `responseCount` when requested.

--- a/docs/useCases.md
+++ b/docs/useCases.md
@@ -3304,7 +3304,14 @@ import { editGuestbook } from '@iqss/dataverse-client-javascript'
 
 const guestbookId = 123
 const guestbook: EditGuestbookDTO = {
-  name: 'new name'
+  name: 'new name',
+  enabled: true,
+  emailRequired: true,
+  nameRequired: true,
+  institutionRequired: false,
+  positionRequired: false,
+  createTime: '2026-06-12T00:00:00Z',
+  customQuestions: []
 }
 
 editGuestbook.execute(guestbookId, guestbook).then(() => {

--- a/docs/useCases.md
+++ b/docs/useCases.md
@@ -143,6 +143,7 @@ The different use cases currently available in the package are classified below,
     - [Download Guestbook Responses Of A Guestbook](#download-guestbook-responses-of-a-guestbook)
   - [Guestbooks write use cases](#guestbooks-write-use-cases)
     - [Create a Guestbook](#create-a-guestbook)
+    - [Edit a Guestbook](#edit-a-guestbook)
     - [Set Guestbook Enabled](#set-guestbook-enabled)
     - [Assign Dataset Guestbook](#assign-dataset-guestbook)
     - [Remove Dataset Guestbook](#remove-dataset-guestbook)
@@ -3172,6 +3173,7 @@ _See [use case](../src/guestbooks/domain/useCases/GetGuestbook.ts) implementatio
 
 Returns all [Guestbook](../src/guestbooks/domain/models/Guestbook.ts) entries available for a collection.
 Set `includeStats` to `true` to include `usageCount` and `responseCount` for each guestbook.
+Set `includeInherited` to `true` to include the collection's guestbooks and guestbooks from the collection's hierarchical owners.
 
 ##### Example call:
 
@@ -3180,9 +3182,10 @@ import { getGuestbooksByCollectionId } from '@iqss/dataverse-client-javascript'
 
 const collectionIdOrAlias = 'root'
 const includeStats = true
+const includeInherited = true
 
 getGuestbooksByCollectionId
-  .execute(collectionIdOrAlias, includeStats)
+  .execute(collectionIdOrAlias, includeStats, includeInherited)
   .then((guestbooks: Guestbook[]) => {
     /* ... */
   })
@@ -3289,6 +3292,27 @@ createGuestbook.execute(guestbook, collectionIdOrAlias).then(() => {
 ```
 
 _See [use case](../src/guestbooks/domain/useCases/CreateGuestbook.ts) implementation_.
+
+#### Edit a Guestbook
+
+Edits an existing guestbook using [EditGuestbookDTO](../src/guestbooks/domain/dtos/EditGuestbookDTO.ts).
+
+##### Example call:
+
+```typescript
+import { editGuestbook } from '@iqss/dataverse-client-javascript'
+
+const guestbookId = 123
+const guestbook: EditGuestbookDTO = {
+  name: 'new name'
+}
+
+editGuestbook.execute(guestbookId, guestbook).then(() => {
+  /* ... */
+})
+```
+
+_See [use case](../src/guestbooks/domain/useCases/EditGuestbook.ts) implementation_.
 
 #### Set Guestbook Enabled
 

--- a/src/guestbooks/domain/dtos/EditGuestbookDTO.ts
+++ b/src/guestbooks/domain/dtos/EditGuestbookDTO.ts
@@ -25,5 +25,5 @@ export interface EditGuestbookDTO {
   institutionRequired: boolean
   positionRequired: boolean
   createTime: string
-  customQuestions?: EditGuestbookCustomQuestionDTO[]
+  customQuestions: EditGuestbookCustomQuestionDTO[]
 }

--- a/src/guestbooks/domain/dtos/EditGuestbookDTO.ts
+++ b/src/guestbooks/domain/dtos/EditGuestbookDTO.ts
@@ -1,0 +1,29 @@
+export type EditGuestbookQuestionTypeDTO = 'text' | 'textarea' | 'options'
+
+export interface EditGuestbookOptionDTO {
+  id?: number | string
+  value: string
+  displayOrder: number
+}
+
+export interface EditGuestbookCustomQuestionDTO {
+  id?: number | string
+  question: string
+  required: boolean
+  displayOrder: number
+  type: EditGuestbookQuestionTypeDTO
+  hidden: boolean
+  optionValues?: EditGuestbookOptionDTO[]
+}
+
+export interface EditGuestbookDTO {
+  id?: number | string
+  name: string
+  enabled: boolean
+  emailRequired: boolean
+  nameRequired: boolean
+  institutionRequired: boolean
+  positionRequired: boolean
+  customQuestions: EditGuestbookCustomQuestionDTO[]
+  createTime?: string
+}

--- a/src/guestbooks/domain/dtos/EditGuestbookDTO.ts
+++ b/src/guestbooks/domain/dtos/EditGuestbookDTO.ts
@@ -17,7 +17,6 @@ export interface EditGuestbookCustomQuestionDTO {
 }
 
 export interface EditGuestbookDTO {
-  id?: number
   name: string
   enabled: boolean
   emailRequired: boolean
@@ -25,5 +24,5 @@ export interface EditGuestbookDTO {
   institutionRequired: boolean
   positionRequired: boolean
   createTime: string
-  customQuestions: EditGuestbookCustomQuestionDTO[]
+  customQuestions?: EditGuestbookCustomQuestionDTO[]
 }

--- a/src/guestbooks/domain/dtos/EditGuestbookDTO.ts
+++ b/src/guestbooks/domain/dtos/EditGuestbookDTO.ts
@@ -1,13 +1,13 @@
 export type EditGuestbookQuestionTypeDTO = 'text' | 'textarea' | 'options'
 
 export interface EditGuestbookOptionDTO {
-  id?: number | string
+  id?: number
   value: string
   displayOrder: number
 }
 
 export interface EditGuestbookCustomQuestionDTO {
-  id?: number | string
+  id?: number
   question: string
   required: boolean
   displayOrder: number
@@ -17,13 +17,13 @@ export interface EditGuestbookCustomQuestionDTO {
 }
 
 export interface EditGuestbookDTO {
-  id?: number | string
+  id?: number
   name: string
   enabled: boolean
   emailRequired: boolean
   nameRequired: boolean
   institutionRequired: boolean
   positionRequired: boolean
-  customQuestions: EditGuestbookCustomQuestionDTO[]
-  createTime?: string
+  createTime: string
+  customQuestions?: EditGuestbookCustomQuestionDTO[]
 }

--- a/src/guestbooks/domain/models/Guestbook.ts
+++ b/src/guestbooks/domain/models/Guestbook.ts
@@ -1,11 +1,13 @@
 export type GuestbookQuestionType = 'text' | 'textarea' | 'options'
 
 export interface GuestbookOption {
+  id?: number | string
   value: string
   displayOrder: number
 }
 
 export interface GuestbookCustomQuestion {
+  id?: number | string
   question: string
   required: boolean
   displayOrder: number

--- a/src/guestbooks/domain/models/Guestbook.ts
+++ b/src/guestbooks/domain/models/Guestbook.ts
@@ -1,13 +1,13 @@
 export type GuestbookQuestionType = 'text' | 'textarea' | 'options'
 
 export interface GuestbookOption {
-  id?: number | string
+  id?: number
   value: string
   displayOrder: number
 }
 
 export interface GuestbookCustomQuestion {
-  id?: number | string
+  id?: number
   question: string
   required: boolean
   displayOrder: number

--- a/src/guestbooks/domain/repositories/IGuestbooksRepository.ts
+++ b/src/guestbooks/domain/repositories/IGuestbooksRepository.ts
@@ -1,4 +1,5 @@
 import { CreateGuestbookDTO } from '../dtos/CreateGuestbookDTO'
+import { EditGuestbookDTO } from '../dtos/EditGuestbookDTO'
 import { Guestbook } from '../models/Guestbook'
 import { GuestbookResponseSubset } from '../models/GuestbookResponse'
 
@@ -7,6 +8,7 @@ export interface IGuestbooksRepository {
     collectionIdOrAlias: number | string,
     guestbook: CreateGuestbookDTO
   ): Promise<number>
+  editGuestbook(guestbookId: number, guestbook: EditGuestbookDTO): Promise<void>
   getGuestbook(guestbookId: number): Promise<Guestbook>
   getGuestbooksByCollectionId(
     collectionIdOrAlias: number | string,

--- a/src/guestbooks/domain/useCases/EditGuestbook.ts
+++ b/src/guestbooks/domain/useCases/EditGuestbook.ts
@@ -1,0 +1,17 @@
+import { EditGuestbookDTO } from '../dtos/EditGuestbookDTO'
+import { IGuestbooksRepository } from '../repositories/IGuestbooksRepository'
+
+export class EditGuestbook {
+  constructor(private readonly guestbooksRepository: IGuestbooksRepository) {}
+
+  /**
+   * Edits an existing guestbook.
+   *
+   * @param {number} guestbookId - Guestbook identifier.
+   * @param {EditGuestbookDTO} guestbook - Guestbook edit payload.
+   * @returns {Promise<void>}
+   */
+  async execute(guestbookId: number, guestbook: EditGuestbookDTO): Promise<void> {
+    return await this.guestbooksRepository.editGuestbook(guestbookId, guestbook)
+  }
+}

--- a/src/guestbooks/index.ts
+++ b/src/guestbooks/index.ts
@@ -1,5 +1,6 @@
 import { GuestbooksRepository } from './infra/repositories/GuestbooksRepository'
 import { CreateGuestbook } from './domain/useCases/CreateGuestbook'
+import { EditGuestbook } from './domain/useCases/EditGuestbook'
 import { DownloadGuestbookResponsesByCollectionId } from './domain/useCases/DownloadGuestbookResponsesByCollectionId'
 import { DownloadGuestbookResponsesOfAGuestbook } from './domain/useCases/DownloadGuestbookResponsesOfAGuestbook'
 import { GetGuestbook } from './domain/useCases/GetGuestbook'
@@ -12,6 +13,7 @@ import { RemoveDatasetGuestbook } from './domain/useCases/RemoveDatasetGuestbook
 const guestbooksRepository = new GuestbooksRepository()
 
 const createGuestbook = new CreateGuestbook(guestbooksRepository)
+const editGuestbook = new EditGuestbook(guestbooksRepository)
 const downloadGuestbookResponsesByCollectionId = new DownloadGuestbookResponsesByCollectionId(
   guestbooksRepository
 )
@@ -29,6 +31,7 @@ const removeDatasetGuestbook = new RemoveDatasetGuestbook(guestbooksRepository)
 
 export {
   createGuestbook,
+  editGuestbook,
   downloadGuestbookResponsesByCollectionId,
   downloadGuestbookResponsesOfAGuestbook,
   getGuestbook,
@@ -44,6 +47,11 @@ export {
   CreateGuestbookCustomQuestionDTO,
   CreateGuestbookOptionDTO
 } from './domain/dtos/CreateGuestbookDTO'
+export {
+  EditGuestbookDTO,
+  EditGuestbookCustomQuestionDTO,
+  EditGuestbookOptionDTO
+} from './domain/dtos/EditGuestbookDTO'
 export {
   GuestbookResponsesDTO,
   GuestbookResponsesPaginationDTO

--- a/src/guestbooks/infra/repositories/GuestbooksRepository.ts
+++ b/src/guestbooks/infra/repositories/GuestbooksRepository.ts
@@ -1,5 +1,6 @@
 import { ApiRepository } from '../../../core/infra/repositories/ApiRepository'
 import { CreateGuestbookDTO } from '../../domain/dtos/CreateGuestbookDTO'
+import { EditGuestbookDTO } from '../../domain/dtos/EditGuestbookDTO'
 import { GuestbookResponsesDTO } from '../../domain/dtos/GuestbookResponsesDTO'
 import { Guestbook } from '../../domain/models/Guestbook'
 import { GuestbookResponseSubset } from '../../domain/models/GuestbookResponse'
@@ -19,6 +20,17 @@ export class GuestbooksRepository extends ApiRepository implements IGuestbooksRe
       guestbook
     )
       .then((response) => response.data.data.id)
+      .catch((error) => {
+        throw error
+      })
+  }
+
+  public async editGuestbook(guestbookId: number, guestbook: EditGuestbookDTO): Promise<void> {
+    return this.doPut(
+      this.buildApiEndpoint(this.guestbooksResourceName, undefined, guestbookId),
+      guestbook
+    )
+      .then(() => undefined)
       .catch((error) => {
         throw error
       })

--- a/src/guestbooks/infra/repositories/GuestbooksRepository.ts
+++ b/src/guestbooks/infra/repositories/GuestbooksRepository.ts
@@ -26,14 +26,10 @@ export class GuestbooksRepository extends ApiRepository implements IGuestbooksRe
   }
 
   public async editGuestbook(guestbookId: number, guestbook: EditGuestbookDTO): Promise<void> {
-    return this.doPut(
+    await this.doPut(
       this.buildApiEndpoint(this.guestbooksResourceName, undefined, guestbookId),
       guestbook
     )
-      .then(() => undefined)
-      .catch((error) => {
-        throw error
-      })
   }
 
   public async getGuestbook(guestbookId: number): Promise<Guestbook> {

--- a/test/integration/guestbooks/GuestbooksRepository.test.ts
+++ b/test/integration/guestbooks/GuestbooksRepository.test.ts
@@ -384,7 +384,6 @@ describe('GuestbooksRepository', () => {
       currentGuestbook: Awaited<ReturnType<GuestbooksRepository['getGuestbook']>>,
       overrides: Partial<EditGuestbookDTO>
     ): EditGuestbookDTO => ({
-      id: currentGuestbook.id,
       name: currentGuestbook.name,
       enabled: currentGuestbook.enabled,
       emailRequired: currentGuestbook.emailRequired,
@@ -394,6 +393,106 @@ describe('GuestbooksRepository', () => {
       createTime: currentGuestbook.createTime,
       customQuestions: currentGuestbook.customQuestions ?? [],
       ...overrides
+    })
+
+    test('should be able to update a single field', async () => {
+      const uniqueSuffix = Date.now().toString()
+      const guestbookId = await sut.createGuestbook(testCollectionId, {
+        ...createGuestbookDTO,
+        name: `guestbook edit email required ${uniqueSuffix}`,
+        emailRequired: true
+      })
+      const guestbookBeforeEdit = await sut.getGuestbook(guestbookId)
+      expect(guestbookBeforeEdit.emailRequired).toBe(true)
+
+      const editedGuestbook = buildEditGuestbookDTO(guestbookBeforeEdit, {
+        emailRequired: false
+      })
+
+      await sut.editGuestbook(guestbookId, editedGuestbook)
+
+      const actual = await sut.getGuestbook(guestbookId)
+      expect(actual.emailRequired).toBe(false)
+    })
+
+    test('should update existing custom question when custom question id is provided', async () => {
+      const uniqueSuffix = Date.now().toString()
+      const guestbookId = await sut.createGuestbook(testCollectionId, {
+        ...createGuestbookDTO,
+        name: `guestbook edit custom question with id ${uniqueSuffix}`
+      })
+      const guestbookBeforeEdit = await sut.getGuestbook(guestbookId)
+      const existingQuestion = guestbookBeforeEdit.customQuestions[0]
+
+      const editedGuestbook = buildEditGuestbookDTO(guestbookBeforeEdit, {
+        name: `edited custom question with id guestbook ${uniqueSuffix}`,
+        customQuestions: [
+          {
+            id: existingQuestion.id,
+            question: `updated custom question ${uniqueSuffix}`,
+            required: false,
+            displayOrder: 0,
+            type: 'textarea',
+            hidden: false
+          }
+        ]
+      })
+
+      await sut.editGuestbook(guestbookId, editedGuestbook)
+
+      const actual = await sut.getGuestbook(guestbookId)
+      expect(actual.name).toBe(editedGuestbook.name)
+      expect(actual.customQuestions).toHaveLength(1)
+      expect(actual.customQuestions[0]).toEqual(
+        expect.objectContaining({
+          id: existingQuestion.id,
+          question: editedGuestbook.customQuestions?.[0].question,
+          required: false,
+          displayOrder: 0,
+          type: 'textarea',
+          hidden: false
+        })
+      )
+    })
+
+    test('should create replacement custom question when custom question id is not provided', async () => {
+      const uniqueSuffix = Date.now().toString()
+      const guestbookId = await sut.createGuestbook(testCollectionId, {
+        ...createGuestbookDTO,
+        name: `guestbook edit custom question without id ${uniqueSuffix}`
+      })
+      const guestbookBeforeEdit = await sut.getGuestbook(guestbookId)
+      const existingQuestion = guestbookBeforeEdit.customQuestions[0]
+
+      const editedGuestbook = buildEditGuestbookDTO(guestbookBeforeEdit, {
+        name: `edited custom question without id guestbook ${uniqueSuffix}`,
+        customQuestions: [
+          {
+            question: `replacement custom question ${uniqueSuffix}`,
+            required: false,
+            displayOrder: 0,
+            type: 'textarea',
+            hidden: false
+          }
+        ]
+      })
+
+      await sut.editGuestbook(guestbookId, editedGuestbook)
+
+      const actual = await sut.getGuestbook(guestbookId)
+      expect(actual.name).toBe(editedGuestbook.name)
+      expect(actual.customQuestions).toHaveLength(1)
+      expect(actual.customQuestions[0]).toEqual(
+        expect.objectContaining({
+          question: editedGuestbook.customQuestions?.[0].question,
+          required: false,
+          displayOrder: 0,
+          type: 'textarea',
+          hidden: false
+        })
+      )
+      expect(actual.customQuestions[0].id).toBeDefined()
+      expect(actual.customQuestions[0].id).not.toBe(existingQuestion.id)
     })
 
     test('should edit guestbook without custom questions', async () => {
@@ -459,7 +558,7 @@ describe('GuestbooksRepository', () => {
       expect(actual.customQuestions).toHaveLength(1)
       expect(actual.customQuestions[0]).toEqual(
         expect.objectContaining({
-          question: editedGuestbook.customQuestions[0].question,
+          question: editedGuestbook.customQuestions?.[0].question,
           required: false,
           displayOrder: 0,
           type: 'textarea',
@@ -501,7 +600,7 @@ describe('GuestbooksRepository', () => {
       expect(actual.customQuestions).toHaveLength(1)
       expect(actual.customQuestions[0]).toEqual(
         expect.objectContaining({
-          question: editedGuestbook.customQuestions[0].question,
+          question: editedGuestbook.customQuestions?.[0].question,
           required: true,
           displayOrder: 0,
           type: 'options',
@@ -536,7 +635,9 @@ describe('GuestbooksRepository', () => {
     })
 
     test('should return error when guestbook does not exist', async () => {
-      await expect(sut.editGuestbook(999999, createGuestbookDTO)).rejects.toThrow(WriteError)
+      await expect(
+        sut.editGuestbook(999999, { ...createGuestbookDTO, createTime: '2026-06-12T00:00:00Z' })
+      ).rejects.toThrow(WriteError)
     })
   })
 

--- a/test/integration/guestbooks/GuestbooksRepository.test.ts
+++ b/test/integration/guestbooks/GuestbooksRepository.test.ts
@@ -2,6 +2,7 @@ import { DataverseApiAuthMechanism } from '../../../src/core/infra/repositories/
 import { ApiConfig, ReadError, WriteError } from '../../../src'
 import { GuestbooksRepository } from '../../../src/guestbooks/infra/repositories/GuestbooksRepository'
 import { CreateGuestbookDTO } from '../../../src/guestbooks/domain/dtos/CreateGuestbookDTO'
+import { EditGuestbookDTO } from '../../../src/guestbooks/domain/dtos/EditGuestbookDTO'
 import { TestConstants } from '../../testHelpers/TestConstants'
 import {
   createDataset,
@@ -375,6 +376,167 @@ describe('GuestbooksRepository', () => {
 
     test('should return error when guestbook does not exist', async () => {
       await expect(sut.getGuestbook(999999)).rejects.toThrow(ReadError)
+    })
+  })
+
+  describe('editGuestbook', () => {
+    const buildEditGuestbookDTO = (
+      currentGuestbook: Awaited<ReturnType<GuestbooksRepository['getGuestbook']>>,
+      overrides: Partial<EditGuestbookDTO>
+    ): EditGuestbookDTO => ({
+      id: currentGuestbook.id,
+      name: currentGuestbook.name,
+      enabled: currentGuestbook.enabled,
+      emailRequired: currentGuestbook.emailRequired,
+      nameRequired: currentGuestbook.nameRequired,
+      institutionRequired: currentGuestbook.institutionRequired,
+      positionRequired: currentGuestbook.positionRequired,
+      createTime: currentGuestbook.createTime,
+      customQuestions: currentGuestbook.customQuestions ?? [],
+      ...overrides
+    })
+
+    test('should edit guestbook without custom questions', async () => {
+      const uniqueSuffix = Date.now().toString()
+      const guestbookId = await sut.createGuestbook(testCollectionId, {
+        ...createGuestbookDTO,
+        name: `guestbook edit no questions ${uniqueSuffix}`,
+        enabled: false,
+        emailRequired: false,
+        nameRequired: false,
+        customQuestions: []
+      })
+      const guestbookBeforeEdit = await sut.getGuestbook(guestbookId)
+
+      const editedGuestbook = buildEditGuestbookDTO(guestbookBeforeEdit, {
+        name: `edited guestbook ${uniqueSuffix}`,
+        enabled: true,
+        emailRequired: true,
+        nameRequired: true,
+        institutionRequired: true,
+        positionRequired: false,
+        customQuestions: []
+      })
+
+      await sut.editGuestbook(guestbookId, editedGuestbook)
+
+      const actual = await sut.getGuestbook(guestbookId)
+      expect(actual.name).toBe(editedGuestbook.name)
+      expect(actual.enabled).toBe(true)
+      expect(actual.emailRequired).toBe(true)
+      expect(actual.nameRequired).toBe(true)
+      expect(actual.institutionRequired).toBe(true)
+      expect(actual.positionRequired).toBe(false)
+      expect(actual.customQuestions ?? []).toHaveLength(0)
+    })
+
+    test('should edit guestbook with a textarea custom question', async () => {
+      const uniqueSuffix = Date.now().toString()
+      const guestbookId = await sut.createGuestbook(testCollectionId, {
+        ...createGuestbookDTO,
+        name: `guestbook edit textarea ${uniqueSuffix}`,
+        customQuestions: []
+      })
+      const guestbookBeforeEdit = await sut.getGuestbook(guestbookId)
+
+      const editedGuestbook = buildEditGuestbookDTO(guestbookBeforeEdit, {
+        name: `edited textarea guestbook ${uniqueSuffix}`,
+        customQuestions: [
+          {
+            question: `textarea question ${uniqueSuffix}`,
+            required: false,
+            displayOrder: 0,
+            type: 'textarea',
+            hidden: false
+          }
+        ]
+      })
+
+      await sut.editGuestbook(guestbookId, editedGuestbook)
+
+      const actual = await sut.getGuestbook(guestbookId)
+      expect(actual.name).toBe(editedGuestbook.name)
+      expect(actual.customQuestions).toHaveLength(1)
+      expect(actual.customQuestions[0]).toEqual(
+        expect.objectContaining({
+          question: editedGuestbook.customQuestions[0].question,
+          required: false,
+          displayOrder: 0,
+          type: 'textarea',
+          hidden: false
+        })
+      )
+    })
+
+    test('should edit guestbook with an options custom question', async () => {
+      const uniqueSuffix = Date.now().toString()
+      const guestbookId = await sut.createGuestbook(testCollectionId, {
+        ...createGuestbookDTO,
+        name: `guestbook edit options ${uniqueSuffix}`,
+        customQuestions: []
+      })
+      const guestbookBeforeEdit = await sut.getGuestbook(guestbookId)
+
+      const editedGuestbook = buildEditGuestbookDTO(guestbookBeforeEdit, {
+        name: `edited options guestbook ${uniqueSuffix}`,
+        customQuestions: [
+          {
+            question: `options question ${uniqueSuffix}`,
+            required: true,
+            displayOrder: 0,
+            type: 'options',
+            hidden: false,
+            optionValues: [
+              { value: 'Red', displayOrder: 0 },
+              { value: 'Blue', displayOrder: 1 }
+            ]
+          }
+        ]
+      })
+
+      await sut.editGuestbook(guestbookId, editedGuestbook)
+
+      const actual = await sut.getGuestbook(guestbookId)
+      expect(actual.name).toBe(editedGuestbook.name)
+      expect(actual.customQuestions).toHaveLength(1)
+      expect(actual.customQuestions[0]).toEqual(
+        expect.objectContaining({
+          question: editedGuestbook.customQuestions[0].question,
+          required: true,
+          displayOrder: 0,
+          type: 'options',
+          hidden: false,
+          optionValues: expect.arrayContaining([
+            expect.objectContaining({ value: 'Red', displayOrder: 0 }),
+            expect.objectContaining({ value: 'Blue', displayOrder: 1 })
+          ])
+        })
+      )
+    })
+
+    test('should remove custom questions when custom question field is empty', async () => {
+      const uniqueSuffix = Date.now().toString()
+      const guestbookId = await sut.createGuestbook(testCollectionId, {
+        ...createGuestbookDTO,
+        name: `guestbook edit empty field ${uniqueSuffix}`
+      })
+      const guestbookBeforeEdit = await sut.getGuestbook(guestbookId)
+      expect(guestbookBeforeEdit.customQuestions).toHaveLength(3)
+
+      const editedGuestbook = buildEditGuestbookDTO(guestbookBeforeEdit, {
+        name: `edited empty field guestbook ${uniqueSuffix}`,
+        customQuestions: []
+      })
+
+      await sut.editGuestbook(guestbookId, editedGuestbook)
+
+      const actual = await sut.getGuestbook(guestbookId)
+      expect(actual.name).toBe(editedGuestbook.name)
+      expect(actual.customQuestions ?? []).toHaveLength(0)
+    })
+
+    test('should return error when guestbook does not exist', async () => {
+      await expect(sut.editGuestbook(999999, createGuestbookDTO)).rejects.toThrow(WriteError)
     })
   })
 

--- a/test/integration/guestbooks/GuestbooksRepository.test.ts
+++ b/test/integration/guestbooks/GuestbooksRepository.test.ts
@@ -395,26 +395,6 @@ describe('GuestbooksRepository', () => {
       ...overrides
     })
 
-    test('should be able to update a single field', async () => {
-      const uniqueSuffix = Date.now().toString()
-      const guestbookId = await sut.createGuestbook(testCollectionId, {
-        ...createGuestbookDTO,
-        name: `guestbook edit email required ${uniqueSuffix}`,
-        emailRequired: true
-      })
-      const guestbookBeforeEdit = await sut.getGuestbook(guestbookId)
-      expect(guestbookBeforeEdit.emailRequired).toBe(true)
-
-      const editedGuestbook = buildEditGuestbookDTO(guestbookBeforeEdit, {
-        emailRequired: false
-      })
-
-      await sut.editGuestbook(guestbookId, editedGuestbook)
-
-      const actual = await sut.getGuestbook(guestbookId)
-      expect(actual.emailRequired).toBe(false)
-    })
-
     test('should update existing custom question when custom question id is provided', async () => {
       const uniqueSuffix = Date.now().toString()
       const guestbookId = await sut.createGuestbook(testCollectionId, {

--- a/test/unit/guestbooks/EditGuestbook.test.ts
+++ b/test/unit/guestbooks/EditGuestbook.test.ts
@@ -1,0 +1,55 @@
+import { WriteError } from '../../../src'
+import { EditGuestbookDTO } from '../../../src/guestbooks/domain/dtos/EditGuestbookDTO'
+import { IGuestbooksRepository } from '../../../src/guestbooks/domain/repositories/IGuestbooksRepository'
+import { EditGuestbook } from '../../../src/guestbooks/domain/useCases/EditGuestbook'
+
+describe('EditGuestbook', () => {
+  const editGuestbookDTO: EditGuestbookDTO = {
+    name: 'my edited guestbook',
+    enabled: true,
+    emailRequired: true,
+    nameRequired: true,
+    institutionRequired: false,
+    positionRequired: false,
+    customQuestions: [
+      {
+        id: 1,
+        question: "how's your day",
+        required: true,
+        displayOrder: 0,
+        type: 'text',
+        hidden: false
+      },
+      {
+        question: 'What color car do you drive',
+        required: true,
+        displayOrder: 1,
+        type: 'options',
+        hidden: false,
+        optionValues: [
+          { id: 10, value: 'Red', displayOrder: 0 },
+          { value: 'White', displayOrder: 1 }
+        ]
+      }
+    ]
+  }
+
+  test('should edit guestbook', async () => {
+    const repository: IGuestbooksRepository = {} as IGuestbooksRepository
+    repository.editGuestbook = jest.fn().mockResolvedValue(undefined)
+
+    const sut = new EditGuestbook(repository)
+    const actual = await sut.execute(123, editGuestbookDTO)
+
+    expect(repository.editGuestbook).toHaveBeenCalledWith(123, editGuestbookDTO)
+    expect(actual).toBeUndefined()
+  })
+
+  test('should throw WriteError when repository fails', async () => {
+    const repository: IGuestbooksRepository = {} as IGuestbooksRepository
+    repository.editGuestbook = jest.fn().mockRejectedValue(new WriteError())
+    const sut = new EditGuestbook(repository)
+
+    await expect(sut.execute(123, editGuestbookDTO)).rejects.toThrow(WriteError)
+  })
+})

--- a/test/unit/guestbooks/EditGuestbook.test.ts
+++ b/test/unit/guestbooks/EditGuestbook.test.ts
@@ -11,6 +11,7 @@ describe('EditGuestbook', () => {
     nameRequired: true,
     institutionRequired: false,
     positionRequired: false,
+    createTime: '2026-06-12T00:00:00Z',
     customQuestions: [
       {
         id: 1,

--- a/test/unit/guestbooks/GuestbooksRepository.test.ts
+++ b/test/unit/guestbooks/GuestbooksRepository.test.ts
@@ -7,6 +7,7 @@ import { GuestbooksRepository } from '../../../src/guestbooks/infra/repositories
 import { ReadError } from '../../../src/core/domain/repositories/ReadError'
 import { TestConstants } from '../../testHelpers/TestConstants'
 import { EventType } from '../../../src/guestbooks/domain/models/GuestbookResponse'
+import { EditGuestbookDTO } from '../../../src/guestbooks/domain/dtos/EditGuestbookDTO'
 
 describe('GuestbooksRepository', () => {
   const sut = new GuestbooksRepository()
@@ -84,6 +85,35 @@ describe('GuestbooksRepository', () => {
   }
   const guestbookResponsesCsv =
     'Guestbook,Dataset,Dataset PID,Date,Type,File Name,File Id,File PID,User Name,Email,Institution,Position,Custom Questions'
+  const editGuestbookDTO: EditGuestbookDTO = {
+    name: 'edited test',
+    enabled: true,
+    emailRequired: true,
+    nameRequired: true,
+    institutionRequired: false,
+    positionRequired: false,
+    customQuestions: [
+      {
+        id: 1,
+        question: "how's your day",
+        required: true,
+        displayOrder: 0,
+        type: 'text',
+        hidden: false
+      },
+      {
+        question: 'What color car do you drive',
+        required: true,
+        displayOrder: 1,
+        type: 'options',
+        hidden: false,
+        optionValues: [
+          { id: 10, value: 'Red', displayOrder: 0 },
+          { value: 'White', displayOrder: 1 }
+        ]
+      }
+    ]
+  }
 
   beforeEach(() => {
     ApiConfig.init(
@@ -128,12 +158,68 @@ describe('GuestbooksRepository', () => {
       expect(actual[0].responseCount).toBe(2)
     })
 
+    test('should list guestbooks with inherited guestbooks when includeInherited is true', async () => {
+      jest.spyOn(axios, 'get').mockResolvedValue(guestbooksResponseWithoutStats)
+
+      const actual = await sut.getGuestbooksByCollectionId(collectionIdOrAlias, false, true)
+
+      expect(axios.get).toHaveBeenCalledWith(
+        `${TestConstants.TEST_API_URL}/guestbooks/${collectionIdOrAlias}/list`,
+        {
+          params: {
+            includeInherited: true
+          },
+          headers: TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY.headers
+        }
+      )
+      expect(actual).toStrictEqual(guestbooksResponseWithoutStats.data.data)
+    })
+
+    test('should list guestbooks with stats and inherited guestbooks when both options are true', async () => {
+      jest.spyOn(axios, 'get').mockResolvedValue(guestbooksResponse)
+
+      const actual = await sut.getGuestbooksByCollectionId(collectionIdOrAlias, true, true)
+
+      expect(axios.get).toHaveBeenCalledWith(
+        `${TestConstants.TEST_API_URL}/guestbooks/${collectionIdOrAlias}/list`,
+        {
+          params: {
+            includeStats: true,
+            includeInherited: true
+          },
+          headers: TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY.headers
+        }
+      )
+      expect(actual).toStrictEqual(guestbooksResponse.data.data)
+    })
+
     test('should return error result on error response', async () => {
       jest.spyOn(axios, 'get').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
 
       await expect(sut.getGuestbooksByCollectionId(collectionIdOrAlias, true)).rejects.toThrow(
         ReadError
       )
+    })
+  })
+
+  describe('editGuestbook', () => {
+    test('should edit guestbook', async () => {
+      jest.spyOn(axios, 'put').mockResolvedValue({ data: { status: 'OK' } })
+
+      const actual = await sut.editGuestbook(12, editGuestbookDTO)
+
+      expect(axios.put).toHaveBeenCalledWith(
+        `${TestConstants.TEST_API_URL}/guestbooks/12`,
+        JSON.stringify(editGuestbookDTO),
+        TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY
+      )
+      expect(actual).toBeUndefined()
+    })
+
+    test('should return error result on error response', async () => {
+      jest.spyOn(axios, 'put').mockRejectedValue(TestConstants.TEST_ERROR_RESPONSE)
+
+      await expect(sut.editGuestbook(12, editGuestbookDTO)).rejects.toThrow()
     })
   })
 

--- a/test/unit/guestbooks/GuestbooksRepository.test.ts
+++ b/test/unit/guestbooks/GuestbooksRepository.test.ts
@@ -92,6 +92,7 @@ describe('GuestbooksRepository', () => {
     nameRequired: true,
     institutionRequired: false,
     positionRequired: false,
+    createTime: '2026-06-12T00:00:00Z',
     customQuestions: [
       {
         id: 1,
@@ -213,6 +214,12 @@ describe('GuestbooksRepository', () => {
         JSON.stringify(editGuestbookDTO),
         TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY
       )
+      const requestPayload = JSON.parse((axios.put as jest.Mock).mock.calls[0][1] as string) as
+        | EditGuestbookDTO
+        | undefined
+      expect(requestPayload?.id).toBeUndefined()
+      expect(requestPayload?.customQuestions?.[0].id).toBe(1)
+      expect(requestPayload?.customQuestions?.[1].optionValues?.[0].id).toBe(10)
       expect(actual).toBeUndefined()
     })
 

--- a/test/unit/guestbooks/GuestbooksRepository.test.ts
+++ b/test/unit/guestbooks/GuestbooksRepository.test.ts
@@ -214,12 +214,38 @@ describe('GuestbooksRepository', () => {
         JSON.stringify(editGuestbookDTO),
         TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY
       )
-      const requestPayload = JSON.parse((axios.put as jest.Mock).mock.calls[0][1] as string) as
-        | EditGuestbookDTO
-        | undefined
-      expect(requestPayload?.id).toBeUndefined()
+      const requestPayload = JSON.parse(
+        (axios.put as jest.Mock).mock.calls[0][1] as string
+      ) as EditGuestbookDTO & { id?: number }
+      expect(requestPayload.id).toBeUndefined()
       expect(requestPayload?.customQuestions?.[0].id).toBe(1)
       expect(requestPayload?.customQuestions?.[1].optionValues?.[0].id).toBe(10)
+      expect(actual).toBeUndefined()
+    })
+
+    test('should edit guestbook without custom questions in payload', async () => {
+      jest.spyOn(axios, 'put').mockResolvedValue({ data: { status: 'OK' } })
+      const editGuestbookDTOWithoutCustomQuestions: EditGuestbookDTO = {
+        name: editGuestbookDTO.name,
+        enabled: editGuestbookDTO.enabled,
+        emailRequired: editGuestbookDTO.emailRequired,
+        nameRequired: editGuestbookDTO.nameRequired,
+        institutionRequired: editGuestbookDTO.institutionRequired,
+        positionRequired: editGuestbookDTO.positionRequired,
+        createTime: editGuestbookDTO.createTime
+      }
+
+      const actual = await sut.editGuestbook(12, editGuestbookDTOWithoutCustomQuestions)
+
+      expect(axios.put).toHaveBeenCalledWith(
+        `${TestConstants.TEST_API_URL}/guestbooks/12`,
+        JSON.stringify(editGuestbookDTOWithoutCustomQuestions),
+        TestConstants.TEST_EXPECTED_AUTHENTICATED_REQUEST_CONFIG_API_KEY
+      )
+      const requestPayload = JSON.parse(
+        (axios.put as jest.Mock).mock.calls[0][1] as string
+      ) as EditGuestbookDTO
+      expect(requestPayload.customQuestions).toBeUndefined()
       expect(actual).toBeUndefined()
     })
 


### PR DESCRIPTION
## What this PR does / why we need it:
This API allows the user to make edits to an existing Guestbook, including adding and removing Custom Guestbook Questions.
`curl -PUT -H  "X-Dataverse-key:$API_TOKEN" "$SERVER_URL/api/guestbooks/{ID}" -d "$JSON"`

When editing, the whole payload should be provided as json format

## Which issue(s) this PR closes:

- Closes #454 

## Related Dataverse PRs:

- Depends on #https://github.com/IQSS/dataverse/pull/12395

## Special notes for your reviewer:

## Suggestions on how to test this:

## Is there a release notes or changelog update needed for this change?:
yes

## Additional documentation:
