### PR TITLE
Guestbook Response DTO Change Username to Name

### DIFF
--- a/src/guestbooks/domain/models/GuestbookResponse.ts
+++ b/src/guestbooks/domain/models/GuestbookResponse.ts
@@ -7,7 +7,7 @@ export interface GuestbookResponse {
   fileName?: string
   fileId?: number
   filePid?: string
-  userName: string
+  name: string
   email?: string
   institution?: string
   position?: string

--- a/test/unit/guestbooks/GetGuestbookResponsesByGuestbookId.test.ts
+++ b/test/unit/guestbooks/GetGuestbookResponsesByGuestbookId.test.ts
@@ -20,7 +20,7 @@ describe('GetGuestbookResponsesByGuestbookId', () => {
       type: EventType.DOWNLOAD,
       fileName: 'dp_statistics_for_grade_grouped_by_student_id.html',
       fileId: 3,
-      userName: 'Guest',
+      name: 'Guest',
       email: 'guest@example.edu',
       customQuestions: [
         {

--- a/test/unit/guestbooks/GuestbooksRepository.test.ts
+++ b/test/unit/guestbooks/GuestbooksRepository.test.ts
@@ -64,7 +64,7 @@ describe('GuestbooksRepository', () => {
           type: EventType.DOWNLOAD,
           fileName: 'dp_statistics_for_grade_grouped_by_student_id.html',
           fileId: 3,
-          userName: 'Guest',
+          name: 'Guest',
           email: 'guest@example.edu'
         }
       ]


### PR DESCRIPTION
## What this PR does / why we need it:
"name" was missing in JSON response to get Guestbook Responses
Changed "userName" in guestbook response to "name" to match the parser in API GET /api/guestbooks/{guestbookId}/responses


## Which issue(s) this PR closes:

- Closes #460 

## Related Dataverse PRs:

- Depends on #https://github.com/IQSS/dataverse/pull/12492

## Special notes for your reviewer:

## Suggestions on how to test this:

## Is there a release notes or changelog update needed for this change?:

## Additional documentation:
