### PR TITLE
feat: update metadata block payload transformation to support deep nesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This changelog follows the principles of [Keep a Changelog](https://keepachangel
 
 ### Changed
 
+- Datasets: Updated dataset metadata transformation to support deeply nested metadata fields returned by the Dataverse API, e.g., using the `getDataset` use case.
+
 ### Fixed
 
 ### Removed

--- a/src/datasets/domain/models/Dataset.ts
+++ b/src/datasets/domain/models/Dataset.ts
@@ -94,7 +94,9 @@ export type DatasetMetadataFieldValue =
   | DatasetMetadataSubField[]
   | AnonymizedField
 
-export type DatasetMetadataSubField = Record<string, string | undefined>
+export interface DatasetMetadataSubField {
+  [key: string]: DatasetMetadataFieldValue | undefined
+}
 
 export interface CitationMetadataBlock extends DatasetMetadataBlock {
   name: 'citation'

--- a/src/datasets/infra/repositories/transformers/DatasetPayload.ts
+++ b/src/datasets/infra/repositories/transformers/DatasetPayload.ts
@@ -69,5 +69,5 @@ export type MetadataFieldValuePayload =
   | MetadataSubfieldValuePayload[]
 
 export interface MetadataSubfieldValuePayload {
-  [key: string]: { value: string; typeName: string; multiple: boolean; typeClass: string }
+  [key: string]: MetadataFieldPayload
 }

--- a/src/datasets/infra/repositories/transformers/datasetTransformers.ts
+++ b/src/datasets/infra/repositories/transformers/datasetTransformers.ts
@@ -409,8 +409,12 @@ const transformPayloadToDatasetMetadataSubfieldValue = (
 ): DatasetMetadataSubField => {
   const result: DatasetMetadataSubField = {}
   Object.keys(metadataSubfieldValuePayload).forEach((key) => {
-    const subFieldValue = metadataSubfieldValuePayload[key].value
-    result[key] = keepRawFields ? subFieldValue : transformHtmlToMarkdown(subFieldValue)
+    const subField = metadataSubfieldValuePayload[key]
+    result[key] = transformPayloadToDatasetMetadataFieldValue(
+      subField.value,
+      subField.typeClass,
+      keepRawFields
+    )
   })
   return result
 }

--- a/test/unit/datasets/datasetTransformers.test.ts
+++ b/test/unit/datasets/datasetTransformers.test.ts
@@ -4,7 +4,11 @@ import {
   createNewDatasetRequestPayload
 } from '../../testHelpers/datasets/datasetHelper'
 import { createDatasetLicenseModel } from '../../testHelpers/datasets/datasetHelper'
-import { transformDatasetModelToNewDatasetRequestPayload } from '../../../src/datasets/infra/repositories/transformers/datasetTransformers'
+import {
+  transformDatasetModelToNewDatasetRequestPayload,
+  transformPayloadToDatasetMetadataBlocks
+} from '../../../src/datasets/infra/repositories/transformers/datasetTransformers'
+import { MetadataBlocksPayload } from '../../../src/datasets/infra/repositories/transformers/DatasetPayload'
 
 describe('transformNewDatasetModelToRequestPayload', () => {
   test('should correctly transform a new dataset model to a new dataset request payload', async () => {
@@ -58,3 +62,43 @@ describe('transformNewDatasetModelToRequestPayload', () => {
     expect(actual).toEqual(expectedNewDatasetRequestPayload)
   })
 })
+
+describe('transformPayloadToDatasetMetadataBlocks', () => {
+  test('should support infinite levels of nesting', () => {
+    const payload: MetadataBlocksPayload = {
+      citation: {
+        name: 'deeplyNestedBlock',
+        fields: [
+          {
+            typeName: 'a',
+            multiple: false,
+            typeClass: 'controlledVocabulary',
+            value: {
+              'a.b': {
+                multiple: false,
+                typeClass: 'controlledVocabulary',
+                typeName: 'a.b',
+                value: {
+                  'a.b.c': {
+                    multiple: false,
+                    typeClass: 'primitive',
+                    typeName: 'a.b.c',
+                    value: 'Deeply nested value'
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+
+    const actual = transformPayloadToDatasetMetadataBlocks(payload, true)
+
+    const deeplyNestedBlock = actual.find((block) => block.name === 'deeplyNestedBlock')
+    const fields = deeplyNestedBlock?.fields
+
+    expect(fields).toStrictEqual({'a': {'a.b': {'a.b.c': 'Deeply nested value'}}})
+  })
+})
+


### PR DESCRIPTION
## What this PR does / why we need it:

Updates dataset metadata payload transformation to support deeply nested metadata fields. This aligns the JavaScript client with the Dataverse API, which already supports unlimited nesting.

## Which issue(s) this PR closes:

None

## Related Dataverse PRs:

None

## Special notes for your reviewer:

None

## Suggestions on how to test this:

Verify that dataset metadata blocks with multiple levels of nested fields are transformed correctly from the API payload into the dataset model. A unit test was added to cover deeply nested metadata fields.

## Is there a release notes or changelog update needed for this change?:

Yes. This is a client behavior improvement that would be worth noting in the changelog. I've updated the changelog.

## Additional documentation:

None