### PR TITLE
Export Metadata Use Case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This changelog follows the principles of [Keep a Changelog](https://keepachangel
 - Guestbooks: Added optional `includeStats` support to `getGuestbooksByCollectionId`, returning `usageCount` and `responseCount` when requested.
 - Files: Added `getFileCitationByFormat` use case, repository method, and `FileCitationFormat` enum to support Dataverse file citation exports in `EndNote`, `RIS`, `BibTeX`, `CSL`, and `Internal` formats.
 - Datasets: Added `getDatasetReviews` use case and repository method to support Dataverse endpoint `GET /datasets/{identifier}/reviews`, for retrieving review datasets associated with a dataset by persistent id or numeric id.
-- Datasets: Added `exportDatasetMetadata` use case, repository method, `ExportedDatasetMetadata` response type, and `DatasetMetadataExportVersion` enum to support exporting dataset metadata by numeric id or persistent id through Dataverse endpoint `GET /datasets/export`.
+- Datasets: Added `exportDatasetMetadata` use case, repository method, and `ExportedDatasetMetadata` response type to support exporting dataset metadata by numeric id or persistent id through Dataverse endpoint `GET /datasets/export`.
 - Collections: Added `allowedDatasetTypes` field to the [Collection](./src/collections/domain/models/Collection.ts) model. This field is optional and only populated the feature is enabled on the installation and configured on the collection.
 - Collections: Added theme information when retrieving a collection using `getCollection`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This changelog follows the principles of [Keep a Changelog](https://keepachangel
 - Guestbooks: Added optional `includeStats` support to `getGuestbooksByCollectionId`, returning `usageCount` and `responseCount` when requested.
 - Files: Added `getFileCitationByFormat` use case, repository method, and `FileCitationFormat` enum to support Dataverse file citation exports in `EndNote`, `RIS`, `BibTeX`, `CSL`, and `Internal` formats.
 - Datasets: Added `getDatasetReviews` use case and repository method to support Dataverse endpoint `GET /datasets/{identifier}/reviews`, for retrieving review datasets associated with a dataset by persistent id or numeric id.
+- Datasets: Added `exportDatasetMetadata` use case, repository method, `ExportedDatasetMetadata` response type, and `DatasetMetadataExportVersion` enum to support exporting dataset metadata by numeric id or persistent id through Dataverse endpoint `GET /datasets/export`.
 - Collections: Added `allowedDatasetTypes` field to the [Collection](./src/collections/domain/models/Collection.ts) model. This field is optional and only populated the feature is enabled on the installation and configured on the collection.
 - Collections: Added theme information when retrieving a collection using `getCollection`.
 

--- a/docs/useCases.md
+++ b/docs/useCases.md
@@ -46,6 +46,8 @@ The different use cases currently available in the package are classified below,
     - [Get a Dataset](#get-a-dataset)
     - [Get Dataset By Private URL Token](#get-dataset-by-private-url-token)
     - [Get Dataset Citation Text](#get-dataset-citation-text)
+    - [Get Dataset Citation In Other Formats](#get-dataset-citation-in-other-formats)
+    - [Export Dataset Metadata](#export-dataset-metadata)
     - [Get Dataset Citation Text By Private URL Token](#get-dataset-citation-text-by-private-url-token)
     - [Get Dataset Locks](#get-dataset-locks)
     - [Get Dataset Summary Field Names](#get-dataset-summary-field-names)
@@ -1052,6 +1054,35 @@ Supported formats include 'EndNote' (XML), 'RIS' (plain text), 'BibTeX' (plain t
 The `datasetId` parameter can be a string, for persistent identifiers, or a number, for numeric identifiers.
 
 There is an optional third parameter called `includeDeaccessioned`, which indicates whether to consider deaccessioned versions or not in the dataset search. If not set, the default value is `false`.
+
+#### Export Dataset Metadata
+
+Exports dataset metadata in a specified metadata export format.
+
+##### Example call:
+
+```typescript
+import {
+  exportDatasetMetadata,
+  DatasetMetadataExportVersion,
+  ExportedDatasetMetadata
+} from '@iqss/dataverse-client-javascript'
+
+/* ... */
+
+const datasetId = 'doi:10.77777/FK2/AAAAAA'
+const exporter = 'ddi'
+
+exportDatasetMetadata
+  .execute(datasetId, exporter, DatasetMetadataExportVersion.DRAFT)
+  .then((metadata: ExportedDatasetMetadata) => {
+    /* ... */
+  })
+
+/* ... */
+```
+
+_See [use case](../src/datasets/domain/useCases/ExportDatasetMetadata.ts) implementation_.
 
 #### Get Dataset Citation Text By Private URL Token
 

--- a/docs/useCases.md
+++ b/docs/useCases.md
@@ -1064,7 +1064,7 @@ Exports dataset metadata in a specified metadata export format.
 ```typescript
 import {
   exportDatasetMetadata,
-  DatasetMetadataExportVersion,
+  DatasetNotNumberedVersion,
   ExportedDatasetMetadata
 } from '@iqss/dataverse-client-javascript'
 
@@ -1074,7 +1074,7 @@ const datasetId = 'doi:10.77777/FK2/AAAAAA'
 const exporter = 'ddi'
 
 exportDatasetMetadata
-  .execute(datasetId, exporter, DatasetMetadataExportVersion.DRAFT)
+  .execute(datasetId, exporter, DatasetNotNumberedVersion.DRAFT)
   .then((metadata: ExportedDatasetMetadata) => {
     /* ... */
   })
@@ -1083,6 +1083,8 @@ exportDatasetMetadata
 ```
 
 _See [use case](../src/datasets/domain/useCases/ExportDatasetMetadata.ts) implementation_.
+
+The `datasetId` parameter can be a string for persistent identifiers or a number for numeric identifiers. The optional `version` parameter accepts `DatasetNotNumberedVersion.LATEST_PUBLISHED` or `DatasetNotNumberedVersion.DRAFT`. If not set, Dataverse defaults to `DatasetNotNumberedVersion.LATEST_PUBLISHED`. Draft exports require configured authentication with access to the draft.
 
 #### Get Dataset Citation Text By Private URL Token
 

--- a/src/datasets/domain/models/ExportedDatasetMetadata.ts
+++ b/src/datasets/domain/models/ExportedDatasetMetadata.ts
@@ -1,0 +1,9 @@
+export type ExportedDatasetMetadata = {
+  content: string
+  contentType: string
+}
+
+export enum DatasetMetadataExportVersion {
+  LATEST_PUBLISHED = ':latest-published',
+  DRAFT = ':draft'
+}

--- a/src/datasets/domain/models/ExportedDatasetMetadata.ts
+++ b/src/datasets/domain/models/ExportedDatasetMetadata.ts
@@ -2,8 +2,3 @@ export type ExportedDatasetMetadata = {
   content: string
   contentType: string
 }
-
-export enum DatasetMetadataExportVersion {
-  LATEST_PUBLISHED = ':latest-published',
-  DRAFT = ':draft'
-}

--- a/src/datasets/domain/repositories/IDatasetsRepository.ts
+++ b/src/datasets/domain/repositories/IDatasetsRepository.ts
@@ -20,7 +20,7 @@ import { StorageDriver } from '../../../core/domain/models/StorageDriver'
 import { DatasetUploadLimits } from '../models/DatasetUploadLimits'
 import { DatasetReview } from '../models/DatasetReview'
 import { ExportedDatasetMetadata } from '../models/ExportedDatasetMetadata'
-import { DatasetMetadataExportVersion } from '../models/ExportedDatasetMetadata'
+import { DatasetNotNumberedVersion } from '../models/DatasetNotNumberedVersion'
 
 export interface IDatasetsRepository {
   getDataset(
@@ -91,7 +91,7 @@ export interface IDatasetsRepository {
   exportDatasetMetadata(
     datasetId: number | string,
     exporter: string,
-    version?: DatasetMetadataExportVersion
+    version?: DatasetNotNumberedVersion.LATEST_PUBLISHED | DatasetNotNumberedVersion.DRAFT
   ): Promise<ExportedDatasetMetadata>
   getDatasetAvailableDatasetTypes(): Promise<DatasetType[]>
   getDatasetAvailableDatasetType(datasetTypeId: number | string): Promise<DatasetType>

--- a/src/datasets/domain/repositories/IDatasetsRepository.ts
+++ b/src/datasets/domain/repositories/IDatasetsRepository.ts
@@ -19,6 +19,8 @@ import { DatasetTypeDTO } from '../dtos/DatasetTypeDTO'
 import { StorageDriver } from '../../../core/domain/models/StorageDriver'
 import { DatasetUploadLimits } from '../models/DatasetUploadLimits'
 import { DatasetReview } from '../models/DatasetReview'
+import { ExportedDatasetMetadata } from '../models/ExportedDatasetMetadata'
+import { DatasetMetadataExportVersion } from '../models/ExportedDatasetMetadata'
 
 export interface IDatasetsRepository {
   getDataset(
@@ -86,6 +88,11 @@ export interface IDatasetsRepository {
     format: CitationFormat,
     includeDeaccessioned?: boolean
   ): Promise<FormattedCitation>
+  exportDatasetMetadata(
+    datasetId: number | string,
+    exporter: string,
+    version?: DatasetMetadataExportVersion
+  ): Promise<ExportedDatasetMetadata>
   getDatasetAvailableDatasetTypes(): Promise<DatasetType[]>
   getDatasetAvailableDatasetType(datasetTypeId: number | string): Promise<DatasetType>
   addDatasetType(datasetType: DatasetTypeDTO): Promise<DatasetType>

--- a/src/datasets/domain/useCases/ExportDatasetMetadata.ts
+++ b/src/datasets/domain/useCases/ExportDatasetMetadata.ts
@@ -1,0 +1,28 @@
+import { UseCase } from '../../../core/domain/useCases/UseCase'
+import { DatasetMetadataExportVersion } from '../models/ExportedDatasetMetadata'
+import { ExportedDatasetMetadata } from '../models/ExportedDatasetMetadata'
+import { IDatasetsRepository } from '../repositories/IDatasetsRepository'
+
+export class ExportDatasetMetadata implements UseCase<ExportedDatasetMetadata> {
+  private datasetsRepository: IDatasetsRepository
+
+  constructor(datasetsRepository: IDatasetsRepository) {
+    this.datasetsRepository = datasetsRepository
+  }
+
+  /**
+   * Exports dataset metadata in the specified metadata export format.
+   *
+   * @param {number | string} datasetId - The dataset identifier, which can be a string for persistent identifiers or a number for numeric identifiers.
+   * @param {string} exporter - The metadata exporter format name.
+   * @param {DatasetMetadataExportVersion} [version] - The dataset version to export. If omitted, Dataverse defaults to :latest-published.
+   * @returns {Promise<ExportedDatasetMetadata>} The exported metadata content and content type.
+   */
+  async execute(
+    datasetId: number | string,
+    exporter: string,
+    version?: DatasetMetadataExportVersion
+  ): Promise<ExportedDatasetMetadata> {
+    return await this.datasetsRepository.exportDatasetMetadata(datasetId, exporter, version)
+  }
+}

--- a/src/datasets/domain/useCases/ExportDatasetMetadata.ts
+++ b/src/datasets/domain/useCases/ExportDatasetMetadata.ts
@@ -1,5 +1,5 @@
 import { UseCase } from '../../../core/domain/useCases/UseCase'
-import { DatasetMetadataExportVersion } from '../models/ExportedDatasetMetadata'
+import { DatasetNotNumberedVersion } from '../models/DatasetNotNumberedVersion'
 import { ExportedDatasetMetadata } from '../models/ExportedDatasetMetadata'
 import { IDatasetsRepository } from '../repositories/IDatasetsRepository'
 
@@ -15,13 +15,13 @@ export class ExportDatasetMetadata implements UseCase<ExportedDatasetMetadata> {
    *
    * @param {number | string} datasetId - The dataset identifier, which can be a string for persistent identifiers or a number for numeric identifiers.
    * @param {string} exporter - The metadata exporter format name.
-   * @param {DatasetMetadataExportVersion} [version] - The dataset version to export. If omitted, Dataverse defaults to :latest-published.
+   * @param {DatasetNotNumberedVersion.LATEST_PUBLISHED | DatasetNotNumberedVersion.DRAFT} [version] - The dataset version to export. If omitted, Dataverse defaults to :latest-published.
    * @returns {Promise<ExportedDatasetMetadata>} The exported metadata content and content type.
    */
   async execute(
     datasetId: number | string,
     exporter: string,
-    version?: DatasetMetadataExportVersion
+    version?: DatasetNotNumberedVersion.LATEST_PUBLISHED | DatasetNotNumberedVersion.DRAFT
   ): Promise<ExportedDatasetMetadata> {
     return await this.datasetsRepository.exportDatasetMetadata(datasetId, exporter, version)
   }

--- a/src/datasets/index.ts
+++ b/src/datasets/index.ts
@@ -36,6 +36,7 @@ import { UpdateDatasetLicense } from './domain/useCases/UpdateDatasetLicense'
 import { GetDatasetStorageDriver } from './domain/useCases/GetDatasetStorageDriver'
 import { GetDatasetUploadLimits } from './domain/useCases/GetDatasetUploadLimits'
 import { GetDatasetReviews } from './domain/useCases/GetDatasetReviews'
+import { ExportDatasetMetadata } from './domain/useCases/ExportDatasetMetadata'
 
 const datasetsRepository = new DatasetsRepository()
 
@@ -88,6 +89,7 @@ const updateDatasetLicense = new UpdateDatasetLicense(datasetsRepository)
 const getDatasetStorageDriver = new GetDatasetStorageDriver(datasetsRepository)
 const getDatasetUploadLimits = new GetDatasetUploadLimits(datasetsRepository)
 const getDatasetReviews = new GetDatasetReviews(datasetsRepository)
+const exportDatasetMetadata = new ExportDatasetMetadata(datasetsRepository)
 
 export {
   getDataset,
@@ -121,9 +123,14 @@ export {
   updateDatasetLicense,
   getDatasetStorageDriver,
   getDatasetUploadLimits,
-  getDatasetReviews
+  getDatasetReviews,
+  exportDatasetMetadata
 }
 export { DatasetNotNumberedVersion } from './domain/models/DatasetNotNumberedVersion'
+export {
+  DatasetMetadataExportVersion,
+  ExportedDatasetMetadata
+} from './domain/models/ExportedDatasetMetadata'
 export { DatasetUserPermissions } from './domain/models/DatasetUserPermissions'
 export { DatasetLock, DatasetLockType } from './domain/models/DatasetLock'
 export {

--- a/src/datasets/index.ts
+++ b/src/datasets/index.ts
@@ -127,10 +127,7 @@ export {
   exportDatasetMetadata
 }
 export { DatasetNotNumberedVersion } from './domain/models/DatasetNotNumberedVersion'
-export {
-  DatasetMetadataExportVersion,
-  ExportedDatasetMetadata
-} from './domain/models/ExportedDatasetMetadata'
+export { ExportedDatasetMetadata } from './domain/models/ExportedDatasetMetadata'
 export { DatasetUserPermissions } from './domain/models/DatasetUserPermissions'
 export { DatasetLock, DatasetLockType } from './domain/models/DatasetLock'
 export {

--- a/src/datasets/infra/repositories/DatasetsRepository.ts
+++ b/src/datasets/infra/repositories/DatasetsRepository.ts
@@ -158,7 +158,7 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
       ...(version && { version })
     })
 
-    const contentType = response.headers['content-type']
+    const contentType = String(response.headers['content-type'] ?? '')
     const content =
       typeof response.data === 'string' ? response.data : JSON.stringify(response.data)
 

--- a/src/datasets/infra/repositories/DatasetsRepository.ts
+++ b/src/datasets/infra/repositories/DatasetsRepository.ts
@@ -35,7 +35,6 @@ import { DatasetUploadLimits } from '../../domain/models/DatasetUploadLimits'
 import { DatasetReview } from '../../domain/models/DatasetReview'
 import { transformDatasetReviewsResponseToDatasetReviews } from './transformers/datasetReviewTransformers'
 import { ExportedDatasetMetadata } from '../../domain/models/ExportedDatasetMetadata'
-import { DatasetMetadataExportVersion } from '../../domain/models/ExportedDatasetMetadata'
 
 export interface GetAllDatasetPreviewsQueryParams {
   per_page?: number
@@ -139,7 +138,7 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
   public async exportDatasetMetadata(
     datasetId: number | string,
     exporter: string,
-    version?: DatasetMetadataExportVersion
+    version?: DatasetNotNumberedVersion.LATEST_PUBLISHED | DatasetNotNumberedVersion.DRAFT
   ): Promise<ExportedDatasetMetadata> {
     const persistentId =
       typeof datasetId === 'number'

--- a/src/datasets/infra/repositories/DatasetsRepository.ts
+++ b/src/datasets/infra/repositories/DatasetsRepository.ts
@@ -26,6 +26,7 @@ import { transformDatasetLinkedCollectionsResponseToDatasetLinkedCollection } fr
 import { FormattedCitation } from '../../domain/models/FormattedCitation'
 import { DatasetType } from '../../domain/models/DatasetType'
 import { TermsOfAccess } from '../../domain/models/Dataset'
+import { DatasetNotNumberedVersion } from '../../domain/models/DatasetNotNumberedVersion'
 import { transformTermsOfAccessToUpdatePayload } from './transformers/termsOfAccessTransformers'
 import { DatasetLicenseUpdateRequest } from '../../domain/dtos/DatasetLicenseUpdateRequest'
 import { DatasetTypeDTO } from '../../domain/dtos/DatasetTypeDTO'
@@ -33,6 +34,8 @@ import { StorageDriver } from '../../../core/domain/models/StorageDriver'
 import { DatasetUploadLimits } from '../../domain/models/DatasetUploadLimits'
 import { DatasetReview } from '../../domain/models/DatasetReview'
 import { transformDatasetReviewsResponseToDatasetReviews } from './transformers/datasetReviewTransformers'
+import { ExportedDatasetMetadata } from '../../domain/models/ExportedDatasetMetadata'
+import { DatasetMetadataExportVersion } from '../../domain/models/ExportedDatasetMetadata'
 
 export interface GetAllDatasetPreviewsQueryParams {
   per_page?: number
@@ -126,6 +129,39 @@ export class DatasetsRepository extends ApiRepository implements IDatasetsReposi
     } else {
       content = response.data
     }
+
+    return {
+      content,
+      contentType
+    }
+  }
+
+  public async exportDatasetMetadata(
+    datasetId: number | string,
+    exporter: string,
+    version?: DatasetMetadataExportVersion
+  ): Promise<ExportedDatasetMetadata> {
+    const persistentId =
+      typeof datasetId === 'number'
+        ? (
+            await this.getDataset(
+              datasetId,
+              version ?? DatasetNotNumberedVersion.LATEST_PUBLISHED,
+              false,
+              false
+            )
+          ).persistentId
+        : datasetId
+
+    const response = await this.doGet('/datasets/export', true, {
+      exporter,
+      persistentId,
+      ...(version && { version })
+    })
+
+    const contentType = response.headers['content-type']
+    const content =
+      typeof response.data === 'string' ? response.data : JSON.stringify(response.data)
 
     return {
       content,

--- a/test/functional/collections/UnlinkCollection.test.ts
+++ b/test/functional/collections/UnlinkCollection.test.ts
@@ -5,6 +5,7 @@ import {
   linkCollection,
   deleteCollection,
   getCollectionItems,
+  getCollectionLinks,
   unlinkCollection
 } from '../../../src'
 import { TestConstants } from '../../testHelpers/TestConstants'
@@ -43,12 +44,14 @@ describe('execute', () => {
     // Verify that the collections are linked
     const collectionItemSubset = await getCollectionItems.execute(firstCollectionAlias)
     expect(collectionItemSubset.items.length).toBe(1)
+    const collectionLinksBefore = await getCollectionLinks.execute(firstCollectionId)
+    expect(collectionLinksBefore.linkedCollections.map((collection) => collection.alias)).toContain(
+      secondCollectionAlias
+    )
 
     await unlinkCollection.execute(secondCollectionAlias, firstCollectionAlias)
-    // Wait for the unlinking to be processed by Solr
-    await new Promise((resolve) => setTimeout(resolve, 5000))
-    const collectionItemSubset2 = await getCollectionItems.execute(firstCollectionAlias)
-    expect(collectionItemSubset2.items.length).toBe(0)
+    const collectionLinksAfter = await getCollectionLinks.execute(firstCollectionId)
+    expect(collectionLinksAfter.linkedCollections).toStrictEqual([])
   })
 
   test('should throw an error when unlinking a non-existent collection', async () => {

--- a/test/integration/collections/CollectionsRepository.test.ts
+++ b/test/integration/collections/CollectionsRepository.test.ts
@@ -2143,12 +2143,16 @@ describe('CollectionsRepository', () => {
       const firstCollection = await sut.getCollection(firstCollectionAlias)
       const secondCollection = await sut.getCollection(secondCollectionAlias)
 
+      const collectionLinksBefore = await sut.getCollectionLinks(firstCollection.id)
+      expect(
+        collectionLinksBefore.linkedCollections.map((collection) => collection.alias)
+      ).toContain(secondCollection.alias)
+
       await sut.unlinkCollection(secondCollection.id, firstCollection.id)
-      await new Promise((res) => setTimeout(res, 2000))
 
       await sut.getCollection(secondCollectionAlias)
-      const collectionItemSubset = await sut.getCollectionItems(firstCollection.alias)
-      expect(collectionItemSubset.items).toStrictEqual([])
+      const collectionLinksAfter = await sut.getCollectionLinks(firstCollection.id)
+      expect(collectionLinksAfter.linkedCollections).toStrictEqual([])
     })
 
     test('should throw error when unlinking a non-existent collection', async () => {

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -35,7 +35,8 @@ import {
   updateTermsOfAccess,
   DatasetLicenseUpdateRequest,
   getDatasetReviews,
-  DatasetReview
+  DatasetReview,
+  DatasetMetadataExportVersion
 } from '../../../src/datasets'
 import { ApiConfig, WriteError } from '../../../src'
 import { DataverseApiAuthMechanism } from '../../../src/core/infra/repositories/ApiConfig'
@@ -769,6 +770,43 @@ describe('DatasetsRepository', () => {
 
       expect(typeof citation.content).toBe('string')
       expect(citation.contentType).toMatch(/text\/plain/)
+    })
+  })
+
+  describe('exportDatasetMetadata', () => {
+    let draftDatasetIds: CreatedDatasetIdentifiers
+    let publishedDatasetIds: CreatedDatasetIdentifiers
+
+    beforeAll(async () => {
+      draftDatasetIds = await createDataset.execute(TestConstants.TEST_NEW_DATASET_DTO)
+      publishedDatasetIds = await createDataset.execute(TestConstants.TEST_NEW_DATASET_DTO)
+      await publishDatasetViaApi(publishedDatasetIds.numericId)
+      await waitForNoLocks(publishedDatasetIds.numericId, 10)
+    })
+
+    afterAll(async () => {
+      await deleteUnpublishedDatasetViaApi(draftDatasetIds.numericId)
+      await deletePublishedDatasetViaApi(publishedDatasetIds.persistentId)
+    })
+
+    test('should export latest published dataset metadata in DDI format by default', async () => {
+      const metadata = await sut.exportDatasetMetadata(publishedDatasetIds.persistentId, 'ddi')
+
+      expect(typeof metadata.content).toBe('string')
+      expect(metadata.content.length).toBeGreaterThan(0)
+      expect(metadata.contentType).toMatch(/xml/)
+    })
+
+    test('should export draft dataset metadata in DDI format', async () => {
+      const metadata = await sut.exportDatasetMetadata(
+        draftDatasetIds.numericId,
+        'ddi',
+        DatasetMetadataExportVersion.DRAFT
+      )
+
+      expect(typeof metadata.content).toBe('string')
+      expect(metadata.content.length).toBeGreaterThan(0)
+      expect(metadata.contentType).toMatch(/xml/)
     })
   })
 

--- a/test/integration/datasets/DatasetsRepository.test.ts
+++ b/test/integration/datasets/DatasetsRepository.test.ts
@@ -35,8 +35,7 @@ import {
   updateTermsOfAccess,
   DatasetLicenseUpdateRequest,
   getDatasetReviews,
-  DatasetReview,
-  DatasetMetadataExportVersion
+  DatasetReview
 } from '../../../src/datasets'
 import { ApiConfig, WriteError } from '../../../src'
 import { DataverseApiAuthMechanism } from '../../../src/core/infra/repositories/ApiConfig'
@@ -801,7 +800,7 @@ describe('DatasetsRepository', () => {
       const metadata = await sut.exportDatasetMetadata(
         draftDatasetIds.numericId,
         'ddi',
-        DatasetMetadataExportVersion.DRAFT
+        DatasetNotNumberedVersion.DRAFT
       )
 
       expect(typeof metadata.content).toBe('string')

--- a/test/unit/datasets/ExportDatasetMetadata.test.ts
+++ b/test/unit/datasets/ExportDatasetMetadata.test.ts
@@ -2,7 +2,7 @@ import { ExportDatasetMetadata } from '../../../src/datasets/domain/useCases/Exp
 import { IDatasetsRepository } from '../../../src/datasets/domain/repositories/IDatasetsRepository'
 import { ReadError } from '../../../src/core/domain/repositories/ReadError'
 import { ExportedDatasetMetadata } from '../../../src/datasets/domain/models/ExportedDatasetMetadata'
-import { DatasetMetadataExportVersion } from '../../../src/datasets/domain/models/ExportedDatasetMetadata'
+import { DatasetNotNumberedVersion } from '../../../src/datasets/domain/models/DatasetNotNumberedVersion'
 
 describe('ExportDatasetMetadata.execute', () => {
   const testDatasetId = 1
@@ -20,17 +20,13 @@ describe('ExportDatasetMetadata.execute', () => {
 
     const sut = new ExportDatasetMetadata(datasetsRepositoryStub)
 
-    const actual = await sut.execute(
-      testDatasetId,
-      testExporter,
-      DatasetMetadataExportVersion.DRAFT
-    )
+    const actual = await sut.execute(testDatasetId, testExporter, DatasetNotNumberedVersion.DRAFT)
 
     expect(actual).toEqual(expectedMetadata)
     expect(datasetsRepositoryStub.exportDatasetMetadata).toHaveBeenCalledWith(
       testDatasetId,
       testExporter,
-      DatasetMetadataExportVersion.DRAFT
+      DatasetNotNumberedVersion.DRAFT
     )
   })
 

--- a/test/unit/datasets/ExportDatasetMetadata.test.ts
+++ b/test/unit/datasets/ExportDatasetMetadata.test.ts
@@ -1,0 +1,46 @@
+import { ExportDatasetMetadata } from '../../../src/datasets/domain/useCases/ExportDatasetMetadata'
+import { IDatasetsRepository } from '../../../src/datasets/domain/repositories/IDatasetsRepository'
+import { ReadError } from '../../../src/core/domain/repositories/ReadError'
+import { ExportedDatasetMetadata } from '../../../src/datasets/domain/models/ExportedDatasetMetadata'
+import { DatasetMetadataExportVersion } from '../../../src/datasets/domain/models/ExportedDatasetMetadata'
+
+describe('ExportDatasetMetadata.execute', () => {
+  const testDatasetId = 1
+  const testExporter = 'ddi'
+
+  test('should return exported dataset metadata on repository success', async () => {
+    const expectedMetadata: ExportedDatasetMetadata = {
+      content: '<codeBook></codeBook>',
+      contentType: 'application/xml'
+    }
+
+    const datasetsRepositoryStub: IDatasetsRepository = {
+      exportDatasetMetadata: jest.fn().mockResolvedValue(expectedMetadata)
+    } as unknown as IDatasetsRepository
+
+    const sut = new ExportDatasetMetadata(datasetsRepositoryStub)
+
+    const actual = await sut.execute(
+      testDatasetId,
+      testExporter,
+      DatasetMetadataExportVersion.DRAFT
+    )
+
+    expect(actual).toEqual(expectedMetadata)
+    expect(datasetsRepositoryStub.exportDatasetMetadata).toHaveBeenCalledWith(
+      testDatasetId,
+      testExporter,
+      DatasetMetadataExportVersion.DRAFT
+    )
+  })
+
+  test('should throw ReadError on repository failure', async () => {
+    const datasetsRepositoryStub: IDatasetsRepository = {
+      exportDatasetMetadata: jest.fn().mockRejectedValue(new ReadError())
+    } as unknown as IDatasetsRepository
+
+    const sut = new ExportDatasetMetadata(datasetsRepositoryStub)
+
+    await expect(sut.execute(testDatasetId, testExporter)).rejects.toThrow(ReadError)
+  })
+})


### PR DESCRIPTION
## What this PR does / why we need it:
Export Metadata Use Case

## Which issue(s) this PR closes:

- Closes #462 

## Related Dataverse PRs:

- Depends on #

## Special notes for your reviewer:

UnlinkCollection test error, the subcollection was removed from the collection links API response, but it still appeared in the Solr-backed `/search?subtree=...` response, which led an error when of `getCollectionItem` use case. I fixed by using `getCollectionLinks` use case to check if the unlinking works successfully

## Suggestions on how to test this:

## Is there a release notes or changelog update needed for this change?:
YES

## Additional documentation:
