### PR TITLE
feat: add ignoreSettingExcludeEmailFromExport param to GetCollection use case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This changelog follows the principles of [Keep a Changelog](https://keepachangel
 - Datasets: Added `exportDatasetMetadata` use case, repository method, and `ExportedDatasetMetadata` response type to support exporting dataset metadata by numeric id or persistent id through Dataverse endpoint `GET /datasets/export`.
 - Collections: Added `allowedDatasetTypes` field to the [Collection](./src/collections/domain/models/Collection.ts) model. This field is optional and only populated the feature is enabled on the installation and configured on the collection.
 - Collections: Added theme information when retrieving a collection using `getCollection`.
+- Collections: Added optional `ignoreSettingExcludeEmailFromExport` support to `getCollection`.
 
 ### Changed
 

--- a/src/collections/domain/repositories/ICollectionsRepository.ts
+++ b/src/collections/domain/repositories/ICollectionsRepository.ts
@@ -16,7 +16,10 @@ import { StorageDriver } from '../../../core/domain/models/StorageDriver'
 import { LinkingObjectType } from '../useCases/GetCollectionsForLinking'
 
 export interface ICollectionsRepository {
-  getCollection(collectionIdOrAlias: number | string): Promise<Collection>
+  getCollection(
+    collectionIdOrAlias: number | string,
+    ignoreSettingExcludeEmailFromExport?: boolean
+  ): Promise<Collection>
   getCollectionStorageDriver(
     collectionIdOrAlias: number | string,
     getEffective?: boolean

--- a/src/collections/domain/useCases/GetCollection.ts
+++ b/src/collections/domain/useCases/GetCollection.ts
@@ -17,7 +17,10 @@ export class GetCollection implements UseCase<Collection> {
    * @param {boolean} ignoreSettingExcludeEmailFromExport - This prevents the contact emails from being excluded when the setting `ExcludeEmailFromExport` is set to true and the user has EditDataverse permissions.
    * @returns {Promise<Collection>}
    */
-  async execute(collectionIdOrAlias: number | string = ROOT_COLLECTION_ID, ignoreSettingExcludeEmailFromExport?: boolean): Promise<Collection> {
+  async execute(
+    collectionIdOrAlias: number | string = ROOT_COLLECTION_ID,
+    ignoreSettingExcludeEmailFromExport?: boolean
+  ): Promise<Collection> {
     return await this.collectionsRepository.getCollection(
       collectionIdOrAlias,
       ignoreSettingExcludeEmailFromExport

--- a/src/collections/domain/useCases/GetCollection.ts
+++ b/src/collections/domain/useCases/GetCollection.ts
@@ -14,9 +14,13 @@ export class GetCollection implements UseCase<Collection> {
    *
    * @param {number | string} [collectionIdOrAlias = ':root'] - A generic collection identifier, which can be either a string (for queries by CollectionAlias), or a number (for queries by CollectionId)
    * If this parameter is not set, the default value is: ':root'
+   * @param {boolean} ignoreSettingExcludeEmailFromExport - This prevents the contact emails from being excluded when the setting `ExcludeEmailFromExport` is set to true and the user has EditDataverse permissions.
    * @returns {Promise<Collection>}
    */
-  async execute(collectionIdOrAlias: number | string = ROOT_COLLECTION_ID): Promise<Collection> {
-    return await this.collectionsRepository.getCollection(collectionIdOrAlias)
+  async execute(collectionIdOrAlias: number | string = ROOT_COLLECTION_ID, ignoreSettingExcludeEmailFromExport?: boolean): Promise<Collection> {
+    return await this.collectionsRepository.getCollection(
+      collectionIdOrAlias,
+      ignoreSettingExcludeEmailFromExport
+    )
   }
 }

--- a/src/collections/infra/repositories/CollectionsRepository.ts
+++ b/src/collections/infra/repositories/CollectionsRepository.ts
@@ -98,11 +98,13 @@ export enum GetMyDataCollectionItemsQueryParams {
 export class CollectionsRepository extends ApiRepository implements ICollectionsRepository {
   private readonly collectionsResourceName: string = 'dataverses'
   public async getCollection(
-    collectionIdOrAlias: number | string = ROOT_COLLECTION_ID
+    collectionIdOrAlias: number | string = ROOT_COLLECTION_ID,
+    ignoreSettingExcludeEmailFromExport?: boolean
   ): Promise<Collection> {
     return this.doGet(`/${this.collectionsResourceName}/${collectionIdOrAlias}`, true, {
       returnOwners: true,
-      returnChildCount: true
+      returnChildCount: true,
+      ignoreSettingExcludeEmailFromExport: ignoreSettingExcludeEmailFromExport
     })
       .then((response) => transformCollectionResponseToCollection(response))
       .catch((error) => {


### PR DESCRIPTION
## What this PR does / why we need it:

This PR adds a support for the `ignoreSettingExcludeEmailFromExport` setting to the GetCollection use case.

This still needs tests, so I'm marking it as a draft PR for now and assigning myself.

## Which issue(s) this PR closes:

None

## Related Dataverse PRs:

- Follow-up to https://github.com/IQSS/dataverse/pull/12195

## Special notes for your reviewer:

None

## Suggestions on how to test this:

TODO

## Is there a release notes or changelog update needed for this change?:

I've added a changelog entry.

## Additional documentation:

None
