### PR TITLE
feat: add `getDefaultContributorRole` use case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This changelog follows the principles of [Keep a Changelog](https://keepachangel
 - Datasets: Added `exportDatasetMetadata` use case, repository method, and `ExportedDatasetMetadata` response type to support exporting dataset metadata by numeric id or persistent id through Dataverse endpoint `GET /datasets/export`.
 - Collections: Added `allowedDatasetTypes` field to the [Collection](./src/collections/domain/models/Collection.ts) model. This field is optional and only populated the feature is enabled on the installation and configured on the collection.
 - Collections: Added theme information when retrieving a collection using `getCollection`.
+- Collections: Added `getDefaultContributorRole` use case.
 
 ### Changed
 

--- a/src/collections/domain/repositories/ICollectionsRepository.ts
+++ b/src/collections/domain/repositories/ICollectionsRepository.ts
@@ -14,6 +14,7 @@ import { CollectionSummary } from '../models/CollectionSummary'
 import { AllowedStorageDrivers } from '../models/AllowedStorageDrivers'
 import { StorageDriver } from '../../../core/domain/models/StorageDriver'
 import { LinkingObjectType } from '../useCases/GetCollectionsForLinking'
+import { Role } from '../../../roles/domain/models/Role'
 
 export interface ICollectionsRepository {
   getCollection(collectionIdOrAlias: number | string): Promise<Collection>
@@ -39,6 +40,9 @@ export interface ICollectionsRepository {
   getCollectionUserPermissions(
     collectionIdOrAlias: number | string
   ): Promise<CollectionUserPermissions>
+  getDefaultContributorRole(
+    collectionIdOrAlias: number | string
+  ): Promise<Role>
   getCollectionItems(
     collectionId?: string,
     limit?: number,

--- a/src/collections/domain/useCases/GetDefaultContributorRole.ts
+++ b/src/collections/domain/useCases/GetDefaultContributorRole.ts
@@ -1,0 +1,25 @@
+import { UseCase } from '../../../core/domain/useCases/UseCase'
+import { ICollectionsRepository } from '../repositories/ICollectionsRepository'
+import { ROOT_COLLECTION_ID } from '../models/Collection'
+import { Role } from '../../../roles/domain/models/Role'
+
+export class GetDefaultContributorRole implements UseCase<Role> {
+  private collectionsRepository: ICollectionsRepository
+
+  constructor(collectionsRepository: ICollectionsRepository) {
+    this.collectionsRepository = collectionsRepository
+  }
+
+  /**
+   * Returns the default Role that is assigned to contributors in the given collection.
+   *
+   * @param {number | string} [collectionIdOrAlias = ':root'] - A generic collection identifier, which can be either a string (for queries by CollectionAlias), or a number (for queries by CollectionId)
+   * If this parameter is not set, the default value is: ':root'
+   * @returns {Promise<Role>}
+   */
+  async execute(
+    collectionIdOrAlias: number | string = ROOT_COLLECTION_ID
+  ): Promise<Role> {
+    return await this.collectionsRepository.getDefaultContributorRole(collectionIdOrAlias)
+  }
+}

--- a/src/collections/index.ts
+++ b/src/collections/index.ts
@@ -20,6 +20,7 @@ import { GetCollectionsForLinking } from './domain/useCases/GetCollectionsForLin
 import { SetCollectionStorageDriver } from './domain/useCases/SetCollectionStorageDriver'
 import { DeleteCollectionStorageDriver } from './domain/useCases/DeleteCollectionStorageDriver'
 import { GetAllowedCollectionStorageDrivers } from './domain/useCases/GetAllowedCollectionStorageDrivers'
+import { GetDefaultContributorRole } from './domain/useCases/GetDefaultContributorRole'
 
 const collectionsRepository = new CollectionsRepository()
 
@@ -46,6 +47,7 @@ const deleteCollectionStorageDriver = new DeleteCollectionStorageDriver(collecti
 const getAllowedCollectionStorageDrivers = new GetAllowedCollectionStorageDrivers(
   collectionsRepository
 )
+const getDefaultContributorRole = new GetDefaultContributorRole(collectionsRepository)
 
 export {
   getCollection,
@@ -68,7 +70,8 @@ export {
   getCollectionsForLinking,
   setCollectionStorageDriver,
   deleteCollectionStorageDriver,
-  getAllowedCollectionStorageDrivers
+  getAllowedCollectionStorageDrivers,
+  getDefaultContributorRole
 }
 export { Collection, CollectionInputLevel, CollectionTheme } from './domain/models/Collection'
 export { CollectionFacet } from './domain/models/CollectionFacet'

--- a/src/collections/infra/repositories/CollectionsRepository.ts
+++ b/src/collections/infra/repositories/CollectionsRepository.ts
@@ -42,6 +42,10 @@ import { CollectionSummary } from '../../domain/models/CollectionSummary'
 import { AllowedStorageDrivers } from '../../domain/models/AllowedStorageDrivers'
 import { StorageDriver } from '../../../core/domain/models/StorageDriver'
 import { LinkingObjectType } from '../../domain/useCases/GetCollectionsForLinking'
+import { Role } from '../../../roles/domain/models/Role'
+import {
+  transformCollectionDefaultContributorRoleToRole
+} from './transformers/collectionDefaultContributorRoleTransformers'
 
 export interface NewCollectionRequestPayload {
   alias: string
@@ -219,6 +223,21 @@ export class CollectionsRepository extends ApiRepository implements ICollections
     )
       .then((response) =>
         transformCollectionUserPermissionsResponseToCollectionUserPermissions(response)
+      )
+      .catch((error) => {
+        throw error
+      })
+  }
+
+  public async getDefaultContributorRole(
+    collectionIdOrAlias: number | string
+  ): Promise<Role> {
+    return this.doGet(
+      `/${this.collectionsResourceName}/${collectionIdOrAlias}/defaultContributorRole`,
+      true
+    )
+      .then((response) =>
+        transformCollectionDefaultContributorRoleToRole(response)
       )
       .catch((error) => {
         throw error

--- a/src/collections/infra/repositories/transformers/CollectionDefaultContributorRolePayload.ts
+++ b/src/collections/infra/repositories/transformers/CollectionDefaultContributorRolePayload.ts
@@ -1,0 +1,7 @@
+export interface CollectionDefaultContributorRolePayload {
+  alias: string
+  name: string
+  permissions: Array<string>
+  description: string
+  id: number
+}

--- a/src/collections/infra/repositories/transformers/collectionDefaultContributorRoleTransformers.ts
+++ b/src/collections/infra/repositories/transformers/collectionDefaultContributorRoleTransformers.ts
@@ -1,0 +1,15 @@
+import { AxiosResponse } from 'axios'
+import { Role } from '../../../../roles/domain/models/Role'
+
+export const transformCollectionDefaultContributorRoleToRole = (
+  response: AxiosResponse
+): Role => {
+  const defaultContributorRolePayload = response.data.data
+  return {
+    alias: defaultContributorRolePayload.alias,
+    name: defaultContributorRolePayload.name,
+    permissions: defaultContributorRolePayload.permissions,
+    description: defaultContributorRolePayload.description,
+    id: defaultContributorRolePayload.id
+  }
+}


### PR DESCRIPTION
## What this PR does / why we need it:

This PR adds a use case for getting the default contributor role of a collection.

This still needs tests, so I'm marking it as a draft PR for now and assigning myself.

Related PR: #415

## Which issue(s) this PR closes:

None

## Related Dataverse PRs:

- Follow-up to https://github.com/IQSS/dataverse/pull/12112

## Special notes for your reviewer:

None

## Suggestions on how to test this:

TODO

## Is there a release notes or changelog update needed for this change?:

I've added a changelog entry.

## Additional documentation:

None
